### PR TITLE
Add shared environment tooling and legal pages

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -4,7 +4,7 @@
     "dockerfile": "Dockerfile",
     "context": ".."
   },
-  "install": "vp env install && vp install --frozen-lockfile",
+  "install": "vp env install && ./scripts/setup.sh",
   "start": "service docker start && docker compose up -d --wait",
   "ports": [
     {

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Local service defaults come from .env.development. Copy the variables you need to override into .env.local or provide them through the shell or deployment environment.
+# DATABASE_URL=
+# VALKEY_URL=

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+* text=auto eol=lf
+
+# Keep deterministic generated outputs committed while collapsing their GitHub diffs. https://docs.github.com/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github
+apps/webapp/src/routeTree.gen.ts linguist-generated
+packages/brand/src/colors.css linguist-generated
+packages/db/migrations/**/snapshot.json linguist-generated

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,17 +2,23 @@
 
 ## Tooling and validation
 
-- Use Vite+ from the repository root: `vp run <script>`, with `-r` only when every workspace package is intended. Docs are in `node_modules/vite-plus/docs` and at https://viteplus.dev/guide/.
+- Use Vite+ from the repository root: `vp run <script>`, with `-r` only when every workspace package is intended. Docs are in `node_modules/vite-plus/docs` and at <https://viteplus.dev/guide/>.
 - Before running `vp run knip:fix`, commit or back up untracked work because it can delete unused files that Git cannot restore; then inspect the complete diff before running recursive Vite+ checks and fixes with `vp run -r check:fix`.
-- Run `vp install` once after pulling. Otherwise, use the smallest relevant package task or syntax/configuration check; documentation and instruction changes need only source review and `git diff --check`.
+- Run `./scripts/setup.sh` once after pulling. Otherwise, use the smallest relevant package task or syntax/configuration check; documentation and instruction changes need only source review and `git diff --check`.
 - Do not automatically run `vp run check`, `vp run test`, or `vp run ready`. `ready` already runs checks, tests, and builds; run it once before creating a PR or when explicitly requested, without separate `check` or `test` runs unless diagnosing a failure.
 - Run `vp env doctor` only for setup, runtime, or package-manager problems.
 
 ## Documentation
 
 - Use `README.md` for consumers and `AGENTS.md` for authors. When creating an `AGENTS.md`, add a sibling `CLAUDE.md` symlink to it.
+- Name planning documents with the `*.plan.md` suffix so they are distinguishable from durable documentation.
 - Keep each Markdown paragraph and list item on one source line.
 - Comment only non-obvious code or configuration decisions, including a link to authoritative documentation or an issue.
+
+## Environment
+
+- Keep environment files at the repository root. Commit only reviewed non-secret templates and defaults (`.env.example`, `.env.development`, and its `.env.test` symlink); never commit credentials or deployment-specific values.
+- Reuse `@astralbeam/utils/environment` from application and standalone-tool configuration instead of adding package-local loaders or environment files. Shell, CI, and deployment variables must take precedence over file values.
 
 ## Shared UI
 

--- a/README.md
+++ b/README.md
@@ -17,10 +17,12 @@ packages/
 Choose either the included devcontainer or the direct macOS workflow. Follow [`SETUP.md`](SETUP.md) for prerequisites and the PostgreSQL and Valkey service lifecycle.
 
 ```sh
-vp install
+./scripts/setup.sh # Install dependencies
 vp run webapp # Starts app on http://localhost:3000
 vp run www # Starts website on http://localhost:3001
 ```
+
+Applications and repository tools load environment files from the repository root through [`@astralbeam/utils/environment`](packages/utils/src/environment.ts). Optional overrides are documented in `.env.example`, local service defaults live in `.env.development`, and secrets belong in the ignored `.env.local`. Keep secrets unprefixed for server-only `process.env` access; only variables intentionally exposed to browsers may use an application's public prefix (`VITE_` for the TanStack Start app and `PUBLIC_` for Astro). Deployment environments must inject secrets at runtime rather than relying on checked-out environment files.
 
 Add shadcn components to the shared UI package:
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -12,10 +12,9 @@ Choose one of the two local workflows below: use the devcontainer or run the cod
   brew install --cask podman-desktop
   ```
 
-  - Start Podman Desktop.
-  - Create a Podman machine.
-  - Enable Docker compatibility.
-  - Do not install the Compose extension from Podman Desktop. Its official Compose provider installs a `docker-compose` wrapper that breaks BuildKit functionality.
+- Start Podman Desktop, create a Podman machine, and enable Docker compatibility.
+
+- Do not install the Compose extension from Podman Desktop. Its provider installs a `docker-compose` wrapper that breaks BuildKit functionality.
 
 - Install `podman-compose`:
 

--- a/apps/webapp/README.md
+++ b/apps/webapp/README.md
@@ -6,4 +6,4 @@ TanStack Start application for the AstralBeam product.
 
 The root route places the checked-in `@astralbeam/brand/colors.css` stylesheet in the server-rendered document head and applies `.light` before first paint. This keeps the default theme available without shipping the Theme resolver in the client bundle.
 
-Tenant lookup, persistence, fallback, and request handling belong at the application boundary. Convert tenant definitions with `@astralbeam/theme` on the server and deliver the selected CSS through the same document-head path.
+Organization lookup, persistence, fallback, and request handling belong at the application boundary. Convert organization definitions with `@astralbeam/theme` on the server and deliver the selected CSS through the same document-head path.

--- a/apps/webapp/vite.config.ts
+++ b/apps/webapp/vite.config.ts
@@ -60,10 +60,16 @@ export default defineConfig(({ mode }) =>
       // https://vitest.dev/guide/#configuring-vitest
       ...(mode === "test" ? [] : [nitro()]),
       viteReact(),
-      // Vite 8 runs React Compiler through Babel; fail the build on every compiler diagnostic.
+      // Fail on critical compiler errors during development, but skip unsupported components in every deployable or automated mode.
       // https://github.com/vitejs/vite-plugin-react/tree/main/packages/plugin-react#react-compiler
       // https://react.dev/reference/react-compiler/panicThreshold
-      babel({ presets: [reactCompilerPreset({ panicThreshold: "all_errors" })] }),
+      babel({
+        presets: [
+          reactCompilerPreset({
+            panicThreshold: mode === "development" ? "critical_errors" : "none",
+          }),
+        ],
+      }),
       tailwindcss(),
     ]),
   }),

--- a/apps/www/astro.config.ts
+++ b/apps/www/astro.config.ts
@@ -1,4 +1,5 @@
 import sitemap from "@astrojs/sitemap"
+import { workspaceEnvironmentViteConfig } from "@astralbeam/utils/environment"
 import { defineConfig } from "astro/config"
 
 import { siteMetadata } from "./src/lib/site.ts"
@@ -6,4 +7,5 @@ import { siteMetadata } from "./src/lib/site.ts"
 export default defineConfig({
   site: siteMetadata.origin,
   integrations: [sitemap()],
+  vite: workspaceEnvironmentViteConfig,
 })

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -23,6 +23,7 @@
     "astro": "7.1.1"
   },
   "devDependencies": {
+    "@astralbeam/utils": "workspace:*",
     "@astrojs/check": "0.9.9",
     "@types/node": "catalog:",
     "sharp": "^0.35.2",

--- a/apps/www/scripts/verify-build.test.ts
+++ b/apps/www/scripts/verify-build.test.ts
@@ -50,6 +50,21 @@ describe("production website build", () => {
     expect(html).not.toMatch(/astralbeam\.com/iu)
   })
 
+  test("publishes and links the legal pages", async () => {
+    const [home, terms, privacy] = await Promise.all([
+      readText("index.html"),
+      readText("terms/index.html"),
+      readText("privacy/index.html"),
+    ])
+
+    expect(home).toContain('href="/terms"')
+    expect(home).toContain('href="/privacy"')
+    expect(terms).toContain(`<link rel="canonical" href="${origin}/terms">`)
+    expect(terms).toContain("Terms of Service")
+    expect(privacy).toContain(`<link rel="canonical" href="${origin}/privacy">`)
+    expect(privacy).toContain("Google API Services User Data Policy")
+  })
+
   test("ships brand colors without Node APIs", async () => {
     const assetDirectory = new URL("_astro/", distUrl)
     const assets = await readdir(assetDirectory)
@@ -104,6 +119,8 @@ describe("production website build", () => {
     expect(licenses).toContain(oflLicense.trimEnd())
     expect(sitemapIndex).toContain(`${origin}/sitemap-0.xml`)
     expect(sitemap).toContain(`<loc>${homeUrl}</loc>`)
+    expect(sitemap).toContain(`<loc>${origin}/privacy/</loc>`)
+    expect(sitemap).toContain(`<loc>${origin}/terms/</loc>`)
     expect(sitemap).not.toContain("/404")
     expect(manifest).toMatchObject({
       name: "AstralBeam",

--- a/apps/www/src/layouts/LegalPageLayout.astro
+++ b/apps/www/src/layouts/LegalPageLayout.astro
@@ -1,0 +1,195 @@
+---
+import astralbeamDarkWordmarkUrl from "@astralbeam/brand/logo/svg/astralbeam-wordmark-dark.svg?url&no-inline"
+import SiteLayout from "@/layouts/SiteLayout.astro"
+import { siteMetadata } from "@/lib/site"
+
+interface Props {
+  title: string
+  description: string
+  canonicalPath: string
+  effectiveDate: string
+}
+
+const { title, description, canonicalPath, effectiveDate } = Astro.props
+---
+
+<SiteLayout title={`${title} | ${siteMetadata.name}`} description={description} canonicalPath={canonicalPath}>
+  <div class="legal-shell">
+    <header class="legal-header">
+      <a class="legal-brand" href="/" aria-label="AstralBeam home">
+        <img src={astralbeamDarkWordmarkUrl} alt="AstralBeam" width="1241" height="136" />
+      </a>
+      <nav aria-label="Legal documents">
+        <a href="/terms">Terms</a>
+        <a href="/privacy">Privacy</a>
+      </nav>
+    </header>
+
+    <main class="legal-main">
+      <header class="legal-title">
+        <p class="mono">// LEGAL</p>
+        <h1>{title}</h1>
+        <p>Effective {effectiveDate}</p>
+      </header>
+
+      <article class="legal-content">
+        <slot />
+      </article>
+    </main>
+
+    <footer class="legal-footer mono">
+      <span>© 2026 ASTRALBEAM</span>
+      <a href={`mailto:${siteMetadata.email}`}>{siteMetadata.email}</a>
+      <a href="/">HOME</a>
+    </footer>
+  </div>
+</SiteLayout>
+
+<style>
+  .legal-shell {
+    min-height: 100svh;
+    background:
+      linear-gradient(to bottom, color-mix(in srgb, var(--primary) 7%, transparent), transparent 22rem),
+      var(--background);
+  }
+
+  .legal-header,
+  .legal-footer {
+    display: flex;
+    align-items: center;
+    gap: 1.5rem;
+    width: min(calc(100% - 2.5rem), 78rem);
+    margin-inline: auto;
+  }
+
+  .legal-header {
+    justify-content: space-between;
+    min-height: 5rem;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .legal-brand img {
+    display: block;
+    width: auto;
+    height: 1.5rem;
+  }
+
+  .legal-header nav {
+    display: flex;
+    gap: 1.25rem;
+    font-family: var(--font-mono);
+    font-size: 0.75rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+  }
+
+  .legal-header a,
+  .legal-footer a,
+  :global(.legal-content a) {
+    color: var(--primary);
+    text-decoration: underline;
+    text-decoration-color: transparent;
+    text-underline-offset: 0.25em;
+    transition: text-decoration-color 0.2s;
+  }
+
+  .legal-header a:hover,
+  .legal-footer a:hover,
+  :global(.legal-content a:hover) {
+    text-decoration-color: currentColor;
+  }
+
+  .legal-main {
+    width: min(calc(100% - 2.5rem), 52rem);
+    margin-inline: auto;
+    padding-block: clamp(4rem, 10vw, 7rem);
+  }
+
+  .legal-title {
+    padding-bottom: 2rem;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .legal-title .mono {
+    color: var(--primary);
+    font-size: 0.75rem;
+    letter-spacing: 0.16em;
+  }
+
+  .legal-title h1 {
+    margin-top: 0.75rem;
+    font-family: var(--font-display);
+    font-size: clamp(3rem, 10vw, 5.5rem);
+    font-weight: 400;
+    line-height: 1;
+    letter-spacing: 0.015em;
+    text-transform: uppercase;
+  }
+
+  .legal-title > p:last-child {
+    margin-top: 1rem;
+    color: var(--muted-foreground);
+  }
+
+  .legal-content {
+    padding-top: 1rem;
+  }
+
+  :global(.legal-content section) {
+    padding-block: 2rem;
+    border-bottom: 1px solid var(--border);
+  }
+
+  :global(.legal-content h2) {
+    margin-bottom: 0.9rem;
+    font-size: 1.2rem;
+    line-height: 1.3;
+  }
+
+  :global(.legal-content p),
+  :global(.legal-content li) {
+    color: var(--muted-foreground);
+  }
+
+  :global(.legal-content p + p),
+  :global(.legal-content ul + p),
+  :global(.legal-content p + ul) {
+    margin-top: 0.9rem;
+  }
+
+  :global(.legal-content ul) {
+    padding-left: 1.25rem;
+  }
+
+  :global(.legal-content li + li) {
+    margin-top: 0.45rem;
+  }
+
+  .legal-footer {
+    flex-wrap: wrap;
+    padding-block: 1.5rem;
+    border-top: 1px solid var(--border);
+    color: var(--muted-foreground);
+    font-size: 0.7rem;
+    letter-spacing: 0.1em;
+  }
+
+  .legal-footer a:first-of-type {
+    margin-left: auto;
+  }
+
+  @media (max-width: 40rem) {
+    .legal-header,
+    .legal-footer {
+      width: min(calc(100% - 2rem), 78rem);
+    }
+
+    .legal-main {
+      width: min(calc(100% - 2rem), 52rem);
+    }
+
+    .legal-footer a:first-of-type {
+      margin-left: 0;
+    }
+  }
+</style>

--- a/apps/www/src/pages/index.astro
+++ b/apps/www/src/pages/index.astro
@@ -33,7 +33,7 @@ const systems = [
   {
     id: "05",
     name: "Enterprise-ready",
-    desc: "Multi-tenant, enterprise-grade SSO, data privacy, and access control, all built in from day one.",
+    desc: "Organization-aware, enterprise-grade SSO, data privacy, and access control, all built in from day one.",
     icon: "shield",
   },
   {
@@ -361,6 +361,8 @@ const bootChecks = [
     <footer class="site-footer mono">
       <span>© 2026 ASTRALBEAM</span>
       <a href="mailto:hello@astralbeam.ai">HELLO@ASTRALBEAM.AI</a>
+      <a href="/terms">TERMS</a>
+      <a href="/privacy">PRIVACY</a>
       <a href="/licenses.txt">LICENSES</a>
       <span class="footer-status"><i class="blink-dot"></i>ALL SYSTEMS NOMINAL</span>
     </footer>

--- a/apps/www/src/pages/llms.txt.ts
+++ b/apps/www/src/pages/llms.txt.ts
@@ -19,7 +19,7 @@ AstralBeam gives application teams one service for adding production-ready agent
 - Drop-in frontend SDK for a customizable, Cursor-like agent sidebar
 - Managed resumable chat streaming, conversation history, observability, analytics, and audit logs
 - Tools, skills, app actions, user-provided MCP support, guardrails, and evaluation hooks
-- Tenant-aware authentication, permissions, context, flexible rate limits, and token-based billing
+- Organization-aware authentication, permissions, context, flexible rate limits, and token-based billing
 - Enterprise SSO, data privacy, access control, prompt management, A/B testing, and production evaluations
 - Multiplayer chat, background agents, dynamic model routing, prompt caching, and token optimization
 

--- a/apps/www/src/pages/privacy.astro
+++ b/apps/www/src/pages/privacy.astro
@@ -1,0 +1,85 @@
+---
+import LegalPageLayout from "@/layouts/LegalPageLayout.astro"
+import { siteMetadata } from "@/lib/site"
+
+const effectiveDate = "August 17, 2026"
+---
+
+<LegalPageLayout
+  title="Privacy Policy"
+  description="How AstralBeam collects, uses, shares, and protects personal information."
+  canonicalPath="/privacy"
+  effectiveDate={effectiveDate}
+>
+  <section>
+    <h2>1. Scope</h2>
+    <p>This Privacy Policy explains how AstralBeam collects, uses, shares, and retains personal information when you visit our websites, create an account, join an organization, use our hosted services, or communicate with us. An organization may separately control Customer Content processed through its account; contact that organization about its own privacy practices.</p>
+  </section>
+
+  <section>
+    <h2>2. Information we collect</h2>
+    <ul>
+      <li><strong>Account information:</strong> name, email address, profile image, identity-provider account identifier, and sign-in records received from Google or GitHub.</li>
+      <li><strong>Organization information:</strong> organization name, membership, role, invitations, settings, and related administrative activity.</li>
+      <li><strong>Customer Content:</strong> prompts, messages, files, tool inputs and outputs, agent configurations, and other information submitted through the Services.</li>
+      <li><strong>Usage and technical information:</strong> IP address, browser and device information, timestamps, session information, diagnostics, security events, and interactions with the Services.</li>
+      <li><strong>Communications:</strong> messages, support requests, feedback, and information submitted through our waitlist or other forms.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>3. How we use information</h2>
+    <p>We use information to provide and personalize the Services; authenticate users; manage organizations; process requested agent and tool operations; maintain security and prevent abuse; monitor reliability and usage; provide support; communicate about the Services; comply with law; and improve our products. We may use aggregated or de-identified information for analytics and product development where it cannot reasonably identify you.</p>
+  </section>
+
+  <section>
+    <h2>4. Google user data</h2>
+    <p>When you choose Google sign-in, AstralBeam requests only the `openid`, `email`, and `profile` scopes. We use the resulting account identifier, name, email address, profile image, and authentication information to create or authenticate your account, display your profile, secure your session, and support account administration.</p>
+    <p>We do not sell Google user data, use it for advertising or credit decisions, or use it to train generalized AI models. We share it only with service providers acting for us, when needed to secure or operate the Services, when you direct us to, or when required by law. Our use of information received from Google APIs adheres to the <a href="https://developers.google.com/terms/api-services-user-data-policy" target="_blank" rel="noopener noreferrer">Google API Services User Data Policy</a>, including its Limited Use requirements.</p>
+  </section>
+
+  <section>
+    <h2>5. How we share information</h2>
+    <p>We may share information with infrastructure, hosting, identity, analytics, communications, payment, model, and tool providers that process it for us; with connected services you choose to use; with organization owners or administrators; to investigate abuse or protect rights and safety; in connection with a business transaction; or when required by law. We do not sell personal information.</p>
+  </section>
+
+  <section>
+    <h2>6. Cookies and similar technologies</h2>
+    <p>We use cookies and similar technologies that are necessary to authenticate users, maintain sessions, remember preferences, protect the Services, and understand operation and usage. Browser settings may let you block cookies, but essential features may stop working.</p>
+  </section>
+
+  <section>
+    <h2>7. Retention and deletion</h2>
+    <p>We retain information for as long as needed to provide the Services, maintain security and business records, resolve disputes, and meet legal obligations. Retention depends on the type of information, why it was collected, and applicable requirements. You may request account or personal-data deletion by contacting us. Organization-controlled information may need to be handled by the organization administrator. We may retain limited information where legally required or necessary to protect the Services.</p>
+  </section>
+
+  <section>
+    <h2>8. Security</h2>
+    <p>We use administrative, technical, and organizational measures designed to protect personal information. No system is completely secure, so we cannot guarantee that information will never be accessed, altered, or lost without authorization.</p>
+  </section>
+
+  <section>
+    <h2>9. International processing</h2>
+    <p>AstralBeam and its service providers may process information in countries other than where you live. Where required, we use appropriate safeguards for cross-border transfers.</p>
+  </section>
+
+  <section>
+    <h2>10. Your choices and rights</h2>
+    <p>You may update certain account information through the Services and disconnect connected services through the relevant provider. Depending on where you live, you may have rights to access, correct, delete, restrict, object to, or receive a copy of personal information. Contact us to make a request. We may need to verify your identity and may retain information where an exception applies.</p>
+  </section>
+
+  <section>
+    <h2>11. Children</h2>
+    <p>The Services are intended for businesses and developers and are not directed to children. Do not use the Services if you lack legal capacity to agree to the applicable terms.</p>
+  </section>
+
+  <section>
+    <h2>12. Changes to this policy</h2>
+    <p>We may update this policy as our practices or legal requirements change. We will post the revised policy with a new effective date and provide additional notice when required.</p>
+  </section>
+
+  <section>
+    <h2>13. Contact</h2>
+    <p>For privacy questions or requests, email <a href={`mailto:${siteMetadata.email}`}>{siteMetadata.email}</a>.</p>
+  </section>
+</LegalPageLayout>

--- a/apps/www/src/pages/terms.astro
+++ b/apps/www/src/pages/terms.astro
@@ -1,0 +1,79 @@
+---
+import LegalPageLayout from "@/layouts/LegalPageLayout.astro"
+import { siteMetadata } from "@/lib/site"
+
+const effectiveDate = "August 17, 2026"
+---
+
+<LegalPageLayout
+  title="Terms of Service"
+  description="Terms governing access to and use of AstralBeam services."
+  canonicalPath="/terms"
+  effectiveDate={effectiveDate}
+>
+  <section>
+    <h2>1. Agreement</h2>
+    <p>These Terms of Service govern your access to and use of AstralBeam websites, hosted services, software, APIs, and related offerings (the “Services”). By creating an account or using the Services, you agree to these terms. If you use the Services for an organization, you represent that you have authority to bind that organization.</p>
+  </section>
+
+  <section>
+    <h2>2. Accounts and organizations</h2>
+    <p>You must provide accurate account information, keep your sign-in credentials secure, and promptly notify us of suspected unauthorized access. Organization owners and administrators control membership and may access or manage organization information through the controls available in the Services. You are responsible for the activity of users you authorize.</p>
+  </section>
+
+  <section>
+    <h2>3. Acceptable use</h2>
+    <p>You may not use the Services to violate law or third-party rights; distribute malware; gain unauthorized access; interfere with the Services; evade limits or security controls; conduct abusive surveillance; or create, distribute, or facilitate harmful, deceptive, or unlawful content. You may not resell or exploit the hosted Services except under an agreement with us.</p>
+  </section>
+
+  <section>
+    <h2>4. Your content and AI output</h2>
+    <p>You retain your rights in prompts, files, configurations, data, and other content you submit (“Customer Content”). You grant us the limited rights needed to host, process, transmit, and display Customer Content to provide, secure, and support the Services. You are responsible for Customer Content, the instructions you provide to models and tools, and how you evaluate and use generated output.</p>
+    <p>AI output can be inaccurate, incomplete, or unsuitable for a particular purpose. Review output before relying on it, especially for decisions that may affect a person’s rights, safety, finances, health, or legal interests.</p>
+  </section>
+
+  <section>
+    <h2>5. Connected and third-party services</h2>
+    <p>The Services may connect to identity providers, model providers, tools, data sources, payment processors, and other third-party services. Their terms and privacy practices govern their services. You authorize us to exchange information with a connected service as necessary to complete the actions you request.</p>
+  </section>
+
+  <section>
+    <h2>6. AstralBeam software and intellectual property</h2>
+    <p>We and our licensors retain all rights in the Services, branding, documentation, and hosted platform except for Customer Content and software expressly distributed under an open-source license. Open-source components are governed by their applicable licenses. These terms do not grant rights to use AstralBeam names, logos, or marks.</p>
+  </section>
+
+  <section>
+    <h2>7. Fees</h2>
+    <p>If you purchase a paid plan, the pricing, usage limits, billing cycle, taxes, renewal terms, and cancellation rights shown at purchase or in an order form apply. Except where required by law or stated otherwise, fees are non-refundable.</p>
+  </section>
+
+  <section>
+    <h2>8. Service changes and availability</h2>
+    <p>We may modify, suspend, or discontinue features and may apply usage or security limits. Preview, beta, and early-access features may change without notice and may be less reliable than generally available features. We aim to operate the Services reliably but do not guarantee uninterrupted or error-free availability.</p>
+  </section>
+
+  <section>
+    <h2>9. Suspension and termination</h2>
+    <p>You may stop using the Services at any time. We may suspend or terminate access when reasonably necessary to protect the Services or others, respond to legal requirements, prevent abuse, address non-payment, or enforce these terms. Provisions that by their nature should survive termination will remain in effect.</p>
+  </section>
+
+  <section>
+    <h2>10. Disclaimers</h2>
+    <p>To the maximum extent permitted by law, the Services are provided “as is” and “as available.” We disclaim implied warranties of merchantability, fitness for a particular purpose, non-infringement, and any warranty arising from course of dealing or usage of trade. Nothing in these terms limits rights that cannot legally be waived.</p>
+  </section>
+
+  <section>
+    <h2>11. Limitation of liability</h2>
+    <p>To the maximum extent permitted by law, AstralBeam and its affiliates, officers, employees, and suppliers will not be liable for indirect, incidental, special, consequential, exemplary, or punitive damages, or for lost profits, revenues, goodwill, data, or business opportunities. Our aggregate liability relating to the Services will not exceed the greater of the amount you paid for the Services during the twelve months before the event giving rise to the claim or US$100.</p>
+  </section>
+
+  <section>
+    <h2>12. Changes to these terms</h2>
+    <p>We may update these terms as the Services or legal requirements change. We will post the revised terms with a new effective date and provide additional notice when required. Continuing to use the Services after the updated terms take effect means you accept them.</p>
+  </section>
+
+  <section>
+    <h2>13. Contact</h2>
+    <p>Questions about these terms can be sent to <a href={`mailto:${siteMetadata.email}`}>{siteMetadata.email}</a>.</p>
+  </section>
+</LegalPageLayout>

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "www": "vp run @astralbeam/www#dev"
   },
   "devDependencies": {
+    "@astralbeam/utils": "workspace:*",
     "@types/node": "catalog:",
     "knip": "catalog:",
     "typescript": "catalog:",

--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -17,3 +17,42 @@ export const listProjects = createServerFn({ method: "GET" }).handler(() =>
 ```
 
 `db` is the shared Drizzle client. The schema entrypoint exports the available tables and relations. Both require server-only code and `DATABASE_URL`.
+
+## Database commands
+
+Run database commands from the repository root. Start the containerized services before commands that connect to PostgreSQL:
+
+```sh
+podman compose up --detach --wait
+```
+
+Apply every checked-in migration that has not yet run against the configured database:
+
+```sh
+vp run @astralbeam/db#db migrate
+```
+
+After changing the TypeScript schema, generate a named migration, inspect its SQL and snapshot, verify migration-history consistency, then apply it:
+
+```sh
+vp run @astralbeam/db#db generate --name=<descriptive-name>
+vp run @astralbeam/db#db check
+vp run @astralbeam/db#db migrate
+```
+
+Reset only the disposable local PostgreSQL database without installing PostgreSQL tools on the host, then reapply all checked-in migrations:
+
+```sh
+podman compose exec postgres sh -ceu 'dropdb --if-exists --force --username "$POSTGRES_USER" "$POSTGRES_DB"; createdb --username "$POSTGRES_USER" "$POSTGRES_DB"'
+vp run @astralbeam/db#db migrate
+```
+
+To remove all local PostgreSQL and Valkey data instead, recreate both named volumes:
+
+```sh
+podman compose down --volumes
+podman compose up --detach --wait
+vp run @astralbeam/db#db migrate
+```
+
+Both reset workflows are destructive and must only be used for disposable local data. `migrate` applies pending checked-in migrations; `check` validates migration-history consistency and does not inspect which migrations a live database has applied.

--- a/packages/db/drizzle.config.ts
+++ b/packages/db/drizzle.config.ts
@@ -1,11 +1,9 @@
-import { fileURLToPath } from "node:url"
+import { loadWorkspaceEnvironment } from "@astralbeam/utils/environment"
 import { defineConfig } from "drizzle-kit"
-import { loadEnv } from "vite"
 
 // Drizzle Kit does not load Vite modes; fall back to local development defaults only. https://vite.dev/config/#using-environment-variables-in-config
-const envDir = fileURLToPath(new URL("../..", import.meta.url))
-const databaseUrl =
-  process.env.DATABASE_URL ?? loadEnv("development", envDir, "DATABASE_URL").DATABASE_URL
+loadWorkspaceEnvironment("development")
+const databaseUrl = process.env.DATABASE_URL
 
 if (!databaseUrl) {
   throw new Error("DATABASE_URL is required")

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -16,10 +16,10 @@
     "postgres": "catalog:"
   },
   "devDependencies": {
+    "@astralbeam/utils": "workspace:*",
     "@types/node": "catalog:",
     "drizzle-kit": "catalog:",
-    "typescript": "catalog:",
-    "vite": "catalog:"
+    "typescript": "catalog:"
   },
   "peerDependencies": {
     "@tanstack/react-start": "catalog:"

--- a/packages/theme/AGENTS.md
+++ b/packages/theme/AGENTS.md
@@ -1,6 +1,6 @@
 # Theme package development
 
-- Keep `@astralbeam/theme` neutral: it owns the semantic theme contract and utilities, while brand and tenant packages own concrete theme values.
+- Keep `@astralbeam/theme` neutral: it owns the semantic theme contract and utilities, while brand and application packages own concrete theme values.
 - Keep generic resolved color and palette conversion in this package; concrete packages may bind those functions to their own validated theme documents but must not duplicate the token-to-property adapter.
 - Keep prerelease Effect versions pinned exactly so Schema APIs do not drift during routine installs.
 - Keep the package pure and structurally typed: no filesystem, HTTP, DOM mutation, environment branching, mutable global caches, or request decoding. Concrete applications own those effects.
@@ -8,7 +8,7 @@
 - Use `compileThemeCss` for an untrusted compact definition at an application boundary, `resolveThemeDefinition` when the resolved document is needed, and `parseThemeDocument` for already resolved runtime documents; downstream CSS utilities accept only the exhaustive resolved contract.
 - Keep light authoring input flat within `colors.light`; restrict optional `colors.dark` authoring to `background`, `foreground`, `primary`, and `accent`; and reject metadata and nested customization wrappers. Permit only the canonical `$schema` URL alongside the required top-level `colors` and `geometry` keys.
 - Treat checked-in `public/schemas/theme.schema.json` as the master authoring schema. Keep the schema `$id`, Brand `$schema`, runtime structure, and exported `themeDefinitionSchemaUrl` synchronized. The JSON Schema defines structure and editor metadata; runtime validation remains authoritative for CSS parsing, opacity, derivation, and contrast.
-- Keep the exported Effect schemas Standard Schema v1-compatible for tenant-admin form tooling.
+- Keep the exported Effect schemas Standard Schema v1-compatible for organization-admin form tooling.
 - Preserve dependency-aware resolution: a direct source color must flow into derived aliases unless an alias-specific color is supplied.
 - Treat changes to OKLCH derivation, WCAG contrast selection, status defaults, or dark-mode transforms as breaking authoring behavior because persisted definitions can otherwise resolve differently.
 - Preserve deterministic token ordering so generated stylesheets are reproducible.

--- a/packages/theme/README.md
+++ b/packages/theme/README.md
@@ -1,6 +1,6 @@
 # `@astralbeam/theme`
 
-`@astralbeam/theme` defines the neutral semantic theme contract shared by AstralBeam and tenant-provided color systems. UI components consume the resulting CSS custom properties and do not own theme selection or persistence.
+`@astralbeam/theme` defines the neutral semantic theme contract shared by AstralBeam and organization-provided color systems. UI components consume the resulting CSS custom properties and do not own theme selection or persistence.
 
 ## Theme documents
 
@@ -29,9 +29,9 @@ const stylesheet = generateThemeCss(theme)
 
 `resolveThemePalette` converts every semantic color to its CSS value, sRGB tuple, and hex value under stable camel-case properties such as `cardForeground` and `chart1`. It accepts an already validated exhaustive document and returns a fresh frozen value without mutating the document. `themeCssVariables` includes `--radius` and every semantic `--*` color property. `generateThemeCss` emits deterministic `.light` and `.dark` rules from the same document.
 
-## Tenant authoring
+## Organization authoring
 
-A `ThemeDefinition` is the compact tenant-authoring input. It requires `colors` and `geometry` and may include the published `$schema` URL for editor assistance. `colors.light.primary` is the sole required color; light `background`, `foreground`, and every other semantic token are optional direct properties. An optional `colors.dark` object accepts only `background`, `foreground`, `primary`, and `accent`; all other dark roles remain derived. The resolver uses shadcn's neutral light background and foreground when they are omitted. An omitted `geometry.radius` resolves to shadcn's `0.625rem` default.
+A `ThemeDefinition` is the compact organization-authoring input. It requires `colors` and `geometry` and may include the published `$schema` URL for editor assistance. `colors.light.primary` is the sole required color; light `background`, `foreground`, and every other semantic token are optional direct properties. An optional `colors.dark` object accepts only `background`, `foreground`, `primary`, and `accent`; all other dark roles remain derived. The resolver uses shadcn's neutral light background and foreground when they are omitted. An omitted `geometry.radius` resolves to shadcn's `0.625rem` default.
 
 ```ts
 import { resolveThemeDefinition } from "@astralbeam/theme"

--- a/packages/theme/public/schemas/theme.schema.json
+++ b/packages/theme/public/schemas/theme.schema.json
@@ -65,7 +65,7 @@
         },
         "primary": {
           "$ref": "#/$defs/themeColor",
-          "description": "Required tenant brand color used to derive primary accents and dark roles."
+          "description": "Required organization brand color used to derive primary accents and dark roles."
         },
         "primary-foreground": { "$ref": "#/$defs/themeColor" },
         "secondary": { "$ref": "#/$defs/themeColor" },

--- a/packages/theme/src/theme.test.ts
+++ b/packages/theme/src/theme.test.ts
@@ -70,7 +70,7 @@ function createThemeDefinition(): ThemeDefinition {
   }
 }
 
-function createTenantTheme(): ThemeDocument {
+function createOrganizationTheme(): ThemeDocument {
   return parseThemeDocument({
     colors: {
       light: createColorMap("#123456", "#ffffff"),
@@ -98,7 +98,7 @@ function createColorMap(surface: string, foreground: string) {
 
 describe("theme document schema", () => {
   test("accepts an exhaustive non-AstralBeam theme", () => {
-    const parsed = parseThemeDocument(createTenantTheme())
+    const parsed = parseThemeDocument(createOrganizationTheme())
 
     expect(Object.keys(parsed)).toEqual(["colors", "geometry"])
     expect(Object.keys(parsed.colors.light)).toEqual(themeTokenNames)
@@ -107,40 +107,40 @@ describe("theme document schema", () => {
   })
 
   test("requires the exact resolved structure and semantic token set", () => {
-    const tenantTheme = createTenantTheme()
-    const missingToken = { ...tenantTheme.colors.light } as Record<string, string>
+    const organizationTheme = createOrganizationTheme()
+    const missingToken = { ...organizationTheme.colors.light } as Record<string, string>
     delete missingToken.background
 
     expect(() =>
       parseThemeDocument({
-        ...tenantTheme,
-        colors: { ...tenantTheme.colors, light: missingToken },
+        ...organizationTheme,
+        colors: { ...organizationTheme.colors, light: missingToken },
       }),
     ).toThrow(/background/u)
 
     const documentsWithExtras = [
-      { ...tenantTheme, metadata: "tenant-aurora" },
+      { ...organizationTheme, metadata: "organization-aurora" },
       {
-        ...tenantTheme,
-        colors: { ...tenantTheme.colors, tenantMode: "tenant" },
+        ...organizationTheme,
+        colors: { ...organizationTheme.colors, organizationMode: "organization" },
       },
       {
-        ...tenantTheme,
+        ...organizationTheme,
         colors: {
-          ...tenantTheme.colors,
-          light: { ...tenantTheme.colors.light, "tenant-light": "#000000" },
+          ...organizationTheme.colors,
+          light: { ...organizationTheme.colors.light, "organization-light": "#000000" },
         },
       },
       {
-        ...tenantTheme,
+        ...organizationTheme,
         colors: {
-          ...tenantTheme.colors,
-          dark: { ...tenantTheme.colors.dark, "tenant-dark": "#000000" },
+          ...organizationTheme.colors,
+          dark: { ...organizationTheme.colors.dark, "organization-dark": "#000000" },
         },
       },
       {
-        ...tenantTheme,
-        geometry: { ...tenantTheme.geometry, density: "compact" },
+        ...organizationTheme,
+        geometry: { ...organizationTheme.geometry, density: "compact" },
       },
     ]
 
@@ -149,33 +149,33 @@ describe("theme document schema", () => {
     }
     expect(() =>
       parseThemeDocument({
-        ...tenantTheme,
+        ...organizationTheme,
         colors: {
-          ...tenantTheme.colors,
-          dark: { ...tenantTheme.colors.dark, "tenant-only": "#000000" },
+          ...organizationTheme.colors,
+          dark: { ...organizationTheme.colors.dark, "organization-only": "#000000" },
         },
       }),
-    ).toThrow(/tenant-only/u)
+    ).toThrow(/organization-only/u)
   })
 
   test("rejects unsafe radius values", () => {
-    const tenantTheme = createTenantTheme()
+    const organizationTheme = createOrganizationTheme()
 
     expect(() =>
-      parseThemeDocument({ ...tenantTheme, geometry: { radius: "calc(1rem + 1px)" } }),
+      parseThemeDocument({ ...organizationTheme, geometry: { radius: "calc(1rem + 1px)" } }),
     ).toThrow("Theme radius must be zero or a nonnegative px, rem, em, or percentage length")
     expect(() =>
-      parseThemeDocument({ ...tenantTheme, geometry: { radius: "1rem; color: red" } }),
+      parseThemeDocument({ ...organizationTheme, geometry: { radius: "1rem; color: red" } }),
     ).toThrow("Theme radius must be zero or a nonnegative px, rem, em, or percentage length")
   })
 
   test("rejects invalid and transparent color values without throwing from safeParse", () => {
-    const tenantTheme = createTenantTheme()
+    const organizationTheme = createOrganizationTheme()
     const malformedTheme = {
-      ...tenantTheme,
+      ...organizationTheme,
       colors: {
-        ...tenantTheme.colors,
-        light: { ...tenantTheme.colors.light, primary: "color(display-p3" },
+        ...organizationTheme.colors,
+        light: { ...organizationTheme.colors.light, primary: "color(display-p3" },
       },
     }
 
@@ -186,38 +186,38 @@ describe("theme document schema", () => {
     expect(Exit.isFailure(safelyDecodeMalformedTheme())).toBe(true)
     expect(() =>
       parseThemeDocument({
-        ...tenantTheme,
+        ...organizationTheme,
         colors: {
-          ...tenantTheme.colors,
-          light: { ...tenantTheme.colors.light, primary: "not-a-color" },
+          ...organizationTheme.colors,
+          light: { ...organizationTheme.colors.light, primary: "not-a-color" },
         },
       }),
     ).toThrow("Theme colors must be valid opaque CSS colors")
     expect(() =>
       parseThemeDocument({
-        ...tenantTheme,
+        ...organizationTheme,
         colors: {
-          ...tenantTheme.colors,
-          dark: { ...tenantTheme.colors.dark, primary: "rgb(0 0 0 / 50%)" },
+          ...organizationTheme.colors,
+          dark: { ...organizationTheme.colors.dark, primary: "rgb(0 0 0 / 50%)" },
         },
       }),
     ).toThrow("Theme colors must be valid opaque CSS colors")
     expect(() =>
       parseThemeDocument({
-        ...tenantTheme,
+        ...organizationTheme,
         colors: {
-          ...tenantTheme.colors,
-          dark: { ...tenantTheme.colors.dark, primary: "rgb(0 0 0 / 99.95%)" },
+          ...organizationTheme.colors,
+          dark: { ...organizationTheme.colors.dark, primary: "rgb(0 0 0 / 99.95%)" },
         },
       }),
     ).toThrow("Theme colors must be valid opaque CSS colors")
     expect(() =>
       parseThemeDocument({
-        ...tenantTheme,
+        ...organizationTheme,
         colors: {
-          ...tenantTheme.colors,
+          ...organizationTheme.colors,
           dark: {
-            ...tenantTheme.colors.dark,
+            ...organizationTheme.colors.dark,
             primary: "color-mix(in srgb, transparent 0.05%, black)",
           },
         },
@@ -226,14 +226,14 @@ describe("theme document schema", () => {
   })
 
   test("rejects low-contrast foreground pairs in resolved documents", () => {
-    const tenantTheme = createTenantTheme()
+    const organizationTheme = createOrganizationTheme()
     const lowContrastTheme = {
-      ...tenantTheme,
+      ...organizationTheme,
       colors: {
-        ...tenantTheme.colors,
+        ...organizationTheme.colors,
         light: {
-          ...tenantTheme.colors.light,
-          "primary-foreground": tenantTheme.colors.light.primary,
+          ...organizationTheme.colors.light,
+          "primary-foreground": organizationTheme.colors.light.primary,
         },
       },
     }
@@ -246,12 +246,12 @@ describe("theme document schema", () => {
     for (const token of ["destructive", "warning"] as const) {
       expect(() =>
         parseThemeDocument({
-          ...tenantTheme,
+          ...organizationTheme,
           colors: {
-            ...tenantTheme.colors,
+            ...organizationTheme.colors,
             light: {
-              ...tenantTheme.colors.light,
-              [token]: tenantTheme.colors.light.background,
+              ...organizationTheme.colors.light,
+              [token]: organizationTheme.colors.light.background,
             },
           },
         }),
@@ -260,12 +260,12 @@ describe("theme document schema", () => {
 
     expect(() =>
       parseThemeDocument({
-        ...tenantTheme,
+        ...organizationTheme,
         colors: {
-          ...tenantTheme.colors,
+          ...organizationTheme.colors,
           light: {
-            ...tenantTheme.colors.light,
-            ring: tenantTheme.colors.light.background,
+            ...organizationTheme.colors.light,
+            ring: organizationTheme.colors.light.background,
           },
         },
       }),
@@ -275,7 +275,7 @@ describe("theme document schema", () => {
 
 describe("theme color and CSS utilities", () => {
   test("resolves a selected mode and token to opaque sRGB", () => {
-    const resolved = resolveThemeColor(createTenantTheme(), "dark", "primary")
+    const resolved = resolveThemeColor(createOrganizationTheme(), "dark", "primary")
 
     expect(resolved).toEqual({
       css: "#abcdef",
@@ -287,26 +287,26 @@ describe("theme color and CSS utilities", () => {
   })
 
   test("resolves every token into a reusable mode palette", () => {
-    const tenantTheme = createTenantTheme()
-    const before = JSON.stringify(tenantTheme)
-    const palette = resolveThemePalette(tenantTheme, "dark")
+    const organizationTheme = createOrganizationTheme()
+    const before = JSON.stringify(organizationTheme)
+    const palette = resolveThemePalette(organizationTheme, "dark")
 
     expect(Object.keys(palette)).toEqual(Object.keys(paletteTokenByProperty))
     expect(Object.values(palette)).toEqual(
       Object.values(paletteTokenByProperty).map((token) =>
-        resolveThemeColor(tenantTheme, "dark", token),
+        resolveThemeColor(organizationTheme, "dark", token),
       ),
     )
     expect(Object.isFrozen(palette)).toBe(true)
     expect(Object.values(palette).every((resolvedColor) => Object.isFrozen(resolvedColor))).toBe(
       true,
     )
-    expect(resolveThemePalette(tenantTheme, "dark")).not.toBe(palette)
-    expect(JSON.stringify(tenantTheme)).toBe(before)
+    expect(resolveThemePalette(organizationTheme, "dark")).not.toBe(palette)
+    expect(JSON.stringify(organizationTheme)).toBe(before)
   })
 
   test("generates deterministic light and dark CSS", () => {
-    const css = generateThemeCss(createTenantTheme())
+    const css = generateThemeCss(createOrganizationTheme())
 
     expect(css).toMatch(/^\/\* Generated by @astralbeam\/theme\. Do not edit\. \*\//u)
     expect(css).toContain(".light,\n.dark {\n  --radius: 0.75rem;\n}")
@@ -317,25 +317,25 @@ describe("theme color and CSS utilities", () => {
   })
 
   test("creates every CSS variable without mutating the document", () => {
-    const tenantTheme = createTenantTheme()
-    const before = JSON.stringify(tenantTheme)
-    const variables = themeCssVariables(tenantTheme, "light")
+    const organizationTheme = createOrganizationTheme()
+    const before = JSON.stringify(organizationTheme)
+    const variables = themeCssVariables(organizationTheme, "light")
 
     expect(Object.keys(variables)).toHaveLength(themeTokenNames.length + 1)
     expect(variables["--radius"]).toBe("0.75rem")
     expect(variables["--primary"]).toBe("#123456")
     expect(Object.isFrozen(variables)).toBe(true)
-    expect(JSON.stringify(tenantTheme)).toBe(before)
+    expect(JSON.stringify(organizationTheme)).toBe(before)
   })
 
   test("runtime-validates resolved documents before serializing CSS", () => {
-    const tenantTheme = createTenantTheme()
+    const organizationTheme = createOrganizationTheme()
     const maliciousTheme = {
-      ...tenantTheme,
+      ...organizationTheme,
       colors: {
-        ...tenantTheme.colors,
+        ...organizationTheme.colors,
         light: {
-          ...tenantTheme.colors.light,
+          ...organizationTheme.colors.light,
           primary: "red; } body { color: lime",
         },
       },
@@ -346,7 +346,7 @@ describe("theme color and CSS utilities", () => {
     )
     expect(() =>
       generateThemeCss({
-        ...tenantTheme,
+        ...organizationTheme,
         geometry: { radius: "1rem; } body { color: lime" },
       }),
     ).toThrow("Theme radius must be zero or a nonnegative px, rem, em, or percentage length")
@@ -481,7 +481,7 @@ describe("theme definitions", () => {
     expect(() =>
       resolveThemeDefinition({ $schema: "https://example.com/theme.json", ...definition }),
     ).toThrow(/\$schema/u)
-    expect(() => resolveThemeDefinition({ ...definition, metadata: "tenant-seed" })).toThrow(
+    expect(() => resolveThemeDefinition({ ...definition, metadata: "organization-seed" })).toThrow(
       /metadata/u,
     )
     expect(() => resolveThemeDefinition({ colors: definition.colors })).toThrow(/geometry/u)

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -1,0 +1,7 @@
+# `@astralbeam/utils`
+
+Shared workspace utilities with explicit responsibility-based exports.
+
+## Workspace environment
+
+`@astralbeam/utils/environment` loads mode-specific environment files from the repository root for Vite-compatible configuration and standalone development tools. Existing process variables take precedence so CI and deployment-provided values are never overwritten.

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@astralbeam/utils",
+  "version": "0.0.0",
+  "private": true,
+  "license": "AGPL-3.0-only",
+  "type": "module",
+  "exports": {
+    "./environment": "./src/environment.ts"
+  },
+  "dependencies": {
+    "vite-plus": "catalog:"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/packages/utils/src/environment.ts
+++ b/packages/utils/src/environment.ts
@@ -1,0 +1,27 @@
+import { fileURLToPath } from "node:url"
+
+import { loadEnv, type Plugin, type UserConfig } from "vite-plus"
+
+const workspaceDirectory = fileURLToPath(new URL("../../../", import.meta.url))
+
+export function loadWorkspaceEnvironment(mode: string) {
+  for (const [name, value] of Object.entries(loadEnv(mode, workspaceDirectory, ""))) {
+    process.env[name] ??= value
+  }
+}
+
+function workspaceEnvironmentPlugin(): Plugin {
+  return {
+    name: "astralbeam:workspace-environment",
+    enforce: "pre",
+    config(_config, { mode }) {
+      // Load before Vite creates its module runners so server packages inherit the root environment. https://vite.dev/guide/api-plugin.html#config
+      loadWorkspaceEnvironment(mode)
+    },
+  }
+}
+
+export const workspaceEnvironmentViteConfig = {
+  envDir: workspaceDirectory,
+  plugins: [workspaceEnvironmentPlugin()],
+} satisfies UserConfig

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -303,7 +303,7 @@ catalogs:
       version: 19.2.7
     shadcn:
       specifier: ^4.13.0
-      version: 4.13.0
+      version: 4.18.0
     tailwind-merge:
       specifier: ^3.6.0
       version: 3.6.0
@@ -330,6 +330,9 @@ importers:
 
   .:
     devDependencies:
+      '@astralbeam/utils':
+        specifier: workspace:*
+        version: link:packages/utils
       '@types/node':
         specifier: 'catalog:'
         version: 22.20.1
@@ -344,7 +347,7 @@ importers:
         version: '@voidzero-dev/vite-plus-core@0.2.5(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(typescript@6.0.3)(yaml@2.9.0)'
       vite-plus:
         specifier: 'catalog:'
-        version: 0.2.5(@types/node@22.20.1)(@voidzero-dev/vite-plus-core@0.2.5(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(typescript@6.0.3)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(jsdom@28.1.0(supports-color@10.2.2))(typescript@6.0.3)(yaml@2.9.0)
+        version: 0.2.5(@types/node@22.20.1)(@voidzero-dev/vite-plus-core@0.2.5(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(typescript@6.0.3)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(jsdom@28.1.0(@noble/hashes@2.3.0)(supports-color@10.2.2))(typescript@6.0.3)(yaml@2.9.0)
 
   apps/webapp:
     dependencies:
@@ -440,6 +443,9 @@ importers:
         specifier: 7.1.1
         version: 7.1.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@22.20.1)(db0@0.3.4)(jiti@2.7.0)(typescript@6.0.3)(yaml@2.9.0)
     devDependencies:
+      '@astralbeam/utils':
+        specifier: workspace:*
+        version: link:../../packages/utils
       '@astrojs/check':
         specifier: 0.9.9
         version: 0.9.9(prettier@3.9.5)(typescript@6.0.3)
@@ -484,6 +490,9 @@ importers:
         specifier: 'catalog:'
         version: 3.4.9
     devDependencies:
+      '@astralbeam/utils':
+        specifier: workspace:*
+        version: link:../utils
       '@types/node':
         specifier: 'catalog:'
         version: 22.20.1
@@ -493,9 +502,6 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
-      vite:
-        specifier: npm:@voidzero-dev/vite-plus-core@0.2.5
-        version: '@voidzero-dev/vite-plus-core@0.2.5(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(typescript@6.0.3)(yaml@2.9.0)'
 
   packages/theme:
     dependencies:
@@ -544,7 +550,7 @@ importers:
         version: 19.2.7(react@19.2.7)
       shadcn:
         specifier: 'catalog:'
-        version: 4.13.0(supports-color@10.2.2)(typescript@6.0.3)
+        version: 4.18.0(supports-color@10.2.2)(typescript@6.0.3)
       tailwind-merge:
         specifier: 'catalog:'
         version: 3.6.0
@@ -561,6 +567,19 @@ importers:
       tailwindcss:
         specifier: 'catalog:'
         version: 4.3.3
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+
+  packages/utils:
+    dependencies:
+      vite-plus:
+        specifier: 'catalog:'
+        version: 0.2.5(@types/node@22.20.1)(@voidzero-dev/vite-plus-core@0.2.5(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(typescript@6.0.3)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(jsdom@28.1.0(@noble/hashes@2.3.0)(supports-color@10.2.2))(typescript@6.0.3)(yaml@2.9.0)
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.20.1
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -1787,6 +1806,10 @@ packages:
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
+
+  '@noble/hashes@2.3.0':
+    resolution: {integrity: sha512-oN+QwyX7VSHotibwubG3kpzbwKrfnyR6OOO+3Nk/53ADL7FmgHHz4TgrbaYKvvOw09u6QTx0oiH1cNCIOuN0CQ==}
+    engines: {node: '>= 20.19.0'}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -4296,9 +4319,6 @@ packages:
     resolution: {integrity: sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==}
     engines: {node: '>=18'}
 
-  get-tsconfig@4.14.0:
-    resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
-
   get-tsconfig@4.14.1:
     resolution: {integrity: sha512-Dz/6HxkrxgNehhxLVeyv8sad9UzF2xBVeaKBQNDfJ5XiSXmp2gTR0eO0RWiT2NCKS5aGP9jjkOMggTN90qU50A==}
 
@@ -5308,8 +5328,8 @@ packages:
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
-  shadcn@4.13.0:
-    resolution: {integrity: sha512-5fuJ4jI/GcPeA/iTL4cJivCZuYQGXz/N3bIzyd+Gd/FM6xUCy2MxGG+LaDQuw2cjNy9zGPSFPTEmI048UwPTZA==}
+  shadcn@4.18.0:
+    resolution: {integrity: sha512-tUFZgkYmfVNQVm3xX7lhSzOvDsp+O14ac5dwgXIr5mIsr79ISueb/Mu+ZtWMz0DH6v77u4eYyvbQ9TTMpSn3aw==}
     engines: {node: '>=20.18.1'}
     hasBin: true
 
@@ -5380,6 +5400,10 @@ packages:
     engines: {node: '>=20.19.5', npm: '>=10.8.2'}
     hasBin: true
 
+  smart-buffer@4.2.0:
+    resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
+    engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
+
   smol-toml@1.7.0:
     resolution: {integrity: sha512-aqVvWoyO21L23mb+drl4RmMXbf6N7FdHjAhTRA9ZBL7apWBgfWC16KjrASI+1p9GAroljyMHj6fK67i0UiTNvQ==}
     engines: {node: '>= 18'}
@@ -5387,6 +5411,10 @@ packages:
   smol-toml@1.7.1:
     resolution: {integrity: sha512-PPlsspAZ4jbMBu5DMFhfUGDQLu/vrL4SyBROVS37x8ynnVmFIs1VPBz1Co8Xks3TvpIaZXmU85y4DrQ+UyVFoQ==}
     engines: {node: '>= 18'}
+
+  socks@2.8.9:
+    resolution: {integrity: sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==}
+    engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
 
   solid-js@1.9.14:
     resolution: {integrity: sha512-sAEXC0Kk0S1EDg+8ysEWJDbYhA3RRoEjwuySUGlKIemeo0I5YZfOyumNjNs9Sv3y2nmhD+0rW66ag2HsMuQiGQ==}
@@ -6912,7 +6940,9 @@ snapshots:
   '@esbuild/win32-x64@0.28.1':
     optional: true
 
-  '@exodus/bytes@1.15.1':
+  '@exodus/bytes@1.15.1(@noble/hashes@2.3.0)':
+    optionalDependencies:
+      '@noble/hashes': 2.3.0
     optional: true
 
   '@floating-ui/core@1.8.0':
@@ -7226,6 +7256,9 @@ snapshots:
       '@emnapi/core': 1.11.2
       '@emnapi/runtime': 1.11.2
       '@tybys/wasm-util': 0.10.3
+    optional: true
+
+  '@noble/hashes@2.3.0':
     optional: true
 
   '@nodelib/fs.scandir@2.1.5':
@@ -8264,7 +8297,7 @@ snapshots:
       '@testing-library/dom': 10.4.1
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
       '@vitest/browser': 4.1.10(@voidzero-dev/vite-plus-core@0.2.5(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(typescript@6.0.3)(yaml@2.9.0))(vitest@4.1.10)
-      vitest: 4.1.10(@types/node@22.20.1)(@vitest/browser-preview@4.1.10)(@voidzero-dev/vite-plus-core@0.2.5(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(typescript@6.0.3)(yaml@2.9.0))(jsdom@28.1.0(supports-color@10.2.2))
+      vitest: 4.1.10(@types/node@22.20.1)(@vitest/browser-preview@4.1.10)(@voidzero-dev/vite-plus-core@0.2.5(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(typescript@6.0.3)(yaml@2.9.0))(jsdom@28.1.0(@noble/hashes@2.3.0)(supports-color@10.2.2))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -8280,7 +8313,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@types/node@22.20.1)(@vitest/browser-preview@4.1.10)(@voidzero-dev/vite-plus-core@0.2.5(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(typescript@6.0.3)(yaml@2.9.0))(jsdom@28.1.0(supports-color@10.2.2))
+      vitest: 4.1.10(@types/node@22.20.1)(@vitest/browser-preview@4.1.10)(@voidzero-dev/vite-plus-core@0.2.5(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(typescript@6.0.3)(yaml@2.9.0))(jsdom@28.1.0(@noble/hashes@2.3.0)(supports-color@10.2.2))
       ws: 8.21.1
     transitivePeerDependencies:
       - bufferutil
@@ -8887,10 +8920,10 @@ snapshots:
 
   csstype@3.2.3: {}
 
-  data-urls@7.0.0:
+  data-urls@7.0.0(@noble/hashes@2.3.0):
     dependencies:
       whatwg-mimetype: 5.0.0
-      whatwg-url: 16.0.1
+      whatwg-url: 16.0.1(@noble/hashes@2.3.0)
     transitivePeerDependencies:
       - '@noble/hashes'
     optional: true
@@ -8976,7 +9009,7 @@ snapshots:
       '@drizzle-team/brocli': 0.12.0
       '@js-temporal/polyfill': 0.5.1
       esbuild: 0.25.12
-      get-tsconfig: 4.14.0
+      get-tsconfig: 4.14.1
       jiti: 2.7.0
 
   drizzle-orm@1.0.0-rc.4(effect@4.0.0-rc.108)(postgres@3.4.9)(valibot@1.4.2(typescript@6.0.3))(zod@4.4.3):
@@ -9343,10 +9376,6 @@ snapshots:
       '@sec-ant/readable-stream': 0.4.1
       is-stream: 4.0.1
 
-  get-tsconfig@4.14.0:
-    dependencies:
-      resolve-pkg-maps: 1.0.0
-
   get-tsconfig@4.14.1:
     dependencies:
       resolve-pkg-maps: 1.0.0
@@ -9455,9 +9484,9 @@ snapshots:
 
   hookable@6.1.1: {}
 
-  html-encoding-sniffer@6.0.0:
+  html-encoding-sniffer@6.0.0(@noble/hashes@2.3.0):
     dependencies:
-      '@exodus/bytes': 1.15.1
+      '@exodus/bytes': 1.15.1(@noble/hashes@2.3.0)
     transitivePeerDependencies:
       - '@noble/hashes'
     optional: true
@@ -9590,16 +9619,16 @@ snapshots:
 
   jsbi@4.3.2: {}
 
-  jsdom@28.1.0(supports-color@10.2.2):
+  jsdom@28.1.0(@noble/hashes@2.3.0)(supports-color@10.2.2):
     dependencies:
       '@acemir/cssom': 0.9.31
       '@asamuzakjp/dom-selector': 6.8.1
       '@bramus/specificity': 2.4.2
-      '@exodus/bytes': 1.15.1
+      '@exodus/bytes': 1.15.1(@noble/hashes@2.3.0)
       cssstyle: 6.2.0
-      data-urls: 7.0.0
+      data-urls: 7.0.0(@noble/hashes@2.3.0)
       decimal.js: 10.6.0
-      html-encoding-sniffer: 6.0.0
+      html-encoding-sniffer: 6.0.0(@noble/hashes@2.3.0)
       http-proxy-agent: 7.0.2(supports-color@10.2.2)
       https-proxy-agent: 7.0.6(supports-color@10.2.2)
       is-potential-custom-element-name: 1.0.1
@@ -9611,7 +9640,7 @@ snapshots:
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
-      whatwg-url: 16.0.1
+      whatwg-url: 16.0.1(@noble/hashes@2.3.0)
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - '@noble/hashes'
@@ -10084,7 +10113,7 @@ snapshots:
       '@oxc-resolver/binding-win32-arm64-msvc': 11.24.2
       '@oxc-resolver/binding-win32-x64-msvc': 11.24.2
 
-  oxfmt@0.58.0(vite-plus@0.2.5(@types/node@22.20.1)(@voidzero-dev/vite-plus-core@0.2.5(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(typescript@6.0.3)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(jsdom@28.1.0(supports-color@10.2.2))(typescript@6.0.3)(yaml@2.9.0)):
+  oxfmt@0.58.0(vite-plus@0.2.5(@types/node@22.20.1)(@voidzero-dev/vite-plus-core@0.2.5(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(typescript@6.0.3)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(jsdom@28.1.0(@noble/hashes@2.3.0)(supports-color@10.2.2))(typescript@6.0.3)(yaml@2.9.0)):
     dependencies:
       tinypool: 2.1.0
     optionalDependencies:
@@ -10107,7 +10136,7 @@ snapshots:
       '@oxfmt/binding-win32-arm64-msvc': 0.58.0
       '@oxfmt/binding-win32-ia32-msvc': 0.58.0
       '@oxfmt/binding-win32-x64-msvc': 0.58.0
-      vite-plus: 0.2.5(@types/node@22.20.1)(@voidzero-dev/vite-plus-core@0.2.5(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(typescript@6.0.3)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(jsdom@28.1.0(supports-color@10.2.2))(typescript@6.0.3)(yaml@2.9.0)
+      vite-plus: 0.2.5(@types/node@22.20.1)(@voidzero-dev/vite-plus-core@0.2.5(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(typescript@6.0.3)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(jsdom@28.1.0(@noble/hashes@2.3.0)(supports-color@10.2.2))(typescript@6.0.3)(yaml@2.9.0)
 
   oxlint-tsgolint@0.24.0:
     optionalDependencies:
@@ -10118,7 +10147,7 @@ snapshots:
       '@oxlint-tsgolint/win32-arm64': 0.24.0
       '@oxlint-tsgolint/win32-x64': 0.24.0
 
-  oxlint@1.73.0(oxlint-tsgolint@0.24.0)(vite-plus@0.2.5(@types/node@22.20.1)(@voidzero-dev/vite-plus-core@0.2.5(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(typescript@6.0.3)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(jsdom@28.1.0(supports-color@10.2.2))(typescript@6.0.3)(yaml@2.9.0)):
+  oxlint@1.73.0(oxlint-tsgolint@0.24.0)(vite-plus@0.2.5(@types/node@22.20.1)(@voidzero-dev/vite-plus-core@0.2.5(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(typescript@6.0.3)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(jsdom@28.1.0(@noble/hashes@2.3.0)(supports-color@10.2.2))(typescript@6.0.3)(yaml@2.9.0)):
     optionalDependencies:
       '@oxlint/binding-android-arm-eabi': 1.73.0
       '@oxlint/binding-android-arm64': 1.73.0
@@ -10140,7 +10169,7 @@ snapshots:
       '@oxlint/binding-win32-ia32-msvc': 1.73.0
       '@oxlint/binding-win32-x64-msvc': 1.73.0
       oxlint-tsgolint: 0.24.0
-      vite-plus: 0.2.5(@types/node@22.20.1)(@voidzero-dev/vite-plus-core@0.2.5(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(typescript@6.0.3)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(jsdom@28.1.0(supports-color@10.2.2))(typescript@6.0.3)(yaml@2.9.0)
+      vite-plus: 0.2.5(@types/node@22.20.1)(@voidzero-dev/vite-plus-core@0.2.5(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(typescript@6.0.3)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(jsdom@28.1.0(@noble/hashes@2.3.0)(supports-color@10.2.2))(typescript@6.0.3)(yaml@2.9.0)
 
   p-limit@2.3.0:
     dependencies:
@@ -10447,7 +10476,7 @@ snapshots:
 
   setprototypeof@1.2.0: {}
 
-  shadcn@4.13.0(supports-color@10.2.2)(typescript@6.0.3):
+  shadcn@4.18.0(supports-color@10.2.2)(typescript@6.0.3):
     dependencies:
       '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/parser': 7.29.7
@@ -10473,6 +10502,7 @@ snapshots:
       postcss-selector-parser: 7.1.4
       prompts: 2.4.2
       recast: 0.23.12
+      socks: 2.8.9
       stringify-object: 5.0.0
       tailwind-merge: 3.6.0
       ts-morph: 26.0.0
@@ -10619,9 +10649,16 @@ snapshots:
       arg: 5.0.2
       sax: 1.6.0
 
+  smart-buffer@4.2.0: {}
+
   smol-toml@1.7.0: {}
 
   smol-toml@1.7.1: {}
+
+  socks@2.8.9:
+    dependencies:
+      ip-address: 10.2.0
+      smart-buffer: 4.2.0
 
   solid-js@1.9.14:
     dependencies:
@@ -10922,7 +10959,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-plus@0.2.5(@types/node@22.20.1)(@voidzero-dev/vite-plus-core@0.2.5(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(typescript@6.0.3)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(jsdom@28.1.0(supports-color@10.2.2))(typescript@6.0.3)(yaml@2.9.0):
+  vite-plus@0.2.5(@types/node@22.20.1)(@voidzero-dev/vite-plus-core@0.2.5(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(typescript@6.0.3)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(jsdom@28.1.0(@noble/hashes@2.3.0)(supports-color@10.2.2))(typescript@6.0.3)(yaml@2.9.0):
     dependencies:
       '@oxc-project/types': 0.139.0
       '@oxlint/plugins': 1.73.0
@@ -10936,10 +10973,10 @@ snapshots:
       '@vitest/spy': 4.1.10
       '@vitest/utils': 4.1.10
       '@voidzero-dev/vite-plus-core': 0.2.5(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(typescript@6.0.3)(yaml@2.9.0)
-      oxfmt: 0.58.0(vite-plus@0.2.5(@types/node@22.20.1)(@voidzero-dev/vite-plus-core@0.2.5(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(typescript@6.0.3)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(jsdom@28.1.0(supports-color@10.2.2))(typescript@6.0.3)(yaml@2.9.0))
-      oxlint: 1.73.0(oxlint-tsgolint@0.24.0)(vite-plus@0.2.5(@types/node@22.20.1)(@voidzero-dev/vite-plus-core@0.2.5(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(typescript@6.0.3)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(jsdom@28.1.0(supports-color@10.2.2))(typescript@6.0.3)(yaml@2.9.0))
+      oxfmt: 0.58.0(vite-plus@0.2.5(@types/node@22.20.1)(@voidzero-dev/vite-plus-core@0.2.5(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(typescript@6.0.3)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(jsdom@28.1.0(@noble/hashes@2.3.0)(supports-color@10.2.2))(typescript@6.0.3)(yaml@2.9.0))
+      oxlint: 1.73.0(oxlint-tsgolint@0.24.0)(vite-plus@0.2.5(@types/node@22.20.1)(@voidzero-dev/vite-plus-core@0.2.5(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(typescript@6.0.3)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(jsdom@28.1.0(@noble/hashes@2.3.0)(supports-color@10.2.2))(typescript@6.0.3)(yaml@2.9.0))
       oxlint-tsgolint: 0.24.0
-      vitest: 4.1.10(@types/node@22.20.1)(@vitest/browser-preview@4.1.10)(@voidzero-dev/vite-plus-core@0.2.5(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(typescript@6.0.3)(yaml@2.9.0))(jsdom@28.1.0(supports-color@10.2.2))
+      vitest: 4.1.10(@types/node@22.20.1)(@vitest/browser-preview@4.1.10)(@voidzero-dev/vite-plus-core@0.2.5(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(typescript@6.0.3)(yaml@2.9.0))(jsdom@28.1.0(@noble/hashes@2.3.0)(supports-color@10.2.2))
     optionalDependencies:
       '@voidzero-dev/vite-plus-darwin-arm64': 0.2.5
       '@voidzero-dev/vite-plus-darwin-x64': 0.2.5
@@ -10984,7 +11021,7 @@ snapshots:
     optionalDependencies:
       vite: '@voidzero-dev/vite-plus-core@0.2.5(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(typescript@6.0.3)(yaml@2.9.0)'
 
-  vitest@4.1.10(@types/node@22.20.1)(@vitest/browser-preview@4.1.10)(@voidzero-dev/vite-plus-core@0.2.5(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(typescript@6.0.3)(yaml@2.9.0))(jsdom@28.1.0(supports-color@10.2.2)):
+  vitest@4.1.10(@types/node@22.20.1)(@vitest/browser-preview@4.1.10)(@voidzero-dev/vite-plus-core@0.2.5(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(typescript@6.0.3)(yaml@2.9.0))(jsdom@28.1.0(@noble/hashes@2.3.0)(supports-color@10.2.2)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(@voidzero-dev/vite-plus-core@0.2.5(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(typescript@6.0.3)(yaml@2.9.0))
@@ -11009,7 +11046,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.20.1
       '@vitest/browser-preview': 4.1.10(@voidzero-dev/vite-plus-core@0.2.5(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(typescript@6.0.3)(yaml@2.9.0))(vitest@4.1.10)
-      jsdom: 28.1.0(supports-color@10.2.2)
+      jsdom: 28.1.0(@noble/hashes@2.3.0)(supports-color@10.2.2)
     transitivePeerDependencies:
       - msw
 
@@ -11136,9 +11173,9 @@ snapshots:
   whatwg-mimetype@5.0.0:
     optional: true
 
-  whatwg-url@16.0.1:
+  whatwg-url@16.0.1(@noble/hashes@2.3.0):
     dependencies:
-      '@exodus/bytes': 1.15.1
+      '@exodus/bytes': 1.15.1(@noble/hashes@2.3.0)
       tr46: 6.0.0
       webidl-conversions: 8.0.1
     transitivePeerDependencies:

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,3 +1,4 @@
+import { workspaceEnvironmentViteConfig } from "@astralbeam/utils/environment"
 import { defineConfig, type UserConfig } from "vite-plus"
 
 const generatedPaths = [
@@ -16,7 +17,7 @@ const generatedPaths = [
 
 // Shared app config via imports: https://viteplus.dev/guide/monorepo#composing-configuration-files
 export const sharedViteConfig = {
-  envDir: import.meta.dirname,
+  ...workspaceEnvironmentViteConfig,
   check: {
     fmt: true,
     lint: true,
@@ -75,8 +76,15 @@ export const sharedViteConfig = {
       ],
       // The automatic JSX runtime does not require React to be imported in every TSX file.
       "react/react-in-jsx-scope": "off",
+      // Keep the stable Rules of Hooks check explicit even though compiler lint also reports hook-order violations. https://react.dev/reference/eslint-plugin-react-hooks
+      "react/rules-of-hooks": "error",
       // React Compiler lint is experimental and intentionally absent from category presets.
       "react/react-compiler": "error",
+      // Compiler enforcement lives in react/react-compiler and the webapp's compiler preset; disable legacy allocation rules that encourage redundant manual memoization. https://react.dev/reference/react-compiler/introduction#what-does-react-compiler-do
+      "react-perf/jsx-no-jsx-as-prop": "off",
+      "react-perf/jsx-no-new-array-as-prop": "off",
+      "react-perf/jsx-no-new-function-as-prop": "off",
+      "react-perf/jsx-no-new-object-as-prop": "off",
       "vite-plus/prefer-vite-plus-imports": "error",
     },
     options: {


### PR DESCRIPTION
- Add shared workspace environment loading through `@astralbeam/utils` and use it from Vite, Astro, and Drizzle configuration.
- Publish Terms of Service and Privacy Policy pages, link them from the marketing site, and verify their generated routes and sitemap entries.
- Standardize Organization terminology across retained theme and website documentation while keeping authentication implementation out of this branch.
- Document Podman database reset and migration workflows and add generated-file Linguist conventions.
- Configure React Compiler panic behavior for development diagnostics and production resilience.
