### PR TITLE
Add reusable Agent Skills workflows

### DIFF
--- a/.agents/skills/AGENTS.md
+++ b/.agents/skills/AGENTS.md
@@ -1,4 +1,5 @@
 # Agent skills
 
-- Install or refresh a skill with `DISABLE_TELEMETRY=1 vp dlx skills@latest add <source> --skill <name> -y`. Do not install the CLI or skills globally.
-- Prefer maintained first-party sources. Review adoption, activity, license, security, and the complete instructions before installation, then review every refresh diff instead of editing downloaded files.
+- Before creating a skill, follow `skill-creator` and research current registries, relevant repositories, local skills, and primary documentation; prefer reuse or improvement over duplication.
+- Keep one portable project copy at `.agents/skills/<name>` and link maintained remote references instead of copying them locally; retain only durable instructions and optional client metadata that does not alter core behavior.
+- Install reviewed skills project-scoped with `DISABLE_TELEMETRY=1 vp dlx skills@latest add <source> --skill <name> --agent universal -y`; do not install the CLI or skills globally.

--- a/.agents/skills/create-github-pr/SKILL.md
+++ b/.agents/skills/create-github-pr/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: create-github-pr
+description: Use this skill when the user explicitly asks to create or publish a GitHub pull request from local repository changes. Confirm scope, publish the intended diff, synthesize a concise title and bullet-only description from relevant user chat, default to draft, prevent duplicates, and verify the created PR. Do not use for text-only PR drafts, reviews, comments, or CI repair.
+compatibility: Requires git, network access, and authenticated GitHub write access through the GitHub CLI or an equivalent GitHub connector.
+---
+
+# Create GitHub PR
+
+Publish the intended local change set as a verified GitHub pull request. Use ordinary git and GitHub mechanics; retain only the non-obvious rules below.
+
+## Workflow
+
+1. Read applicable repository instructions and PR templates, inspect the full proposed change and target, and check whether the head already has an open PR. Report an existing PR instead of creating a duplicate; edit it only when requested.
+2. Confirm scope, leave clearly separable user work untouched, follow repository conventions, run required checks, then commit and push the intended changes without rewriting history.
+3. Compose the title and description using the content contract below.
+4. Create a draft unless the user explicitly requested ready-for-review state. Prefer an authenticated GitHub connector that can create and read PRs; otherwise use [`gh pr create`](https://cli.github.com/manual/gh_pr_create) with a body file so Markdown is preserved.
+5. Read the PR back from GitHub, verify its URL, title, state, base, and head, then report those values with the commit and check results.
+
+## Content contract
+
+- Review the proposed diff, every included commit's subject and body relative to the target branch, and relevant user-authored chat messages before drafting. Extract intent, constraints, corrections, accepted decisions, terminology, and links; keep the final diff authoritative over reverted or superseded commit details.
+- Use one concise, imperative title that summarizes the whole change.
+- Write the description as concise Markdown bullets only, nesting when useful. Do not add headings, prose sections, checklists, validation commands, or test results.
+- Prefer relevant links already supplied by the user or discovered in the current conversation and place them inline in the supporting bullet. Do not add a references section, revive superseded context, or invent links.
+- Honor compatible repository template requirements; ask before creating the PR if a mandatory template conflicts with this format. Use issue-closing keywords only for a verified issue the user intends to close.
+
+## Guardrails
+
+- Only an explicit request to create or publish a PR authorizes commits, pushes, and PR creation.
+- Never stage unrelated work or stash, discard, amend, rebase, squash, or force-push without explicit authorization.
+- Fix or stop for a required check broken by the change. A demonstrably pre-existing or environmental failure may proceed only as a draft and belongs in the handoff, not the PR description.
+- Do not add reviewers, assignees, labels, milestones, or projects unless requested or required by repository instructions.
+- If GitHub access is unavailable, report the blocker without requesting credentials in chat. After an ambiguous create error, check for a new PR before retrying.
+- Claim success only after remote read-back confirms the PR.

--- a/.agents/skills/skill-creator/LICENSE.txt
+++ b/.agents/skills/skill-creator/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/.agents/skills/skill-creator/NOTICE.txt
+++ b/.agents/skills/skill-creator/NOTICE.txt
@@ -1,0 +1,10 @@
+AstralBeam skill-creator derivative
+
+Derived from these Apache-2.0 sources:
+
+- OpenAI skill-creator, https://github.com/openai/skills/tree/49f948faa9258a0c61caceaf225e179651397431/skills/.system/skill-creator
+- Anthropic skill-creator, https://github.com/anthropics/skills/tree/f17010c9bb483898c1d9c9f42dde2b3a98889434/skills/skill-creator
+
+See LICENSE.txt. Anthropic upstream: Copyright 2026 Anthropic, PBC.
+
+The pinned links record the merged revisions; SKILL.md links to current guidance.

--- a/.agents/skills/skill-creator/SKILL.md
+++ b/.agents/skills/skill-creator/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: skill-creator
+description: Create, update, review, evaluate, package, source, and distribute portable Agent Skills. Use when turning a workflow into a reusable skill, editing or auditing SKILL.md, adding bundled resources or client metadata, comparing public skills, validating or packaging a skill, testing it against realistic prompts or a baseline, or improving its trigger description.
+license: Apache-2.0
+compatibility: Portable across Agent Skills-compatible runtimes. Remote guidance benefits from network access; bundled helpers require Python 3 and PyYAML.
+---
+
+# Skill Creator
+
+Build one standards-based skill folder that works unchanged across compatible agents.
+
+## Use current sources
+
+Before authoring or reviewing, read the current [Agent Skills specification](https://agentskills.io/specification) and [creator best practices](https://agentskills.io/skill-creation/best-practices). When relevant, also read:
+
+- [Using scripts](https://agentskills.io/skill-creation/using-scripts) before adding executable helpers.
+- [Evaluating skills](https://agentskills.io/skill-creation/evaluating-skills) and [optimizing descriptions](https://agentskills.io/skill-creation/optimizing-descriptions) for evaluation or iteration.
+- Vercel's [skills CLI](https://github.com/vercel-labs/skills) and [distribution guide](https://vercel.com/kb/guide/agent-skills-creating-installing-and-sharing-reusable-agent-context) for sourcing, installation, updates, or publishing.
+- The current default-branch [OpenAI](https://github.com/openai/skills/blob/main/skills/.system/skill-creator/SKILL.md) and [Anthropic](https://github.com/anthropics/skills/blob/main/skills/skill-creator/SKILL.md) creators when comparing or refreshing upstream practices; use immutable revisions only for provenance.
+- OpenAI's current default-branch [`agents/openai.yaml` reference](https://github.com/openai/skills/blob/main/skills/.system/skill-creator/references/openai_yaml.md) before changing that optional adapter.
+
+If remote documentation is unavailable, follow the portable invariants below and the bundled validator. `NOTICE.txt` records the immutable OpenAI and Anthropic source revisions merged into this derivative.
+
+## Workflow
+
+1. For a new skill, start with market research: search current skill registries with `npx skills@latest find <query>`, relevant repositories, local skills, and maintained primary documentation. Compare scope, maintenance, adoption, license, portability, dependencies, and security; record sources and prefer reuse or improvement over duplication.
+2. Read the conversation, target skill, direct references, author instructions, provenance or lock data, and current diff.
+3. Decide whether the workflow belongs in an on-demand skill; keep rules that apply to nearly every task in `AGENTS.md` or its equivalent.
+4. Capture two or three realistic requests, expected outcomes, near-misses, dependencies, permissions, failure recovery, and verification.
+5. Ground instructions in completed tasks, corrections, project artifacts, failures, and primary documentation. Keep only knowledge an agent would otherwise miss.
+6. Choose the smallest useful structure: `SKILL.md` is required; add `scripts/`, `references/`, or `assets/` only when they improve execution; keep client enhancements under `agents/`.
+
+## Portable invariants
+
+- Treat `SKILL.md` and relative resources as the behavioral source of truth. Never rewrite core behavior for a detected harness; optional client metadata may be ignored without changing the workflow.
+- Use only specification-defined frontmatter. The folder and `name` must match; `description` must say what the skill does and when to use it; state actual compatibility requirements rather than assuming a product.
+- Keep `SKILL.md` concise, imperative, and generally below 500 lines and 5,000 tokens. Link maintained remote specifications and documentation instead of copying them locally; retain only durable workflow, project policy, offline-critical guidance, and reusable resources, and state when each link should be read.
+- Match specificity to risk. Put non-obvious gotchas and security-critical warnings beside the relevant step; disclose dependencies, network access, credentials, permissions, side effects, and recovery.
+- Prefer clear defaults over menus. Use tested, non-interactive scripts only for deterministic or repeated work.
+- Before sourcing a skill, review its resolved source, license, instructions, references, scripts, and update diff. Run `npx skills@latest` ephemerally and select `--agent universal`; do not let detected harnesses change the canonical content or destination.
+
+## Initialize and author
+
+Skip initialization for an existing skill.
+
+```bash
+python3 <skill-creator-dir>/scripts/init_skill.py <skill-name> --path <output-directory> [--resources scripts,references,assets] [--examples]
+```
+
+Remove every placeholder. Generate optional OpenAI presentation metadata with `scripts/generate_openai_yaml.py`; the adapter may improve a supporting client but must not become required behavior.
+
+## Validate and improve
+
+1. Run `python3 <skill-creator-dir>/scripts/quick_validate.py <skill-directory>`.
+2. Run every changed helper on representative success and invalid-input cases, inspect the tree and diff for unsafe or generated content, and run the repository's checks.
+3. Run a realistic smoke test. For justified comparisons, use fresh contexts and identical prompts; compare a new skill with no skill and an update with its prior version. Use blind comparison or repeated runs only when their cost and decision value warrant them.
+4. Generalize from observed failures and feedback; remove instructions that waste work or merely restate general knowledge.
+
+Package only when requested:
+
+```bash
+python3 <skill-creator-dir>/scripts/package_skill.py <skill-directory> [output-directory]
+```
+
+Report changed files, evidence, assumptions, dependencies, and provenance. Give a representative invocation without assuming harness-specific syntax.

--- a/.agents/skills/skill-creator/agents/openai.yaml
+++ b/.agents/skills/skill-creator/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Skill Creator"
+  short_description: "Create, test, and improve agent skills"
+  default_prompt: "Use $skill-creator to create or improve a reusable project skill and validate it with realistic examples."

--- a/.agents/skills/skill-creator/scripts/generate_openai_yaml.py
+++ b/.agents/skills/skill-creator/scripts/generate_openai_yaml.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""
+OpenAI YAML Generator - Creates agents/openai.yaml for a skill folder.
+
+Usage:
+    generate_openai_yaml.py <skill_dir> [--name <skill_name>] [--interface key=value]
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+ACRONYMS = {
+    "GH",
+    "MCP",
+    "API",
+    "CI",
+    "CLI",
+    "LLM",
+    "PDF",
+    "PR",
+    "UI",
+    "URL",
+    "SQL",
+}
+
+BRANDS = {
+    "openai": "OpenAI",
+    "openapi": "OpenAPI",
+    "github": "GitHub",
+    "pagerduty": "PagerDuty",
+    "datadog": "DataDog",
+    "sqlite": "SQLite",
+    "fastapi": "FastAPI",
+}
+
+SMALL_WORDS = {"and", "or", "to", "up", "with"}
+
+ALLOWED_INTERFACE_KEYS = {
+    "display_name",
+    "short_description",
+    "icon_small",
+    "icon_large",
+    "brand_color",
+    "default_prompt",
+}
+
+
+def yaml_quote(value):
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
+    return f'"{escaped}"'
+
+
+def format_display_name(skill_name):
+    words = [word for word in skill_name.split("-") if word]
+    formatted = []
+    for index, word in enumerate(words):
+        lower = word.lower()
+        upper = word.upper()
+        if upper in ACRONYMS:
+            formatted.append(upper)
+            continue
+        if lower in BRANDS:
+            formatted.append(BRANDS[lower])
+            continue
+        if index > 0 and lower in SMALL_WORDS:
+            formatted.append(lower)
+            continue
+        formatted.append(word.capitalize())
+    return " ".join(formatted)
+
+
+def generate_short_description(display_name):
+    description = f"Help with {display_name} tasks"
+
+    if len(description) < 25:
+        description = f"Help with {display_name} tasks and workflows"
+    if len(description) < 25:
+        description = f"Help with {display_name} tasks with guidance"
+
+    if len(description) > 64:
+        description = f"Help with {display_name}"
+    if len(description) > 64:
+        description = f"{display_name} helper"
+    if len(description) > 64:
+        description = f"{display_name} tools"
+    if len(description) > 64:
+        suffix = " helper"
+        max_name_length = 64 - len(suffix)
+        trimmed = display_name[:max_name_length].rstrip()
+        description = f"{trimmed}{suffix}"
+    if len(description) > 64:
+        description = description[:64].rstrip()
+
+    if len(description) < 25:
+        description = f"{description} workflows"
+        if len(description) > 64:
+            description = description[:64].rstrip()
+
+    return description
+
+
+def read_frontmatter_name(skill_dir):
+    skill_md = Path(skill_dir) / "SKILL.md"
+    if not skill_md.exists():
+        print(f"[ERROR] SKILL.md not found in {skill_dir}")
+        return None
+    content = skill_md.read_text()
+    match = re.match(r"^---\n(.*?)\n---", content, re.DOTALL)
+    if not match:
+        print("[ERROR] Invalid SKILL.md frontmatter format.")
+        return None
+    frontmatter_text = match.group(1)
+    try:
+        frontmatter = yaml.safe_load(frontmatter_text)
+    except yaml.YAMLError as exc:
+        print(f"[ERROR] Invalid YAML frontmatter: {exc}")
+        return None
+    if not isinstance(frontmatter, dict):
+        print("[ERROR] Frontmatter must be a YAML dictionary.")
+        return None
+    name = frontmatter.get("name", "")
+    if not isinstance(name, str) or not name.strip():
+        print("[ERROR] Frontmatter 'name' is missing or invalid.")
+        return None
+    return name.strip()
+
+
+def parse_interface_overrides(raw_overrides):
+    overrides = {}
+    optional_order = []
+    for item in raw_overrides:
+        if "=" not in item:
+            print(f"[ERROR] Invalid interface override '{item}'. Use key=value.")
+            return None, None
+        key, value = item.split("=", 1)
+        key = key.strip()
+        value = value.strip()
+        if not key:
+            print(f"[ERROR] Invalid interface override '{item}'. Key is empty.")
+            return None, None
+        if key not in ALLOWED_INTERFACE_KEYS:
+            allowed = ", ".join(sorted(ALLOWED_INTERFACE_KEYS))
+            print(f"[ERROR] Unknown interface field '{key}'. Allowed: {allowed}")
+            return None, None
+        overrides[key] = value
+        if key not in ("display_name", "short_description") and key not in optional_order:
+            optional_order.append(key)
+    return overrides, optional_order
+
+
+def write_openai_yaml(skill_dir, skill_name, raw_overrides):
+    overrides, optional_order = parse_interface_overrides(raw_overrides)
+    if overrides is None:
+        return None
+
+    display_name = overrides.get("display_name") or format_display_name(skill_name)
+    short_description = overrides.get("short_description") or generate_short_description(display_name)
+
+    if not (25 <= len(short_description) <= 64):
+        print(
+            "[ERROR] short_description must be 25-64 characters "
+            f"(got {len(short_description)})."
+        )
+        return None
+
+    interface_lines = [
+        "interface:",
+        f"  display_name: {yaml_quote(display_name)}",
+        f"  short_description: {yaml_quote(short_description)}",
+    ]
+
+    for key in optional_order:
+        value = overrides.get(key)
+        if value is not None:
+            interface_lines.append(f"  {key}: {yaml_quote(value)}")
+
+    agents_dir = Path(skill_dir) / "agents"
+    agents_dir.mkdir(parents=True, exist_ok=True)
+    output_path = agents_dir / "openai.yaml"
+    output_path.write_text("\n".join(interface_lines) + "\n")
+    print(f"[OK] Created agents/openai.yaml")
+    return output_path
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Create agents/openai.yaml for a skill directory.",
+    )
+    parser.add_argument("skill_dir", help="Path to the skill directory")
+    parser.add_argument(
+        "--name",
+        help="Skill name override (defaults to SKILL.md frontmatter)",
+    )
+    parser.add_argument(
+        "--interface",
+        action="append",
+        default=[],
+        help="Interface override in key=value format (repeatable)",
+    )
+    args = parser.parse_args()
+
+    skill_dir = Path(args.skill_dir).resolve()
+    if not skill_dir.exists():
+        print(f"[ERROR] Skill directory not found: {skill_dir}")
+        sys.exit(1)
+    if not skill_dir.is_dir():
+        print(f"[ERROR] Path is not a directory: {skill_dir}")
+        sys.exit(1)
+
+    skill_name = args.name or read_frontmatter_name(skill_dir)
+    if not skill_name:
+        sys.exit(1)
+
+    result = write_openai_yaml(skill_dir, skill_name, args.interface)
+    if result:
+        sys.exit(0)
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/skill-creator/scripts/init_skill.py
+++ b/.agents/skills/skill-creator/scripts/init_skill.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Create a concise, portable Agent Skill scaffold."""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+from generate_openai_yaml import write_openai_yaml
+
+MAX_SKILL_NAME_LENGTH = 64
+ALLOWED_RESOURCES = {"scripts", "references", "assets"}
+PLACEHOLDER_MARKER = "[" + "TODO"
+
+SKILL_TEMPLATE = """---
+name: {skill_name}
+description: "{todo}: State what this skill enables and the user intents or situations that should trigger it.]"
+---
+
+# {skill_title}
+
+## Outcome
+
+{todo}: State the reusable outcome in one sentence.]
+
+## Workflow
+
+1. {todo}: Start with the first decision or action.]
+2. {todo}: Add only steps an agent would not reliably infer.]
+3. {todo}: End with verification or recovery.]
+
+## Guardrails
+
+- {todo}: Keep only non-obvious safety, permission, or edge-case constraints; delete this section if none apply.]
+"""
+
+EXAMPLE_SCRIPT = '''#!/usr/bin/env python3
+"""{todo}: Replace or remove this non-interactive helper.]"""
+
+import sys
+
+
+def main() -> int:
+    print("Replace scripts/example.py with a real helper.", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+'''
+
+EXAMPLE_REFERENCE = """# {skill_title} reference
+
+{todo}: Replace this file with conditional detail and link it directly from SKILL.md, or remove it.]
+"""
+
+EXAMPLE_ASSET = """{todo}: Replace this placeholder with an asset used in the skill's output, or remove it.]
+"""
+
+
+def normalize_skill_name(skill_name: str) -> str:
+    """Normalize a skill name to lowercase hyphen-case."""
+    normalized = re.sub(r"[^a-z0-9]+", "-", skill_name.strip().lower())
+    normalized = re.sub(r"-{2,}", "-", normalized).strip("-")
+    return normalized
+
+
+def title_case_skill_name(skill_name: str) -> str:
+    """Convert a hyphenated name to a display title."""
+    return " ".join(word.capitalize() for word in skill_name.split("-"))
+
+
+def parse_resources(raw_resources: str) -> list[str]:
+    if not raw_resources:
+        return []
+
+    resources = [item.strip() for item in raw_resources.split(",") if item.strip()]
+    invalid = sorted({item for item in resources if item not in ALLOWED_RESOURCES})
+    if invalid:
+        allowed = ", ".join(sorted(ALLOWED_RESOURCES))
+        raise ValueError(f"Unknown resource type(s): {', '.join(invalid)}. Allowed: {allowed}")
+
+    return list(dict.fromkeys(resources))
+
+
+def create_resource_dirs(
+    skill_dir: Path,
+    skill_name: str,
+    resources: list[str],
+    include_examples: bool,
+) -> None:
+    skill_title = title_case_skill_name(skill_name)
+    for resource in resources:
+        resource_dir = skill_dir / resource
+        resource_dir.mkdir()
+        if not include_examples:
+            print(f"[OK] Created {resource}/")
+            continue
+
+        if resource == "scripts":
+            example_path = resource_dir / "example.py"
+            example_path.write_text(
+                EXAMPLE_SCRIPT.format(todo=PLACEHOLDER_MARKER),
+                encoding="utf-8",
+            )
+            example_path.chmod(0o755)
+        elif resource == "references":
+            example_path = resource_dir / "reference.md"
+            example_path.write_text(
+                EXAMPLE_REFERENCE.format(
+                    skill_title=skill_title,
+                    todo=PLACEHOLDER_MARKER,
+                ),
+                encoding="utf-8",
+            )
+        else:
+            example_path = resource_dir / "example_asset.txt"
+            example_path.write_text(
+                EXAMPLE_ASSET.format(todo=PLACEHOLDER_MARKER),
+                encoding="utf-8",
+            )
+        print(f"[OK] Created {example_path.relative_to(skill_dir)}")
+
+
+def init_skill(
+    skill_name: str,
+    output_root: Path,
+    resources: list[str],
+    include_examples: bool,
+    openai_interface: list[str],
+) -> Path:
+    """Initialize a portable skill, with optional OpenAI presentation metadata."""
+    skill_dir = output_root.resolve() / skill_name
+    if skill_dir.exists():
+        raise FileExistsError(f"Skill directory already exists: {skill_dir}")
+
+    skill_dir.mkdir(parents=True)
+    skill_title = title_case_skill_name(skill_name)
+    (skill_dir / "SKILL.md").write_text(
+        SKILL_TEMPLATE.format(
+            skill_name=skill_name,
+            skill_title=skill_title,
+            todo=PLACEHOLDER_MARKER,
+        ),
+        encoding="utf-8",
+    )
+    print(f"[OK] Created {skill_dir}")
+    print("[OK] Created SKILL.md")
+
+    if openai_interface:
+        if not write_openai_yaml(skill_dir, skill_name, openai_interface):
+            raise ValueError("Could not create the optional OpenAI adapter")
+    else:
+        print("[OK] No client adapter created")
+
+    create_resource_dirs(skill_dir, skill_name, resources, include_examples)
+    return skill_dir
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Create a portable Agent Skill scaffold.",
+    )
+    parser.add_argument("skill_name", help="Skill name, normalized to hyphen-case")
+    parser.add_argument("--path", required=True, type=Path, help="Parent output directory")
+    parser.add_argument(
+        "--resources",
+        default="",
+        help="Comma-separated list chosen from scripts,references,assets",
+    )
+    parser.add_argument(
+        "--examples",
+        action="store_true",
+        help="Add removable placeholders inside selected resource directories",
+    )
+    parser.add_argument(
+        "--openai-interface",
+        "--interface",
+        dest="openai_interface",
+        action="append",
+        default=[],
+        metavar="KEY=VALUE",
+        help="Create optional agents/openai.yaml metadata; repeat for each interface field",
+    )
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    skill_name = normalize_skill_name(args.skill_name)
+    if not skill_name:
+        print("[ERROR] Skill name must include at least one ASCII letter or digit.", file=sys.stderr)
+        return 1
+    if len(skill_name) > MAX_SKILL_NAME_LENGTH:
+        print(
+            f"[ERROR] Normalized name is {len(skill_name)} characters; maximum is 64.",
+            file=sys.stderr,
+        )
+        return 1
+    if skill_name != args.skill_name:
+        print(f"[INFO] Normalized '{args.skill_name}' to '{skill_name}'.")
+
+    try:
+        resources = parse_resources(args.resources)
+        if args.examples and not resources:
+            raise ValueError("--examples requires --resources")
+        skill_dir = init_skill(
+            skill_name,
+            args.path,
+            resources,
+            args.examples,
+            args.openai_interface,
+        )
+    except (FileExistsError, OSError, ValueError) as error:
+        print(f"[ERROR] {error}", file=sys.stderr)
+        return 1
+
+    print(f"\n[OK] Initialized portable skill at {skill_dir}")
+    print("Next: replace every TODO, add only necessary resources, validate, and run a realistic smoke test.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/skill-creator/scripts/package_skill.py
+++ b/.agents/skills/skill-creator/scripts/package_skill.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Create a validated, distributable .skill archive."""
+
+import fnmatch
+import sys
+import tempfile
+import zipfile
+from pathlib import Path
+
+from quick_validate import validate_skill
+
+EXCLUDED_DIRS = {".git", "__pycache__", "node_modules"}
+EXCLUDED_FILES = {".DS_Store"}
+EXCLUDED_GLOBS = {"*.pyc"}
+ROOT_EXCLUDED_DIRS = {"evals"}
+
+
+def should_exclude(relative_path: Path) -> bool:
+    parts = relative_path.parts
+    if any(part in EXCLUDED_DIRS for part in parts):
+        return True
+    if len(parts) > 1 and parts[1] in ROOT_EXCLUDED_DIRS:
+        return True
+    if relative_path.name in EXCLUDED_FILES:
+        return True
+    return any(fnmatch.fnmatch(relative_path.name, pattern) for pattern in EXCLUDED_GLOBS)
+
+
+def package_skill(skill_path: Path, output_directory: Path) -> Path:
+    skill_path = skill_path.resolve()
+    output_directory = output_directory.resolve()
+
+    if not skill_path.is_dir():
+        raise ValueError(f"Skill directory not found: {skill_path}")
+
+    valid, message = validate_skill(skill_path)
+    if not valid:
+        raise ValueError(f"Skill validation failed: {message}")
+
+    archive_path = output_directory / f"{skill_path.name}.skill"
+    if skill_path == output_directory or skill_path in archive_path.parents:
+        raise ValueError("Output directory must be outside the skill directory")
+
+    files_to_archive = []
+    for file_path in sorted(skill_path.rglob("*")):
+        if file_path.is_symlink():
+            raise ValueError(f"Skill archives cannot contain symlinks: {file_path}")
+        if not file_path.is_file():
+            continue
+        relative_path = file_path.relative_to(skill_path.parent)
+        if not should_exclude(relative_path):
+            files_to_archive.append((file_path, relative_path))
+
+    output_directory.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        dir=output_directory,
+        prefix=f".{skill_path.name}.",
+        suffix=".skill.tmp",
+        delete=False,
+    ) as temporary_file:
+        temporary_path = Path(temporary_file.name)
+
+    try:
+        with zipfile.ZipFile(temporary_path, "w", zipfile.ZIP_DEFLATED) as archive:
+            for file_path, relative_path in files_to_archive:
+                archive.write(file_path, relative_path)
+        temporary_path.replace(archive_path)
+    except Exception:
+        temporary_path.unlink(missing_ok=True)
+        raise
+
+    return archive_path
+
+
+def main() -> int:
+    if len(sys.argv) not in (2, 3):
+        print("Usage: python package_skill.py <skill-directory> [output-directory]", file=sys.stderr)
+        return 1
+
+    skill_path = Path(sys.argv[1])
+    output_directory = Path(sys.argv[2]) if len(sys.argv) == 3 else Path.cwd()
+
+    try:
+        archive_path = package_skill(skill_path, output_directory)
+    except (OSError, ValueError, zipfile.BadZipFile) as error:
+        print(f"Error: {error}", file=sys.stderr)
+        return 1
+
+    print(f"Packaged skill: {archive_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/skill-creator/scripts/quick_validate.py
+++ b/.agents/skills/skill-creator/scripts/quick_validate.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Validate the portable Agent Skills format and an optional OpenAI adapter."""
+
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+MAX_SKILL_NAME_LENGTH = 64
+MAX_DESCRIPTION_LENGTH = 1024
+MAX_COMPATIBILITY_LENGTH = 500
+ALLOWED_FRONTMATTER_KEYS = {
+    "allowed-tools",
+    "compatibility",
+    "description",
+    "license",
+    "metadata",
+    "name",
+}
+PLACEHOLDER_MARKER = "[" + "TODO"
+TEXT_SUFFIXES = {
+    ".js",
+    ".json",
+    ".md",
+    ".py",
+    ".rb",
+    ".sh",
+    ".toml",
+    ".ts",
+    ".txt",
+    ".yaml",
+    ".yml",
+}
+
+
+def validate_openai_yaml(skill_path: Path, skill_name: str) -> tuple[bool, str]:
+    metadata_path = skill_path / "agents" / "openai.yaml"
+    if not metadata_path.exists():
+        return True, ""
+
+    try:
+        metadata = yaml.safe_load(metadata_path.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError) as error:
+        return False, f"Invalid agents/openai.yaml: {error}"
+
+    if not isinstance(metadata, dict):
+        return False, "agents/openai.yaml must be a YAML dictionary"
+
+    interface = metadata.get("interface")
+    if not isinstance(interface, dict):
+        return False, "agents/openai.yaml must contain an interface dictionary"
+
+    display_name = interface.get("display_name")
+    if not isinstance(display_name, str) or not display_name.strip():
+        return False, "interface.display_name must be a non-empty string"
+
+    short_description = interface.get("short_description")
+    if not isinstance(short_description, str) or not 25 <= len(short_description.strip()) <= 64:
+        return False, "interface.short_description must contain 25 to 64 characters"
+
+    default_prompt = interface.get("default_prompt")
+    if default_prompt is not None:
+        if not isinstance(default_prompt, str) or not default_prompt.strip():
+            return False, "interface.default_prompt must be a non-empty string"
+        if f"${skill_name}" not in default_prompt:
+            return False, f"interface.default_prompt must mention ${skill_name}"
+
+    brand_color = interface.get("brand_color")
+    if brand_color is not None and (
+        not isinstance(brand_color, str)
+        or not re.fullmatch(r"#[0-9A-Fa-f]{6}", brand_color)
+    ):
+        return False, "interface.brand_color must be a six-digit hex color"
+
+    for icon_key in ("icon_small", "icon_large"):
+        icon_value = interface.get(icon_key)
+        if icon_value is None:
+            continue
+        if not isinstance(icon_value, str) or not icon_value.strip():
+            return False, f"interface.{icon_key} must be a non-empty relative path"
+        icon_path = Path(icon_value)
+        if icon_path.is_absolute() or ".." in icon_path.parts:
+            return False, f"interface.{icon_key} must stay inside the skill directory"
+        if not (skill_path / icon_path).is_file():
+            return False, f"interface.{icon_key} does not exist: {icon_value}"
+
+    return True, ""
+
+
+def find_placeholder(skill_path: Path) -> Path | None:
+    for path in sorted(skill_path.rglob("*")):
+        if (
+            not path.is_file()
+            or path.is_symlink()
+            or path.stat().st_size > 1_000_000
+            or path.suffix.lower() not in TEXT_SUFFIXES
+        ):
+            continue
+        try:
+            if PLACEHOLDER_MARKER in path.read_text(encoding="utf-8"):
+                return path
+        except UnicodeDecodeError:
+            continue
+    return None
+
+
+def validate_frontmatter(frontmatter: dict, skill_path: Path) -> tuple[bool, str]:
+    unexpected_keys = sorted(set(frontmatter) - ALLOWED_FRONTMATTER_KEYS)
+    if unexpected_keys:
+        allowed = ", ".join(sorted(ALLOWED_FRONTMATTER_KEYS))
+        return False, f"Unexpected frontmatter keys: {', '.join(unexpected_keys)}. Allowed: {allowed}"
+
+    name = frontmatter.get("name")
+    if not isinstance(name, str) or not name.strip():
+        return False, "Frontmatter name must be a non-empty string"
+    name = name.strip()
+    if not re.fullmatch(r"[a-z0-9]+(?:-[a-z0-9]+)*", name):
+        return False, f"Name '{name}' must use lowercase ASCII letters, digits, and single hyphens"
+    if len(name) > MAX_SKILL_NAME_LENGTH:
+        return False, f"Name is too long ({len(name)} characters; maximum is 64)"
+    if skill_path.name != name:
+        return False, f"Skill folder '{skill_path.name}' must match frontmatter name '{name}'"
+
+    description = frontmatter.get("description")
+    if not isinstance(description, str) or not description.strip():
+        return False, "Frontmatter description must be a non-empty string"
+    if len(description.strip()) > MAX_DESCRIPTION_LENGTH:
+        return False, f"Description is too long ({len(description.strip())} characters; maximum is 1024)"
+
+    license_value = frontmatter.get("license")
+    if license_value is not None and (
+        not isinstance(license_value, str) or not license_value.strip()
+    ):
+        return False, "License must be a non-empty string"
+
+    compatibility = frontmatter.get("compatibility")
+    if compatibility is not None:
+        if not isinstance(compatibility, str) or not compatibility.strip():
+            return False, "Compatibility must be a non-empty string"
+        if len(compatibility) > MAX_COMPATIBILITY_LENGTH:
+            return False, "Compatibility cannot exceed 500 characters"
+
+    metadata = frontmatter.get("metadata")
+    if metadata is not None:
+        if not isinstance(metadata, dict):
+            return False, "Frontmatter metadata must be a dictionary"
+        if not all(isinstance(key, str) and isinstance(value, str) for key, value in metadata.items()):
+            return False, "Frontmatter metadata must map string keys to string values"
+
+    allowed_tools = frontmatter.get("allowed-tools")
+    if allowed_tools is not None and (
+        not isinstance(allowed_tools, str) or not allowed_tools.strip()
+    ):
+        return False, "allowed-tools must be a non-empty, space-separated string"
+
+    valid_adapter, adapter_error = validate_openai_yaml(skill_path, name)
+    if not valid_adapter:
+        return False, adapter_error
+
+    return True, ""
+
+
+def validate_skill(skill_path: str | Path) -> tuple[bool, str]:
+    skill_path = Path(skill_path)
+    skill_md = skill_path / "SKILL.md"
+    if not skill_md.is_file():
+        return False, "SKILL.md not found"
+
+    try:
+        content = skill_md.read_text(encoding="utf-8")
+    except OSError as error:
+        return False, f"Could not read SKILL.md: {error}"
+
+    match = re.match(r"^---\n(.*?)\n---(?:\n|$)", content, re.DOTALL)
+    if not match:
+        return False, "SKILL.md must start with YAML frontmatter"
+
+    try:
+        frontmatter = yaml.safe_load(match.group(1))
+    except yaml.YAMLError as error:
+        return False, f"Invalid YAML frontmatter: {error}"
+    if not isinstance(frontmatter, dict):
+        return False, "Frontmatter must be a YAML dictionary"
+
+    valid_frontmatter, frontmatter_error = validate_frontmatter(frontmatter, skill_path)
+    if not valid_frontmatter:
+        return False, frontmatter_error
+
+    if not content[match.end() :].strip():
+        return False, "SKILL.md must contain Markdown instructions after frontmatter"
+
+    placeholder = find_placeholder(skill_path)
+    if placeholder:
+        return False, f"Unfinished placeholder in {placeholder.relative_to(skill_path)}"
+
+    return True, "Skill is valid!"
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("Usage: python quick_validate.py <skill-directory>", file=sys.stderr)
+        return 1
+
+    valid, message = validate_skill(sys.argv[1])
+    print(message)
+    return 0 if valid else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.devcontainer/.defaults.env
+++ b/.devcontainer/.defaults.env
@@ -6,6 +6,7 @@ export CODEX_HOME=/workspaces/astralbeam/tmp/.codex
 export CURSOR_CONFIG_DIR=/workspaces/astralbeam/tmp/.cursor
 export CLAUDE_CONFIG_DIR=/workspaces/astralbeam/tmp/.claude
 export OPENCODE_CONFIG_DIR=/workspaces/astralbeam/tmp/.opencode
+export GH_CONFIG_DIR=/workspaces/astralbeam/tmp/.gh
 
 # Persist shell history in the gitignored, host-mounted workspace tmp directory.
 export HISTFILE=/workspaces/astralbeam/tmp/.zsh_history

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - "${HOME}/.cursor:/workspaces/astralbeam/tmp/.cursor:cached"
       - "${HOME}/.codex:/workspaces/astralbeam/tmp/.codex:cached"
       - "${HOME}/.claude:/workspaces/astralbeam/tmp/.claude:cached"
+      - "${HOME}/.config/gh:/workspaces/astralbeam/tmp/.gh:cached"
     command: sleep infinity
     init: true
     depends_on:

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ skills-lock.json
 !.vscode/
 !.vscode/settings.json
 !.vscode/extensions.json
+__pycache__/
 
 # Tanstack
 .nitro

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,44 +1,30 @@
-<!--VITE PLUS START-->
+# AstralBeam development
 
-# Using Vite+, the Unified Toolchain for the Web
+## Tooling and validation
 
-This project is using Vite+, a unified toolchain built on top of Vite, Rolldown, Vitest, tsdown, Oxlint, Oxfmt, and Vite Task. Vite+ wraps runtime management, package management, and frontend tooling in a single global CLI called `vp`. Vite+ is distinct from Vite. From the repository root, run project commands through `vp run <script>`; add `-r` when the task must run in every workspace package, such as `vp run -r check:fix`; package scripts invoke the underlying Vite+ commands. Run `vp help` to print a list of commands and `vp <command> --help` for information about a specific command.
+- Use Vite+ from the repository root: `vp run <script>`, with `-r` only when every workspace package is intended. Docs are in `node_modules/vite-plus/docs` and at https://viteplus.dev/guide/.
+- Run `vp install` once after pulling. Otherwise, use the smallest relevant package task or syntax/configuration check; documentation and instruction changes need only source review and `git diff --check`.
+- Do not automatically run `vp run check`, `vp run test`, or `vp run ready`. `ready` already runs checks, tests, and builds; run it once before creating a PR or when explicitly requested, without separate `check` or `test` runs unless diagnosing a failure.
+- Run `vp env doctor` only for setup, runtime, or package-manager problems.
 
-Docs are local at `node_modules/vite-plus/docs` or online at https://viteplus.dev/guide/.
+## Documentation
 
-## Review Checklist
+- Use `README.md` for consumers and `AGENTS.md` for authors. When creating an `AGENTS.md`, add a sibling `CLAUDE.md` symlink to it.
+- Keep each Markdown paragraph and list item on one source line.
+- Comment only non-obvious code or configuration decisions, including a link to authoritative documentation or an issue.
 
-- [ ] Run `vp install` after pulling remote changes and before getting started.
-- [ ] Run `vp run check` and `vp run test` to format, lint, type check and test changes through the repository tasks.
-- [ ] Check if there are `vite.config.ts` tasks or `package.json` scripts necessary for validation, run via `vp run <script>`.
-- [ ] If setup, runtime, or package-manager behavior looks wrong, run `vp env doctor` and include its output when asking for help.
-- [ ] Run `vp run ready` before handing off changes; it runs the repository checks, tests, and production builds.
+## Shared UI
 
-<!--VITE PLUS END-->
+- `packages/ui` owns the monorepo's only `components.json` and all shadcn-generated components, hooks, and utilities; applications import them from `@astralbeam/ui`.
+- Add components from the repository root with `vp run @astralbeam/ui#ui add <component>`.
 
-## Documentation convention
+## Database
 
-- Use a folder's `README.md` for consumers of its public API.
-- Use a folder's `AGENTS.md` for authors editing its contents.
-- Keep each Markdown prose paragraph and list item on one source line; rely on editor word wrap instead of inserting fixed-width line breaks.
-- For non-obvious code or configuration decisions, add a concise nearby comment explaining why with a link to authoritative upstream documentation or an issue; do not comment self-explanatory code.
-- Whenever you create an `AGENTS.md`, create a sibling `CLAUDE.md` symlink to it with `ln -s AGENTS.md CLAUDE.md`; never duplicate the instructions.
-
-## Shared UI workflow
-
-- Keep `packages/ui/components.json` as the only shadcn configuration in the monorepo; do not create app-level `components.json` files.
-- Keep every shadcn-generated component, hook, and utility in `packages/ui`; applications consume them through `@astralbeam/ui` exports.
-- Add shadcn components from the repository root with `vp run @astralbeam/ui#ui add <component>`.
-
-## Database workflow
-
-- The shared PostgreSQL and Drizzle implementation lives in `packages/db`.
-- Run database commands from the repository root through `vp run @astralbeam/db#db <command>`.
-- After changing a schema, run `generate` with a descriptive `--name`, inspect the generated SQL, run `check`, and commit the schema and migration files together.
-- Use `migrate` for checked-in migrations. Treat `push` as a local prototyping command, preview it with `push --explain`, and do not use it as the normal deployment workflow.
-- Import `@astralbeam/db` and keep database operations in server-only modules.
-- Use the environment-provided `DATABASE_URL`; do not commit credentials or package-local environment files.
+- Keep PostgreSQL and Drizzle code in the server-only `packages/db` package and import it through `@astralbeam/db`.
+- Run database commands from the repository root with `vp run @astralbeam/db#db <command>`.
+- After schema changes, run `generate --name <description>`, inspect the SQL, run `check`, and commit schema and migration files together.
+- Use `migrate` for checked-in migrations; reserve `push --explain` for local prototypes. Use the provided `DATABASE_URL` and never commit credentials or package-local environment files.
 
 ## Cursor Cloud
 
-- For UI changes, verify the affected flow through browser computer use, attach a screenshot or video artifact, then run `vp run ready`.
+- For UI changes, verify the affected flow through browser computer use and attach a screenshot or video artifact.

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -50,22 +50,29 @@ install_macos_packages() {
 
 install_ubuntu_packages() {
   [ "$platform_name" = Linux ] || return 0
-  run_as_root env DEBIAN_FRONTEND=noninteractive apt-get update -yq
-  run_as_root env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    build-essential libatomic1 ca-certificates locales lsb-release tzdata \
-    curl wget \
-    git \
-    zsh \
-    vim nano \
-    iputils-ping net-tools procps openssh-client \
-    fontconfig fonts-montserrat pkg-config python3 python3-yaml \
-    xdg-utils \
-    liburing-dev
 
-  # Host-mounted workspaces often have a different UID than the container user.
-  if ! run_as_root git config --system --get-all safe.directory | grep -qxF '*'; then
-    run_as_root git config --system --add safe.directory '*'
-  fi
+  run_as_root env DEBIAN_FRONTEND=noninteractive /bin/bash -euxo pipefail <<'EOF'
+apt-get update -yq
+apt-get install -y --no-install-recommends \
+  build-essential libatomic1 ca-certificates locales lsb-release tzdata \
+  curl wget \
+  git \
+  zsh \
+  vim nano \
+  iputils-ping net-tools procps openssh-client \
+  fontconfig fonts-montserrat pkg-config python3 python3-yaml \
+  xdg-utils \
+  liburing-dev
+
+# Install GitHub CLI from its supported signed Debian repository: https://github.com/cli/cli/blob/trunk/docs/install_linux.md#debian
+mkdir -p -m 755 /etc/apt/keyrings /etc/apt/sources.list.d; curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | tee /etc/apt/keyrings/githubcli-archive-keyring.gpg >/dev/null; chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg; printf 'deb [arch=%s signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main\n' "$(dpkg --print-architecture)" | tee /etc/apt/sources.list.d/github-cli.list >/dev/null
+apt-get update -yq; apt-get install -y --no-install-recommends gh
+
+# Host-mounted workspaces often have a different UID than the container user.
+if ! git config --system --get-all safe.directory | grep -qxF '*'; then
+  git config --system --add safe.directory '*'
+fi
+EOF
 }
 
 install_vite_plus() {

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -58,7 +58,7 @@ install_ubuntu_packages() {
     zsh \
     vim nano \
     iputils-ping net-tools procps openssh-client \
-    fontconfig fonts-montserrat pkg-config python3 \
+    fontconfig fonts-montserrat pkg-config python3 python3-yaml \
     xdg-utils \
     liburing-dev
 


### PR DESCRIPTION
- Add a portable `skill-creator` workflow based on the [Agent Skills specification](https://agentskills.io/specification), [OpenAI](https://github.com/openai/skills/tree/main/skills/.system/skill-creator), and [Anthropic](https://github.com/anthropics/skills/tree/main/skills/skill-creator), with helpers for scaffolding, validation, packaging, and optional OpenAI metadata.
- Add a `create-github-pr` workflow that confirms scope, preserves unrelated work, defaults to draft pull requests, and verifies the published result.
- Standardize project skill guidance and project-scoped installation through the [Vercel skills CLI](https://github.com/vercel-labs/skills).
- Provision Python YAML and GitHub CLI support through workspace setup, persist GitHub CLI configuration in the devcontainer, and simplify contributor guidance around focused Vite+ validation.
