### PR TITLE
Website improvements WIP

### DIFF
--- a/www/README.md
+++ b/www/README.md
@@ -16,7 +16,7 @@ Run all tasks from this directory:
 Structure:
 
 - `src/layouts/SiteLayout.astro` — shared document shell, search/social metadata, icons, manifest, and Organization structured data
-- `src/pages/index.astro` — the whole page (hero, compare, features, quickstart, open source, launch) plus HUD chrome
+- `src/pages/index.astro` — the whole page (hero, compare, quickstart, features, open source, launch) plus HUD chrome
 - `src/pages/404.astro` — "SIGNAL LOST" error page (wrangler `404-page` handling)
 - `src/pages/*.ts` — prerendered metadata resources, sitemap, icons, social image, `robots.txt`, and `llms.txt`
 - `src/styles/global.css` — all styling; site-specific derived tokens and shared semantic colors under explicit theme selectors

--- a/www/README.md
+++ b/www/README.md
@@ -16,11 +16,11 @@ Run all tasks from this directory:
 Structure:
 
 - `src/layouts/SiteLayout.astro` — shared document shell, search/social metadata, icons, manifest, and Organization structured data
-- `src/pages/index.astro` — the whole page (hero, transmission, systems, deploy sequence, open source, launch) plus HUD chrome
+- `src/pages/index.astro` — the whole page (hero, compare, features, quickstart, open source, launch) plus HUD chrome
 - `src/pages/404.astro` — "SIGNAL LOST" error page (wrangler `404-page` handling)
 - `src/pages/*.ts` — prerendered metadata resources, sitemap, icons, social image, `robots.txt`, and `llms.txt`
 - `src/styles/global.css` — all styling; site-specific derived tokens and shared semantic colors under explicit theme selectors
-- `src/scripts/main.ts` — canvas starfield, scramble-in headlines, scroll reveals, terminal typing, boot log, HUD scroll/sector readouts
+- `src/scripts/main.ts` — canvas starfield, scramble-in headlines, scroll reveals, terminal typing, and the hardcoded agent-sidebar prototype replay
 - `src/pages/schemas/theme.schema.json.ts` — prerendered route that publishes the checked-in `src/brand/theme.schema.json`
 - `scripts/verify-build.test.ts` — Vitest contract tests for page metadata and every generated discovery asset
 

--- a/www/src/layouts/LegalPageLayout.astro
+++ b/www/src/layouts/LegalPageLayout.astro
@@ -128,7 +128,7 @@ const { title, description, canonicalPath, effectiveDate } = Astro.props
 
   .legal-title > p:last-child {
     margin-top: 1rem;
-    color: var(--muted-foreground);
+    color: var(--text-muted);
   }
 
   .legal-content {
@@ -148,7 +148,7 @@ const { title, description, canonicalPath, effectiveDate } = Astro.props
 
   :global(.legal-content p),
   :global(.legal-content li) {
-    color: var(--muted-foreground);
+    color: var(--text-muted);
   }
 
   :global(.legal-content p + p),
@@ -169,7 +169,7 @@ const { title, description, canonicalPath, effectiveDate } = Astro.props
     flex-wrap: wrap;
     padding-block: 1.5rem;
     border-top: 1px solid var(--border);
-    color: var(--muted-foreground);
+    color: var(--text-muted);
     font-size: 0.7rem;
     letter-spacing: 0.1em;
   }

--- a/www/src/lib/site.ts
+++ b/www/src/lib/site.ts
@@ -3,7 +3,7 @@ export const siteMetadata = {
   origin: "https://www.astralbeam.ai",
   title: "AstralBeam - Ship agents in minutes, not months",
   description:
-    "Open source AI agent infrastructure. Drop in the frontend SDK, and AstralBeam handles agentic chat, streaming, history, tools, metering, billing, and auth.",
+    "Open source AI infrastructure. Drop in the frontend SDK, and AstralBeam handles agentic chat, streaming, history, tools, metering, billing, and auth.",
   email: "hello@astralbeam.ai",
   icon: {
     path: "/favicon.png",

--- a/www/src/lib/site.ts
+++ b/www/src/lib/site.ts
@@ -3,7 +3,7 @@ export const siteMetadata = {
   origin: "https://www.astralbeam.ai",
   title: "AstralBeam - Ship agents in minutes, not months",
   description:
-    "Open-source agent infrastructure. One service to add production-ready agents to any app: streaming, history, tools, billing, auth, and evals.",
+    "Open source AI agent infrastructure. Drop in the frontend SDK, and AstralBeam handles agentic chat, streaming, history, tools, metering, billing, and auth.",
   email: "hello@astralbeam.ai",
   icon: {
     path: "/favicon.png",

--- a/www/src/pages/index.astro
+++ b/www/src/pages/index.astro
@@ -1,5 +1,4 @@
 ---
-import astralbeamDarkLogoUrl from "@/brand/logo/svg/astralbeam-logo-dark.svg?url&no-inline"
 import astralbeamDarkWordmarkUrl from "@/brand/logo/svg/astralbeam-wordmark-dark.svg?url&no-inline"
 import SiteLayout from "@/layouts/SiteLayout.astro"
 import { siteMetadata } from "@/lib/site"
@@ -8,56 +7,49 @@ const waitlistUrl = "https://airtable.com/app5bJZxFB5NoPBUX/paghAGYUoz5JoIQDs/fo
 
 const features = [
   {
-    id: "01",
     name: "Frontend SDK",
     desc: "A fully-customizable, Cursor-like agent sidebar. Drop it into your web app in a few lines of code.",
     icon: "panel",
   },
   {
-    id: "02",
     name: "Managed Backend",
     desc: "Resumable chat streaming, conversation history, and observability, all managed for you, nothing to run.",
     icon: "server",
   },
   {
-    id: "03",
     name: "Tools, Skills & MCP",
     desc: "Wire up tools and skills, let users bring their own MCPs, and let agents take real actions in your app.",
     icon: "plug",
   },
   {
-    id: "04",
     name: "Metered Billing & Rate Limits",
     desc: "Per-customer rate limits and token-metered billing, wired to Stripe subscriptions out of the box.",
     icon: "meter",
   },
   {
-    id: "05",
     name: "Enterprise-Ready",
     desc: "Organization-aware, enterprise-grade SSO, data privacy, and access control, all built in from day one.",
     icon: "shield",
   },
   {
-    id: "06",
     name: "Prompts & Evals",
     desc: "Edit prompts, run A/B tests, and score live conversations from a web UI. No redeploy, no engineer needed.",
     icon: "flask",
   },
 ]
 
-// The same responsibilities appear in both comparison panels: seven vendors to
-// integrate on the left, one service that covers them on the right.
-const stackPieces = [
-  "LLM Gateway",
-  "Agent Framework",
-  "Observability",
-  "Tools & MCPs",
-  "Metering & Billing",
-  "Auth & SSO",
-  "Prompts & Evals",
+// Nodes of the "without AstralBeam" tangle. Scattered positions and per-node
+// tilts are hand-picked so the diagram reads as a mess, not a grid; `w` is the
+// box width that fits the label at 10px mono with 0.14em tracking.
+const tangledNodes = [
+  { label: "LLM GATEWAY", x: 96, y: 40, w: 104, tilt: -4, delay: "0s" },
+  { label: "FRAMEWORK", x: 300, y: 28, w: 88, tilt: 3, delay: "-1.1s" },
+  { label: "OBSERVABILITY", x: 112, y: 116, w: 118, tilt: 2.5, delay: "-0.5s" },
+  { label: "TOOLS & MCPS", x: 296, y: 106, w: 110, tilt: -3, delay: "-1.7s" },
+  { label: "BILLING", x: 66, y: 196, w: 74, tilt: 4, delay: "-0.8s" },
+  { label: "AUTH & SSO", x: 214, y: 176, w: 96, tilt: -2, delay: "-2.2s" },
+  { label: "EVALS", x: 350, y: 208, w: 58, tilt: 3.5, delay: "-1.4s" },
 ]
-
-const openStandards = ["AG-UI", "MCP", "OpenResponses"]
 
 const githubUrl = "https://github.com/astralbeamai/astralbeam"
 ---
@@ -81,8 +73,8 @@ const githubUrl = "https://github.com/astralbeamai/astralbeam"
         <img class="hud-brand-wordmark" src={astralbeamDarkWordmarkUrl} alt="" width="1241" height="136" />
       </a>
       <nav class="hud-nav" aria-label="Primary">
-        <a href="#features">FEATURES</a>
         <a href="#quickstart">QUICKSTART</a>
+        <a href="#features">FEATURES</a>
         <a href="#open-source">OPEN&nbsp;SOURCE</a>
         <a class="hud-nav-github" href={githubUrl} target="_blank" rel="noopener noreferrer" aria-label="AstralBeam on GitHub">
           <svg class="icon-github" viewBox="0 0 16 16" aria-hidden="true"><path d="M8 0a8 8 0 0 0-2.53 15.59c.4.07.55-.17.55-.38l-.01-1.34c-2.23.48-2.7-1.07-2.7-1.07-.36-.93-.89-1.18-.89-1.18-.73-.5.05-.49.05-.49.8.06 1.23.83 1.23.83.72 1.23 1.88.87 2.34.67.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.28.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48l-.01 2.2c0 .21.14.46.55.38A8 8 0 0 0 8 0z"></path></svg>
@@ -100,7 +92,7 @@ const githubUrl = "https://github.com/astralbeamai/astralbeam"
         <div class="hero-beam" aria-hidden="true"></div>
 
         <div class="hero-inner">
-          <p class="eyebrow reveal">OPEN SOURCE AI AGENT INFRASTRUCTURE</p>
+          <p class="eyebrow reveal">OPEN SOURCE AI INFRASTRUCTURE</p>
           <h1 class="display hero-title">
             <span class="reveal scramble" data-text="SHIP AGENTS">SHIP AGENTS</span><br />
             <span class="reveal scramble" data-text="IN MINUTES" style="--reveal-delay:.12s">IN MINUTES</span><br />
@@ -118,13 +110,11 @@ const githubUrl = "https://github.com/astralbeamai/astralbeam"
               STAR ON GITHUB
             </a>
           </div>
-          <p class="hero-alt mono reveal" style="--reveal-delay:.56s">SELF-HOST IT // OR ASTRALBEAM CLOUD</p>
         </div>
 
-        <div class="scroll-cue mono" aria-hidden="true">
-          <span>SCROLL TO INITIALIZE</span>
-          <i class="scroll-chevron"></i>
-        </div>
+        <a class="scroll-cue" href="#compare" aria-label="Skip to the next section">
+          <i class="scroll-chevron" aria-hidden="true"></i>
+        </a>
       </section>
 
       <!-- ============ COMPARE ============ -->
@@ -143,41 +133,181 @@ const githubUrl = "https://github.com/astralbeamai/astralbeam"
         <div class="compare-grid">
           <figure class="panel compare-panel reveal">
             <figcaption class="panel-label mono"><span class="x-mark">✕</span> WITHOUT ASTRALBEAM</figcaption>
-            <div class="compare-body">
-              <svg class="tangle-art" viewBox="0 0 400 260" preserveAspectRatio="none" aria-hidden="true">
-                <g class="tangle" fill="none" stroke-dasharray="5 6">
-                  <path d="M40 30 C 180 10, 120 150, 330 60"></path>
-                  <path d="M40 30 C 90 180, 300 60, 250 240"></path>
-                  <path d="M40 130 C 200 230, 220 40, 360 150"></path>
-                  <path d="M60 230 C 140 120, 260 200, 350 90"></path>
-                  <path d="M30 190 C 190 250, 180 90, 370 220"></path>
-                </g>
-              </svg>
-              <ul class="stack-chips mono">
-                {stackPieces.map((piece) => <li>{piece}</li>)}
-              </ul>
-            </div>
+            <svg class="compare-art is-chaos" viewBox="0 0 420 260" aria-hidden="true">
+              <defs>
+                <radialGradient id="chaos-glow">
+                  <stop offset="0" stop-color="currentColor" stop-opacity="0.18"></stop>
+                  <stop offset="1" stop-color="currentColor" stop-opacity="0"></stop>
+                </radialGradient>
+              </defs>
+              <ellipse cx="210" cy="130" rx="205" ry="130" fill="url(#chaos-glow)"></ellipse>
+              <g class="tangle" fill="none" stroke-dasharray="6 7">
+                <path d="M30 30 C 200 0, 120 170, 390 70"></path>
+                <path d="M40 60 C 130 210, 330 40, 300 250"></path>
+                <path d="M60 130 C 240 240, 250 30, 400 160"></path>
+                <path d="M30 210 C 160 90, 300 220, 380 40"></path>
+                <path d="M20 170 C 200 250, 150 60, 400 230"></path>
+                <path d="M100 20 C 60 140, 380 130, 340 230"></path>
+                <path d="M380 20 C 220 90, 260 200, 40 240"></path>
+                <path d="M50 100 C 180 150, 220 100, 390 120"></path>
+                <path d="M150 250 C 250 150, 100 100, 260 20"></path>
+              </g>
+              <g class="node-set is-tangled">
+                {
+                  tangledNodes.map((node) => (
+                    <g transform={`translate(${node.x},${node.y}) rotate(${node.tilt})`}>
+                      <g class="node" style={`--jitter-delay:${node.delay}`}>
+                        <rect x={-node.w / 2} y="-13" width={node.w} height="26"></rect>
+                        <text y="4">{node.label}</text>
+                      </g>
+                    </g>
+                  ))
+                }
+              </g>
+            </svg>
             <p class="compare-note">
-              Multiple vendors, months of integration, all before a single agent ships.
+              Multiple vendors & months of integration before a single agent ships.
             </p>
           </figure>
 
           <figure class="panel compare-panel is-beam reveal" style="--reveal-delay:.15s">
             <figcaption class="panel-label mono"><span class="check-mark">✓</span> WITH ASTRALBEAM</figcaption>
-            <div class="compare-body is-single">
-              <div class="single-core">
-                <span class="single-beam" aria-hidden="true"></span>
-                <img class="single-logo" src={astralbeamDarkLogoUrl} alt="" width="270" height="270" />
-                <span class="single-name mono">ONE SERVICE</span>
-              </div>
-              <ul class="stack-chips is-included mono">
-                {stackPieces.map((piece) => <li>{piece}</li>)}
-              </ul>
-            </div>
+            <svg class="compare-art" viewBox="0 0 420 260" aria-hidden="true">
+              <line class="beam-line" x1="210" y1="12" x2="210" y2="248"></line>
+              <g class="node-set is-aligned">
+                <g transform="translate(210,44)"><rect x="-56" y="-13" width="112" height="26"></rect><text y="4">YOUR APP</text></g>
+                <g transform="translate(210,130)" class="core-node">
+                  <rect x="-108" y="-25" width="216" height="50"></rect>
+                  {/* The wordmark carries its own sRGB paints, so it renders correctly as an <image> reference. */}
+                  <image
+                    class="core-wordmark"
+                    href={astralbeamDarkWordmarkUrl}
+                    x="-93"
+                    y="-10.2"
+                    width="186"
+                    height="20.4"
+                  />
+                </g>
+                <g transform="translate(210,216)"><rect x="-56" y="-13" width="112" height="26"></rect><text y="4">ANY LLM</text></g>
+              </g>
+            </svg>
             <p class="compare-note">
-              One service. One SDK. Everything between your app and the model, handled.
+              One service. Everything between your app and the model, handled.
             </p>
           </figure>
+        </div>
+      </section>
+
+      <!-- ============ QUICKSTART ============ -->
+      <section class="section" id="quickstart">
+        <div class="section-head">
+          <h2 class="display section-title reveal scramble" data-text="LIFT OFF IN FIVE MINUTES">
+            LIFT OFF IN FIVE MINUTES
+          </h2>
+          <p class="section-sub reveal">
+            One package, one component. Point it at your tools, bring your own UI elements, and
+            the agent starts working on real data inside your product.
+          </p>
+        </div>
+
+        <div class="quickstart-grid">
+          <div class="panel terminal reveal" id="terminal">
+            <header class="terminal-bar mono">
+              <span class="term-dots"><i></i><i></i><i></i></span>
+              <span>app.tsx</span>
+            </header>
+            <pre class="terminal-body mono" aria-label="Example: install and mount the AstralBeam chat component"><code
+><span class="t-line" data-type="cmd"><span class="t-prompt">$</span> npm i @astralbeam/sdk</span>
+<span class="t-line" data-type="out">+ @astralbeam/sdk 1.0.0</span>
+<span class="t-line"> </span>
+<span class="t-line"><span class="t-kw">import</span> {"{"} AstralBeamChat {"}"} <span class="t-kw">from</span> <span class="t-str">"@astralbeam/sdk/react"</span></span>
+<span class="t-line"><span class="t-kw">import</span> {"{"} OrderCard {"}"} <span class="t-kw">from</span> <span class="t-str">"./widgets"</span></span>
+<span class="t-line"> </span>
+<span class="t-line"><span class="t-kw">export function</span> <span class="t-fn">App</span>() {"{"}</span>
+<span class="t-line">  <span class="t-kw">return</span> (</span>
+<span class="t-line">    &lt;&gt;</span>
+<span class="t-line">      &lt;<span class="t-tag">YourApp</span> /&gt;</span>
+<span class="t-line">      &lt;<span class="t-tag">AstralBeamChat</span> <span class="t-attr">agent</span>=<span class="t-str">"support"</span></span>
+<span class="t-line">        <span class="t-attr">tools</span>={"{"}[lookupOrder, refund, sendEmail]{"}"}</span>
+<span class="t-line">        <span class="t-attr">widgets</span>={"{{"} order: OrderCard {"}}"} /&gt;</span>
+<span class="t-line">    &lt;/&gt;</span>
+<span class="t-line">  )</span>
+<span class="t-line">{"}"}</span></code><span class="t-caret" aria-hidden="true"></span></pre>
+          </div>
+
+          <div class="agent-slot reveal" style="--reveal-delay:.15s">
+          <aside class="panel agent-panel" id="agent-demo">
+            <header class="agent-bar mono">
+              <span class="agent-title">SUPPORT AGENT</span>
+              <button class="agent-replay mono" type="button" data-replay>
+                <svg class="icon-replay" viewBox="0 0 16 16" aria-hidden="true">
+                  <path d="M13.6 8a5.6 5.6 0 1 1-1.7-4"></path>
+                  <path d="M12.6 1.3v3.2H9.4"></path>
+                </svg>
+                REPLAY
+              </button>
+            </header>
+
+            <div class="agent-thread" data-thread>
+              <article class="agent-msg is-user" data-step>
+                <p>Refund order 4821 and let the customer know.</p>
+              </article>
+              <article class="agent-msg is-agent" data-step>
+                <ul class="agent-tools mono">
+                  <li class="agent-tool" data-tool>
+                    <i class="tool-dot" aria-hidden="true"></i><span class="tool-name">lookupOrder</span><b>4821</b>
+                  </li>
+                  <li class="agent-tool" data-tool>
+                    <i class="tool-dot" aria-hidden="true"></i><span class="tool-name">refund</span><b>$128.00</b>
+                  </li>
+                  <li class="agent-tool" data-tool>
+                    <i class="tool-dot" aria-hidden="true"></i><span class="tool-name">sendEmail</span><b>receipt</b>
+                  </li>
+                </ul>
+                <!-- The <OrderCard /> widget passed to `widgets` in the snippet above. -->
+                <div class="agent-widget" data-widget>
+                  <header class="widget-head mono">
+                    <span>ORDER 4821</span>
+                    <span class="widget-badge">REFUNDED</span>
+                  </header>
+                  <dl class="widget-rows mono">
+                    <div><dt>Customer</dt><dd>Dana Whitfield</dd></div>
+                    <div><dt>Total</dt><dd>$128.00</dd></div>
+                    <div><dt>Card</dt><dd>Visa ···4242</dd></div>
+                  </dl>
+                </div>
+                <p class="agent-stream" data-stream>
+                  Refunded $128.00 and emailed Dana the confirmation.
+                </p>
+              </article>
+              <article class="agent-msg is-user" data-step>
+                <p>Anything else open on her account?</p>
+              </article>
+              <article class="agent-msg is-agent" data-step>
+                <ul class="agent-tools mono">
+                  <li class="agent-tool" data-tool>
+                    <i class="tool-dot" aria-hidden="true"></i><span class="tool-name">lookupOrder</span><b>open</b>
+                  </li>
+                </ul>
+                <p class="agent-stream" data-stream>
+                  One order still open, 4830, shipping tomorrow. I'll watch it and flag any delay.
+                </p>
+              </article>
+            </div>
+
+            <form class="agent-composer" data-composer>
+              <input
+                class="agent-input"
+                type="text"
+                autocomplete="off"
+                placeholder="Ask the agent…"
+                aria-label="Ask the demo agent"
+                data-input
+              />
+              <button class="agent-send" type="submit" aria-label="Send message">↑</button>
+            </form>
+          </aside>
+          </div>
         </div>
       </section>
 
@@ -197,9 +327,6 @@ const githubUrl = "https://github.com/astralbeamai/astralbeam"
           {
             features.map((feature, i) => (
               <article class="panel feature-panel reveal" style={`--reveal-delay:${(i % 3) * 0.12}s`}>
-                <header class="feature-head mono">
-                  <span class="feature-id">FEATURE {feature.id}</span>
-                </header>
                 <div class={`feature-icon icon-${feature.icon}`} aria-hidden="true">
                   {feature.icon === "panel" && (
                     <svg viewBox="0 0 32 32"><rect x="3" y="5" width="26" height="22" rx="1"></rect><line x1="19" y1="5" x2="19" y2="27"></line><line x1="22" y1="10" x2="26" y2="10"></line><line x1="22" y1="14" x2="26" y2="14"></line></svg>
@@ -226,75 +353,6 @@ const githubUrl = "https://github.com/astralbeamai/astralbeam"
               </article>
             ))
           }
-        </div>
-      </section>
-
-      <!-- ============ QUICKSTART ============ -->
-      <section class="section" id="quickstart">
-        <div class="section-head">
-          <h2 class="display section-title reveal scramble" data-text="LIFT OFF IN FIVE MINUTES">
-            LIFT OFF IN FIVE MINUTES
-          </h2>
-          <p class="section-sub reveal">
-            One package, one component. Point it at your tools and the agent starts working on
-            real data in your own UI.
-          </p>
-        </div>
-
-        <div class="quickstart-grid">
-          <div class="panel terminal reveal" id="terminal">
-            <header class="terminal-bar mono">
-              <span class="term-dots"><i></i><i></i><i></i></span>
-              <span>app.tsx</span>
-            </header>
-            <pre class="terminal-body mono" aria-label="Example: install and mount the AstralBeam sidebar"><code
-><span class="t-line" data-type="cmd"><span class="t-prompt">$</span> npm i @astralbeam/react</span>
-<span class="t-line" data-type="out">+ @astralbeam/react 1.0.0</span>
-<span class="t-line"> </span>
-<span class="t-line"><span class="t-kw">import</span> {"{"} AgentSidebar {"}"} <span class="t-kw">from</span> <span class="t-str">"@astralbeam/react"</span></span>
-<span class="t-line"> </span>
-<span class="t-line"><span class="t-kw">export function</span> <span class="t-fn">App</span>() {"{"}</span>
-<span class="t-line">  <span class="t-kw">return</span> (</span>
-<span class="t-line">    &lt;&gt;</span>
-<span class="t-line">      &lt;<span class="t-tag">YourApp</span> /&gt;</span>
-<span class="t-line">      &lt;<span class="t-tag">AgentSidebar</span> <span class="t-attr">agent</span>=<span class="t-str">"support"</span></span>
-<span class="t-line">        <span class="t-attr">tools</span>={"{"}[lookupOrder, refund]{"}"} /&gt;</span>
-<span class="t-line">    &lt;/&gt;</span>
-<span class="t-line">  )</span>
-<span class="t-line">{"}"}</span></code><span class="t-caret" aria-hidden="true"></span></pre>
-          </div>
-
-          <aside class="panel agent-panel reveal" style="--reveal-delay:.15s" id="agent-demo">
-            <header class="agent-bar mono">
-              <span class="agent-title">SUPPORT AGENT</span>
-              <span class="agent-model">STREAMING</span>
-            </header>
-            <div class="agent-thread">
-              <article class="agent-msg is-user" data-step>
-                <p>Refund order 4821 and let the customer know.</p>
-              </article>
-              <article class="agent-msg is-agent" data-step>
-                <ul class="agent-tools mono">
-                  <li class="agent-tool" data-tool>
-                    <i class="tool-dot" aria-hidden="true"></i><span class="tool-name">lookupOrder</span><b>4821</b>
-                  </li>
-                  <li class="agent-tool" data-tool>
-                    <i class="tool-dot" aria-hidden="true"></i><span class="tool-name">refund</span><b>$128.00</b>
-                  </li>
-                  <li class="agent-tool" data-tool>
-                    <i class="tool-dot" aria-hidden="true"></i><span class="tool-name">sendEmail</span><b>receipt</b>
-                  </li>
-                </ul>
-                <p class="agent-stream" data-stream>
-                  Refunded $128.00 on order 4821 and emailed the customer a confirmation. Want me to close the ticket too?
-                </p>
-              </article>
-            </div>
-            <div class="agent-composer" aria-hidden="true">
-              <span class="agent-placeholder">Ask the agent…</span>
-              <span class="agent-send">↑</span>
-            </div>
-          </aside>
         </div>
       </section>
 
@@ -335,11 +393,8 @@ const githubUrl = "https://github.com/astralbeamai/astralbeam"
             <p>Start with the entire platform, or adopt it incrementally, piece by piece.</p>
           </div>
           <div class="panel os-panel reveal" style="--reveal-delay:.3s">
-            <h3 class="os-name mono">OPEN STANDARDS</h3>
-            <p>Built on protocols you can swap in and out, not a proprietary runtime.</p>
-            <ul class="os-standards mono">
-              {openStandards.map((standard) => <li>{standard}</li>)}
-            </ul>
+            <h3 class="os-name mono">OPEN PROTOCOLS</h3>
+            <p>Built on open protocols: AG-UI, MCP, A2A. Swap pieces in and out instead of adopting a proprietary runtime.</p>
           </div>
         </div>
 

--- a/www/src/pages/index.astro
+++ b/www/src/pages/index.astro
@@ -1,11 +1,12 @@
 ---
+import astralbeamDarkLogoUrl from "@/brand/logo/svg/astralbeam-logo-dark.svg?url&no-inline"
 import astralbeamDarkWordmarkUrl from "@/brand/logo/svg/astralbeam-wordmark-dark.svg?url&no-inline"
 import SiteLayout from "@/layouts/SiteLayout.astro"
 import { siteMetadata } from "@/lib/site"
 
 const waitlistUrl = "https://airtable.com/app5bJZxFB5NoPBUX/paghAGYUoz5JoIQDs/form"
 
-const systems = [
+const features = [
   {
     id: "01",
     name: "Frontend SDK",
@@ -14,53 +15,51 @@ const systems = [
   },
   {
     id: "02",
-    name: "Managed backend",
+    name: "Managed Backend",
     desc: "Resumable chat streaming, conversation history, and observability, all managed for you, nothing to run.",
     icon: "server",
   },
   {
     id: "03",
-    name: "Tools · Skills · MCP",
+    name: "Tools, Skills & MCP",
     desc: "Wire up tools and skills, let users bring their own MCPs, and let agents take real actions in your app.",
     icon: "plug",
   },
   {
     id: "04",
-    name: "Billing & rate limits",
-    desc: "Per-customer flexible rate limits and token-based billing, integrated with Stripe out of the box.",
+    name: "Metered Billing & Rate Limits",
+    desc: "Per-customer rate limits and token-metered billing, wired to Stripe subscriptions out of the box.",
     icon: "meter",
   },
   {
     id: "05",
-    name: "Enterprise-ready",
+    name: "Enterprise-Ready",
     desc: "Organization-aware, enterprise-grade SSO, data privacy, and access control, all built in from day one.",
     icon: "shield",
   },
   {
     id: "06",
-    name: "Prompts & evals",
-    desc: "PMs and non-engineers manage prompts, run A/B tests, and evaluate in production. No deploy required.",
+    name: "Prompts & Evals",
+    desc: "Edit prompts, run A/B tests, and score live conversations from a web UI. No redeploy, no engineer needed.",
     icon: "flask",
   },
 ]
 
-const auxSystems = [
-  "Multiplayer chat",
-  "Background agents",
-  "Dynamic LLM routing",
-  "Prompt caching",
-  "Audit logs",
-  "Token optimization",
+// The same responsibilities appear in both comparison panels: seven vendors to
+// integrate on the left, one service that covers them on the right.
+const stackPieces = [
+  "LLM Gateway",
+  "Agent Framework",
+  "Observability",
+  "Tools & MCPs",
+  "Metering & Billing",
+  "Auth & SSO",
+  "Prompts & Evals",
 ]
 
-const bootChecks = [
-  ["STREAMING", "RESUMABLE"],
-  ["HISTORY", "PERSISTED"],
-  ["TOOLS + MCP", "ARMED"],
-  ["BILLING", "METERED"],
-  ["SSO / AUTH", "LOCKED IN"],
-  ["EVALS", "LIVE"],
-]
+const openStandards = ["AG-UI", "MCP", "OpenResponses"]
+
+const githubUrl = "https://github.com/astralbeamai/astralbeam"
 ---
 
 <SiteLayout title={siteMetadata.title} description={siteMetadata.description} canonicalPath="/">
@@ -82,28 +81,26 @@ const bootChecks = [
         <img class="hud-brand-wordmark" src={astralbeamDarkWordmarkUrl} alt="" width="1241" height="136" />
       </a>
       <nav class="hud-nav" aria-label="Primary">
-        <a href="#systems">SYSTEMS</a>
-        <a href="#deploy">DEPLOY</a>
+        <a href="#features">FEATURES</a>
+        <a href="#quickstart">QUICKSTART</a>
         <a href="#open-source">OPEN&nbsp;SOURCE</a>
+        <a class="hud-nav-github" href={githubUrl} target="_blank" rel="noopener noreferrer" aria-label="AstralBeam on GitHub">
+          <svg class="icon-github" viewBox="0 0 16 16" aria-hidden="true"><path d="M8 0a8 8 0 0 0-2.53 15.59c.4.07.55-.17.55-.38l-.01-1.34c-2.23.48-2.7-1.07-2.7-1.07-.36-.93-.89-1.18-.89-1.18-.73-.5.05-.49.05-.49.8.06 1.23.83 1.23.83.72 1.23 1.88.87 2.34.67.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.28.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48l-.01 2.2c0 .21.14.46.55.38A8 8 0 0 0 8 0z"></path></svg>
+          <span class="hud-nav-label">GITHUB</span>
+        </a>
       </nav>
       <a class="btn btn-primary hud-cta" href={waitlistUrl} target="_blank" rel="noopener noreferrer">
-        JOIN THE WAITLIST
+        JOIN WAITLIST
       </a>
     </header>
 
-    <div class="hud-bottom" aria-hidden="true">
-      <span class="hud-readout"><i class="blink-dot"></i>SYS.STATUS: NOMINAL</span>
-      <span class="hud-readout hud-readout-mid">OPEN SOURCE // AGPL-3.0</span>
-      <span class="hud-readout"><span id="hud-sector">SECTOR 01/05</span> · SCROLL <span id="hud-scroll">000</span>%</span>
-    </div>
-
     <main>
-      <!-- ============ 00 / HERO ============ -->
+      <!-- ============ HERO ============ -->
       <section class="hero" id="top">
         <div class="hero-beam" aria-hidden="true"></div>
 
         <div class="hero-inner">
-          <p class="eyebrow reveal">// OPEN-SOURCE AGENT INFRASTRUCTURE</p>
+          <p class="eyebrow reveal">OPEN SOURCE AI AGENT INFRASTRUCTURE</p>
           <h1 class="display hero-title">
             <span class="reveal scramble" data-text="SHIP AGENTS">SHIP AGENTS</span><br />
             <span class="reveal scramble" data-text="IN MINUTES" style="--reveal-delay:.12s">IN MINUTES</span><br />
@@ -114,14 +111,14 @@ const bootChecks = [
           </p>
           <div class="hero-ctas reveal" style="--reveal-delay:.48s">
             <a class="btn btn-primary btn-lg" href={waitlistUrl} target="_blank" rel="noopener noreferrer">
-              JOIN THE WAITLIST
+              JOIN WAITLIST
             </a>
-            <span class="hero-alt mono">SELF-HOST IT // OR ASTRALBEAM CLOUD</span>
+            <a class="btn btn-ghost btn-lg" href={githubUrl} target="_blank" rel="noopener noreferrer">
+              <svg class="icon-github" viewBox="0 0 16 16" aria-hidden="true"><path d="M8 0a8 8 0 0 0-2.53 15.59c.4.07.55-.17.55-.38l-.01-1.34c-2.23.48-2.7-1.07-2.7-1.07-.36-.93-.89-1.18-.89-1.18-.73-.5.05-.49.05-.49.8.06 1.23.83 1.23.83.72 1.23 1.88.87 2.34.67.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.28.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48l-.01 2.2c0 .21.14.46.55.38A8 8 0 0 0 8 0z"></path></svg>
+              STAR ON GITHUB
+            </a>
           </div>
-        </div>
-
-        <div class="hero-readouts mono reveal" style="--reveal-delay:.6s" aria-hidden="true">
-          {bootChecks.map(([k, v]) => <span class="readout-chip">{k}: <b>{v}</b></span>)}
+          <p class="hero-alt mono reveal" style="--reveal-delay:.56s">SELF-HOST IT // OR ASTRALBEAM CLOUD</p>
         </div>
 
         <div class="scroll-cue mono" aria-hidden="true">
@@ -130,140 +127,129 @@ const bootChecks = [
         </div>
       </section>
 
-      <!-- ============ 01 / TRANSMISSION ============ -->
-      <section class="section" id="transmission" data-sector="02">
+      <!-- ============ COMPARE ============ -->
+      <section class="section" id="compare">
         <div class="section-head">
-          <p class="section-tag mono reveal">01 // TRANSMISSION</p>
           <h2 class="display section-title reveal scramble" data-text="STOP STITCHING YOUR STACK">
             STOP STITCHING YOUR STACK
           </h2>
           <p class="section-sub reveal">
-            LLM providers. Backend frameworks. Observability. Billing glue. Every team rebuilds
-            the same plumbing before their first agent ships. AstralBeam cuts through all
-            of it: a single open-source service, production-ready on day one.
+            LLM gateways. Agent frameworks. Observability. Billing. Every team rebuilds the same
+            seven pieces before their first agent ships. AstralBeam replaces all of them with a
+            single open-source service.
           </p>
         </div>
 
         <div class="compare-grid">
           <figure class="panel compare-panel reveal">
             <figcaption class="panel-label mono"><span class="x-mark">✕</span> WITHOUT ASTRALBEAM</figcaption>
-            <svg class="compare-art" viewBox="0 0 400 220" aria-hidden="true">
-              <g class="tangle" fill="none" stroke-dasharray="5 6">
-                <path d="M60 60 C 140 20, 180 130, 260 66"></path>
-                <path d="M60 60 C 90 160, 220 40, 210 150"></path>
-                <path d="M210 150 C 260 190, 300 90, 340 140"></path>
-                <path d="M260 66 C 230 120, 320 170, 340 140"></path>
-                <path d="M60 160 C 150 200, 200 90, 340 60"></path>
-                <path d="M60 160 C 110 110, 160 190, 210 150"></path>
-              </g>
-              <g class="node-set">
-                <g transform="translate(60,60)"><rect x="-34" y="-13" width="68" height="26"></rect><text y="4">LLM API</text></g>
-                <g transform="translate(260,66)"><rect x="-38" y="-13" width="76" height="26"></rect><text y="4">FRAMEWORK</text></g>
-                <g transform="translate(60,160)"><rect x="-34" y="-13" width="68" height="26"></rect><text y="4">TRACING</text></g>
-                <g transform="translate(210,150)"><rect x="-34" y="-13" width="68" height="26"></rect><text y="4">BILLING</text></g>
-                <g transform="translate(340,60)"><rect x="-26" y="-13" width="52" height="26"></rect><text y="4">AUTH</text></g>
-                <g transform="translate(340,140)"><rect x="-28" y="-13" width="56" height="26"></rect><text y="4">EVALS</text></g>
-              </g>
-            </svg>
-            <p class="compare-note">Multiple services, months of integration, all before a single agent ships.</p>
+            <div class="compare-body">
+              <svg class="tangle-art" viewBox="0 0 400 260" preserveAspectRatio="none" aria-hidden="true">
+                <g class="tangle" fill="none" stroke-dasharray="5 6">
+                  <path d="M40 30 C 180 10, 120 150, 330 60"></path>
+                  <path d="M40 30 C 90 180, 300 60, 250 240"></path>
+                  <path d="M40 130 C 200 230, 220 40, 360 150"></path>
+                  <path d="M60 230 C 140 120, 260 200, 350 90"></path>
+                  <path d="M30 190 C 190 250, 180 90, 370 220"></path>
+                </g>
+              </svg>
+              <ul class="stack-chips mono">
+                {stackPieces.map((piece) => <li>{piece}</li>)}
+              </ul>
+            </div>
+            <p class="compare-note">
+              Multiple vendors, months of integration, all before a single agent ships.
+            </p>
           </figure>
 
           <figure class="panel compare-panel is-beam reveal" style="--reveal-delay:.15s">
             <figcaption class="panel-label mono"><span class="check-mark">✓</span> WITH ASTRALBEAM</figcaption>
-            <svg class="compare-art" viewBox="0 0 400 220" aria-hidden="true">
-              <line class="beam-line" x1="200" y1="10" x2="200" y2="210"></line>
-              <g class="node-set is-aligned">
-                <g transform="translate(200,36)"><rect x="-52" y="-13" width="104" height="26"></rect><text y="4">YOUR APP</text></g>
-                <g transform="translate(200,110)" class="core-node">
-                  <rect x="-64" y="-16" width="128" height="32"></rect><text y="5">ASTRALBEAM</text>
-                </g>
-                <g transform="translate(200,184)"><rect x="-52" y="-13" width="104" height="26"></rect><text y="4">ANY LLM</text></g>
-              </g>
-            </svg>
-            <p class="compare-note">One service. One SDK. Everything between your app and the model, handled.</p>
+            <div class="compare-body is-single">
+              <div class="single-core">
+                <span class="single-beam" aria-hidden="true"></span>
+                <img class="single-logo" src={astralbeamDarkLogoUrl} alt="" width="270" height="270" />
+                <span class="single-name mono">ONE SERVICE</span>
+              </div>
+              <ul class="stack-chips is-included mono">
+                {stackPieces.map((piece) => <li>{piece}</li>)}
+              </ul>
+            </div>
+            <p class="compare-note">
+              One service. One SDK. Everything between your app and the model, handled.
+            </p>
           </figure>
         </div>
       </section>
 
-      <!-- ============ 02 / SYSTEMS ============ -->
-      <section class="section" id="systems" data-sector="03">
+      <!-- ============ FEATURES ============ -->
+      <section class="section" id="features">
         <div class="section-head">
-          <p class="section-tag mono reveal">02 // SYSTEMS ONLINE</p>
           <h2 class="display section-title reveal scramble" data-text="EVERYTHING YOU NEED IN PRODUCTION">
             EVERYTHING YOU NEED IN PRODUCTION
           </h2>
           <p class="section-sub reveal">
-            Stop wiring together six tools. Every system below ships in the box, you focus on the
-            experience, AstralBeam handles the rest.
+            A drop-in agent sidebar, a managed streaming backend, tools and MCP, metered billing,
+            enterprise auth, and live evals. Every feature below ships in the box.
           </p>
         </div>
 
-        <div class="systems-grid">
+        <div class="features-grid">
           {
-            systems.map((sys, i) => (
-              <article class="panel sys-panel reveal" style={`--reveal-delay:${(i % 3) * 0.12}s`}>
-                <header class="sys-head mono">
-                  <span class="sys-id">SYS.{sys.id}</span>
-                  <span class="sys-status"><i class="blink-dot"></i>ONLINE</span>
+            features.map((feature, i) => (
+              <article class="panel feature-panel reveal" style={`--reveal-delay:${(i % 3) * 0.12}s`}>
+                <header class="feature-head mono">
+                  <span class="feature-id">FEATURE {feature.id}</span>
                 </header>
-                <div class={`sys-icon icon-${sys.icon}`} aria-hidden="true">
-                  {sys.icon === "panel" && (
+                <div class={`feature-icon icon-${feature.icon}`} aria-hidden="true">
+                  {feature.icon === "panel" && (
                     <svg viewBox="0 0 32 32"><rect x="3" y="5" width="26" height="22" rx="1"></rect><line x1="19" y1="5" x2="19" y2="27"></line><line x1="22" y1="10" x2="26" y2="10"></line><line x1="22" y1="14" x2="26" y2="14"></line></svg>
                   )}
-                  {sys.icon === "server" && (
+                  {feature.icon === "server" && (
                     <svg viewBox="0 0 32 32"><rect x="4" y="4" width="24" height="10" rx="1"></rect><rect x="4" y="18" width="24" height="10" rx="1"></rect><circle cx="9" cy="9" r="1.5" class="fill"></circle><circle cx="9" cy="23" r="1.5" class="fill"></circle></svg>
                   )}
-                  {sys.icon === "plug" && (
+                  {feature.icon === "plug" && (
                     <svg viewBox="0 0 32 32"><path d="M11 4v7M21 4v7"></path><path d="M7 11h18l-2 8a7 7 0 0 1-14 0z"></path><path d="M16 22v6"></path></svg>
                   )}
-                  {sys.icon === "meter" && (
+                  {feature.icon === "meter" && (
                     <svg viewBox="0 0 32 32"><path d="M4 24a12 12 0 0 1 24 0"></path><line x1="16" y1="24" x2="23" y2="13"></line><circle cx="16" cy="24" r="2" class="fill"></circle></svg>
                   )}
-                  {sys.icon === "shield" && (
+                  {feature.icon === "shield" && (
                     <svg viewBox="0 0 32 32"><path d="M16 3l11 4v9c0 7-5 11-11 13C10 27 5 23 5 16V7z"></path><path d="M11 16l4 4 6-7"></path></svg>
                   )}
-                  {sys.icon === "flask" && (
+                  {feature.icon === "flask" && (
                     <svg viewBox="0 0 32 32"><path d="M13 4v8L5 26a2 2 0 0 0 2 3h18a2 2 0 0 0 2-3l-8-14V4"></path><line x1="10" y1="4" x2="22" y2="4"></line><line x1="9" y1="21" x2="23" y2="21"></line></svg>
                   )}
                 </div>
-                <h3 class="sys-name">{sys.name}</h3>
-                <p class="sys-desc">{sys.desc}</p>
+                <h3 class="feature-name">{feature.name}</h3>
+                <p class="feature-desc">{feature.desc}</p>
                 <i class="panel-corner" aria-hidden="true"></i>
               </article>
             ))
           }
         </div>
-
-        <div class="aux-row reveal">
-          <span class="aux-label mono">AUX. SYSTEMS //</span>
-          <ul class="aux-chips mono">
-            {auxSystems.map((f) => <li>{f}</li>)}
-          </ul>
-        </div>
       </section>
 
-      <!-- ============ 03 / DEPLOY SEQUENCE ============ -->
-      <section class="section" id="deploy" data-sector="04">
+      <!-- ============ QUICKSTART ============ -->
+      <section class="section" id="quickstart">
         <div class="section-head">
-          <p class="section-tag mono reveal">03 // DEPLOY SEQUENCE</p>
-          <h2 class="display section-title reveal scramble" data-text="T-MINUS FIVE MINUTES">
-            T-MINUS FIVE MINUTES
+          <h2 class="display section-title reveal scramble" data-text="LIFT OFF IN FIVE MINUTES">
+            LIFT OFF IN FIVE MINUTES
           </h2>
           <p class="section-sub reveal">
-            Install the SDK, mount the sidebar, ship. Every subsystem comes online with it,
-            no backend to stand up, no pipeline to build.
+            One package, one component. Point it at your tools and the agent starts working on
+            real data in your own UI.
           </p>
         </div>
 
-        <div class="deploy-grid">
+        <div class="quickstart-grid">
           <div class="panel terminal reveal" id="terminal">
             <header class="terminal-bar mono">
               <span class="term-dots"><i></i><i></i><i></i></span>
-              <span>app.tsx - astralbeam deploy console</span>
+              <span>app.tsx</span>
             </header>
             <pre class="terminal-body mono" aria-label="Example: install and mount the AstralBeam sidebar"><code
-><span class="t-line" data-type="cmd"><span class="t-prompt">$</span> pnpm add @astralbeam/react</span>
-<span class="t-line" data-type="out">+ @astralbeam/react 1.0.0 - installed in 2.4s</span>
+><span class="t-line" data-type="cmd"><span class="t-prompt">$</span> npm i @astralbeam/react</span>
+<span class="t-line" data-type="out">+ @astralbeam/react 1.0.0</span>
 <span class="t-line"> </span>
 <span class="t-line"><span class="t-kw">import</span> {"{"} AgentSidebar {"}"} <span class="t-kw">from</span> <span class="t-str">"@astralbeam/react"</span></span>
 <span class="t-line"> </span>
@@ -271,35 +257,49 @@ const bootChecks = [
 <span class="t-line">  <span class="t-kw">return</span> (</span>
 <span class="t-line">    &lt;&gt;</span>
 <span class="t-line">      &lt;<span class="t-tag">YourApp</span> /&gt;</span>
-<span class="t-line">      &lt;<span class="t-tag">AgentSidebar</span> <span class="t-attr">agent</span>=<span class="t-str">"copilot"</span></span>
-<span class="t-line">        <span class="t-attr">tools</span>={"{"}[searchDocs, createTicket]{"}"} /&gt;</span>
+<span class="t-line">      &lt;<span class="t-tag">AgentSidebar</span> <span class="t-attr">agent</span>=<span class="t-str">"support"</span></span>
+<span class="t-line">        <span class="t-attr">tools</span>={"{"}[lookupOrder, refund]{"}"} /&gt;</span>
 <span class="t-line">    &lt;/&gt;</span>
 <span class="t-line">  )</span>
-<span class="t-line">{"}"}</span>
-<span class="t-line"> </span>
-<span class="t-line" data-type="ok">▲ ALL SYSTEMS GO - agents are live.</span></code><span class="t-caret" aria-hidden="true"></span></pre>
+<span class="t-line">{"}"}</span></code><span class="t-caret" aria-hidden="true"></span></pre>
           </div>
 
-          <aside class="panel boot-panel reveal" style="--reveal-delay:.15s" id="bootlist">
-            <header class="panel-label mono">SUBSYSTEM BOOT LOG</header>
-            <ul class="boot-list mono">
-              {
-                bootChecks.map(([k]) => (
-                  <li class="boot-item">
-                    <span class="boot-name">{k}</span>
-                    <span class="boot-track" aria-hidden="true" />
-                    <span class="boot-state">ONLINE</span>
+          <aside class="panel agent-panel reveal" style="--reveal-delay:.15s" id="agent-demo">
+            <header class="agent-bar mono">
+              <span class="agent-title">SUPPORT AGENT</span>
+              <span class="agent-model">STREAMING</span>
+            </header>
+            <div class="agent-thread">
+              <article class="agent-msg is-user" data-step>
+                <p>Refund order 4821 and let the customer know.</p>
+              </article>
+              <article class="agent-msg is-agent" data-step>
+                <ul class="agent-tools mono">
+                  <li class="agent-tool" data-tool>
+                    <i class="tool-dot" aria-hidden="true"></i><span class="tool-name">lookupOrder</span><b>4821</b>
                   </li>
-                ))
-              }
-            </ul>
-            <p class="boot-foot mono"><i class="blink-dot"></i>READY FOR LAUNCH</p>
+                  <li class="agent-tool" data-tool>
+                    <i class="tool-dot" aria-hidden="true"></i><span class="tool-name">refund</span><b>$128.00</b>
+                  </li>
+                  <li class="agent-tool" data-tool>
+                    <i class="tool-dot" aria-hidden="true"></i><span class="tool-name">sendEmail</span><b>receipt</b>
+                  </li>
+                </ul>
+                <p class="agent-stream" data-stream>
+                  Refunded $128.00 on order 4821 and emailed the customer a confirmation. Want me to close the ticket too?
+                </p>
+              </article>
+            </div>
+            <div class="agent-composer" aria-hidden="true">
+              <span class="agent-placeholder">Ask the agent…</span>
+              <span class="agent-send">↑</span>
+            </div>
           </aside>
         </div>
       </section>
 
-      <!-- ============ 04 / OPEN SOURCE ============ -->
-      <section class="section" id="open-source" data-sector="05">
+      <!-- ============ OPEN SOURCE ============ -->
+      <section class="section" id="open-source">
         <svg class="os-watermark" viewBox="-84 -62 168 124" aria-hidden="true">
           <g fill="none" stroke="currentColor" stroke-width="1.5">
             <path d="M -6.56 -18.02 A 30 34 0 1 0 -6.56 18.02"></path>
@@ -312,13 +312,12 @@ const bootChecks = [
         </svg>
 
         <div class="section-head">
-          <p class="section-tag mono reveal">04 // SOURCE CODE</p>
           <h2 class="display section-title reveal scramble" data-text="YOURS TO RUN. YOURS TO EXTEND.">
             YOURS TO RUN. YOURS TO EXTEND.
           </h2>
           <p class="section-sub reveal">
-            The entire platform is open source under AGPL-3.0. Modular and built on open
-            standards, so you can adopt it incrementally alongside the stack you already have.
+            Every line of AstralBeam is open source under AGPL-3.0, built on open standards, and
+            modular by design. Read it, fork it, run it, extend it.
           </p>
         </div>
 
@@ -332,27 +331,37 @@ const bootChecks = [
             <p>Let us run it for you: managed infrastructure, zero maintenance, always current.</p>
           </div>
           <div class="panel os-panel reveal" style="--reveal-delay:.2s">
-            <h3 class="os-name mono">INCREMENTAL</h3>
-            <p>Modular by design. Adopt one piece at a time, not all at once.</p>
+            <h3 class="os-name mono">MODULAR</h3>
+            <p>Start with the entire platform, or adopt it incrementally, piece by piece.</p>
           </div>
           <div class="panel os-panel reveal" style="--reveal-delay:.3s">
             <h3 class="os-name mono">OPEN STANDARDS</h3>
-            <p>MCP and open protocols throughout. Compatible with the stack you already run.</p>
+            <p>Built on protocols you can swap in and out, not a proprietary runtime.</p>
+            <ul class="os-standards mono">
+              {openStandards.map((standard) => <li>{standard}</li>)}
+            </ul>
           </div>
+        </div>
+
+        <div class="os-repo reveal" style="--reveal-delay:.35s">
+          <a class="btn btn-ghost btn-lg" href={githubUrl} target="_blank" rel="noopener noreferrer">
+            <svg class="icon-github" viewBox="0 0 16 16" aria-hidden="true"><path d="M8 0a8 8 0 0 0-2.53 15.59c.4.07.55-.17.55-.38l-.01-1.34c-2.23.48-2.7-1.07-2.7-1.07-.36-.93-.89-1.18-.89-1.18-.73-.5.05-.49.05-.49.8.06 1.23.83 1.23.83.72 1.23 1.88.87 2.34.67.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.28.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48l-.01 2.2c0 .21.14.46.55.38A8 8 0 0 0 8 0z"></path></svg>
+            BROWSE THE SOURCE
+          </a>
+          <span class="os-repo-path mono">github.com/astralbeamai/astralbeam</span>
         </div>
       </section>
 
-      <!-- ============ 05 / LAUNCH ============ -->
+      <!-- ============ LAUNCH ============ -->
       <section class="section launch" id="launch">
         <div class="launch-beam" aria-hidden="true"></div>
-        <p class="section-tag mono reveal">05 // FINAL CHECK</p>
         <h2 class="display launch-title reveal scramble" data-text="READY FOR LAUNCH">READY FOR LAUNCH</h2>
         <p class="section-sub launch-sub reveal">
           Get started with a few lines of code. Join the waitlist for early access.
         </p>
         <div class="reveal" style="--reveal-delay:.2s">
           <a class="btn btn-primary btn-xl" href={waitlistUrl} target="_blank" rel="noopener noreferrer">
-            JOIN THE WAITLIST
+            JOIN WAITLIST
           </a>
         </div>
       </section>
@@ -360,11 +369,11 @@ const bootChecks = [
 
     <footer class="site-footer mono">
       <span>© 2026 ASTRALBEAM</span>
+      <a href={githubUrl} target="_blank" rel="noopener noreferrer">GITHUB</a>
       <a href="mailto:hello@astralbeam.ai">HELLO@ASTRALBEAM.AI</a>
       <a href="/terms">TERMS</a>
       <a href="/privacy">PRIVACY</a>
       <a href="/licenses.txt">LICENSES</a>
-      <span class="footer-status"><i class="blink-dot"></i>ALL SYSTEMS NOMINAL</span>
     </footer>
 
   <script src="../scripts/main.ts"></script>

--- a/www/src/pages/llms.txt.ts
+++ b/www/src/pages/llms.txt.ts
@@ -10,28 +10,30 @@ export const GET: APIRoute = ({ site }) => {
   return new Response(
     `# AstralBeam
 
-> AstralBeam is open-source infrastructure for shipping agents in minutes, not months.
+> AstralBeam is open source AI agent infrastructure for shipping agents in minutes, not months.
 
-AstralBeam gives application teams one service for adding production-ready agents instead of assembling separate frontend, backend, model, observability, billing, authentication, and evaluation systems.
+Drop in the AstralBeam frontend SDK, and AstralBeam handles agentic chat, streaming, history, tools, metering, billing, and auth. Application teams get one service instead of stitching together an LLM gateway, an agent framework, observability, tools and MCP plumbing, billing, authentication, and evaluations.
 
-## Product Focus
+## Features
 
-- Drop-in frontend SDK for a customizable, Cursor-like agent sidebar
-- Managed resumable chat streaming, conversation history, observability, analytics, and audit logs
-- Tools, skills, app actions, user-provided MCP support, guardrails, and evaluation hooks
-- Organization-aware authentication, permissions, context, flexible rate limits, and token-based billing
-- Enterprise SSO, data privacy, access control, prompt management, A/B testing, and production evaluations
-- Multiplayer chat, background agents, dynamic model routing, prompt caching, and token optimization
+- Frontend SDK: a fully-customizable, Cursor-like agent sidebar that drops into any web app
+- Managed backend: resumable chat streaming, conversation history, and observability, with nothing to run
+- Tools, skills, and MCP: app actions, user-provided MCP servers, and real actions inside your product
+- Metered billing and rate limits: per-customer rate limits and token-metered billing wired to Stripe
+- Enterprise-ready: organization-aware SSO, data privacy, and access control built in from day one
+- Prompts and evals: prompt editing, A/B tests, and scoring of live conversations from a web UI
 
 ## Deployment
 
 - Self-host the open-source AGPL-3.0 platform on your own infrastructure.
 - Use AstralBeam Cloud for managed infrastructure and maintenance.
-- Adopt the modular platform incrementally through open standards.
+- Start with the entire platform, or adopt it incrementally, piece by piece.
+- Built on open standards: AG-UI, MCP, and OpenResponses.
 
-## Pages
+## Links
 
-- [Home](${homeUrl}): Product overview, capabilities, deployment model, and early-access waitlist.
+- [Home](${homeUrl}): Product overview, features, deployment model, and early-access waitlist.
+- [Source code](https://github.com/astralbeamai/astralbeam): The open-source platform under AGPL-3.0.
 
 ## Contact
 

--- a/www/src/pages/llms.txt.ts
+++ b/www/src/pages/llms.txt.ts
@@ -10,13 +10,13 @@ export const GET: APIRoute = ({ site }) => {
   return new Response(
     `# AstralBeam
 
-> AstralBeam is open source AI agent infrastructure for shipping agents in minutes, not months.
+> AstralBeam is open source AI infrastructure for shipping agents in minutes, not months.
 
 Drop in the AstralBeam frontend SDK, and AstralBeam handles agentic chat, streaming, history, tools, metering, billing, and auth. Application teams get one service instead of stitching together an LLM gateway, an agent framework, observability, tools and MCP plumbing, billing, authentication, and evaluations.
 
 ## Features
 
-- Frontend SDK: a fully-customizable, Cursor-like agent sidebar that drops into any web app
+- Frontend SDK (@astralbeam/sdk): a fully-customizable, Cursor-like agent sidebar with your own UI widgets
 - Managed backend: resumable chat streaming, conversation history, and observability, with nothing to run
 - Tools, skills, and MCP: app actions, user-provided MCP servers, and real actions inside your product
 - Metered billing and rate limits: per-customer rate limits and token-metered billing wired to Stripe
@@ -28,7 +28,7 @@ Drop in the AstralBeam frontend SDK, and AstralBeam handles agentic chat, stream
 - Self-host the open-source AGPL-3.0 platform on your own infrastructure.
 - Use AstralBeam Cloud for managed infrastructure and maintenance.
 - Start with the entire platform, or adopt it incrementally, piece by piece.
-- Built on open standards: AG-UI, MCP, and OpenResponses.
+- Built on open protocols: AG-UI, MCP, and A2A.
 
 ## Links
 

--- a/www/src/pages/og-image.png.ts
+++ b/www/src/pages/og-image.png.ts
@@ -39,7 +39,7 @@ function socialCardSvg() {
     <rect x="38" y="38" width="1124" height="554" rx="8" fill="none" stroke="${palette.dark.border.srgbHex}" stroke-width="2"/>
     <path d="M38 94V38H94M1106 38H1162V94M38 536V592H94M1106 592H1162V536" fill="none" stroke="${palette.dark.primary.srgbHex}" stroke-width="3"/>
     <circle cx="96" cy="94" r="3" fill="${palette.dark.primary.srgbHex}"/>
-    <text x="80" y="112" fill="${palette.dark.primary.srgbHex}" font-family="DejaVu Sans Mono, monospace" font-size="22" font-weight="700" letter-spacing="4">// OPEN-SOURCE AGENT INFRASTRUCTURE</text>
+    <text x="80" y="112" fill="${palette.dark.primary.srgbHex}" font-family="DejaVu Sans Mono, monospace" font-size="22" font-weight="700" letter-spacing="4">OPEN SOURCE AI AGENT INFRASTRUCTURE</text>
     <text x="76" y="272" fill="${palette.dark.foreground.srgbHex}" font-family="DejaVu Sans, Arial, sans-serif" font-size="82" font-weight="700" letter-spacing="2">SHIP AGENTS</text>
     <text x="76" y="370" fill="${palette.dark.foreground.srgbHex}" font-family="DejaVu Sans, Arial, sans-serif" font-size="82" font-weight="700" letter-spacing="2">IN MINUTES</text>
     <text x="76" y="468" fill="${palette.dark.primary.srgbHex}" font-family="DejaVu Sans, Arial, sans-serif" font-size="82" font-weight="700" letter-spacing="2">NOT MONTHS</text>

--- a/www/src/pages/og-image.png.ts
+++ b/www/src/pages/og-image.png.ts
@@ -39,7 +39,7 @@ function socialCardSvg() {
     <rect x="38" y="38" width="1124" height="554" rx="8" fill="none" stroke="${palette.dark.border.srgbHex}" stroke-width="2"/>
     <path d="M38 94V38H94M1106 38H1162V94M38 536V592H94M1106 592H1162V536" fill="none" stroke="${palette.dark.primary.srgbHex}" stroke-width="3"/>
     <circle cx="96" cy="94" r="3" fill="${palette.dark.primary.srgbHex}"/>
-    <text x="80" y="112" fill="${palette.dark.primary.srgbHex}" font-family="DejaVu Sans Mono, monospace" font-size="22" font-weight="700" letter-spacing="4">OPEN SOURCE AI AGENT INFRASTRUCTURE</text>
+    <text x="80" y="112" fill="${palette.dark.primary.srgbHex}" font-family="DejaVu Sans Mono, monospace" font-size="22" font-weight="700" letter-spacing="4">OPEN SOURCE AI INFRASTRUCTURE</text>
     <text x="76" y="272" fill="${palette.dark.foreground.srgbHex}" font-family="DejaVu Sans, Arial, sans-serif" font-size="82" font-weight="700" letter-spacing="2">SHIP AGENTS</text>
     <text x="76" y="370" fill="${palette.dark.foreground.srgbHex}" font-family="DejaVu Sans, Arial, sans-serif" font-size="82" font-weight="700" letter-spacing="2">IN MINUTES</text>
     <text x="76" y="468" fill="${palette.dark.primary.srgbHex}" font-family="DejaVu Sans, Arial, sans-serif" font-size="82" font-weight="700" letter-spacing="2">NOT MONTHS</text>

--- a/www/src/scripts/main.ts
+++ b/www/src/scripts/main.ts
@@ -143,7 +143,7 @@ const SCRAMBLE_CHARS = "▓▒░<>/\\|=+*ASTRLBEM0123456789"
 
 function scramble(el: HTMLElement) {
   const finalText = el.dataset.text ?? el.textContent ?? ""
-  const duration = 620
+  const duration = 260
   const start = performance.now()
 
   function frame(now: number) {
@@ -213,8 +213,6 @@ function initTerminal() {
       let delay = 300
       for (const line of lines) {
         const isCmd = line.dataset.type === "cmd"
-        const isOk = line.dataset.type === "ok"
-        if (isOk) delay += 500
         setTimeout(() => line.classList.add("typed"), delay)
         delay += isCmd ? 650 : 120
       }
@@ -225,80 +223,73 @@ function initTerminal() {
   io.observe(terminal)
 }
 
-/* ============ boot log ============ */
+/* ============ agent sidebar prototype ============ */
 
-function initBootLog() {
-  const panel = document.getElementById("bootlist")
+/* Hardcoded stand-in for the shipped sidebar: replay one turn (user message,
+   tool calls, streamed answer) the first time the panel scrolls into view. */
+function initAgentDemo() {
+  const panel = document.getElementById("agent-demo")
   if (!panel) return
-  const items = Array.from(panel.querySelectorAll<HTMLElement>(".boot-item"))
+  const steps = Array.from(panel.querySelectorAll<HTMLElement>("[data-step]"))
+  const tools = Array.from(panel.querySelectorAll<HTMLElement>("[data-tool]"))
+  const stream = panel.querySelector<HTMLElement>("[data-stream]")
+  const answer = stream?.textContent?.trim() ?? ""
+
+  if (stream) stream.textContent = answer
 
   if (reducedMotion) {
-    items.forEach((i) => i.classList.add("online"))
-    panel.classList.add("booted")
+    steps.forEach((step) => step.classList.add("shown"))
+    tools.forEach((tool) => tool.classList.add("running", "done"))
     return
+  }
+
+  if (stream) stream.textContent = ""
+
+  function streamAnswer() {
+    if (!stream) return
+    // Rebind after the guard: the hoisted frame callback doesn't see narrowing.
+    const target = stream
+    target.classList.add("streaming")
+    // Reveal a few characters per frame so the answer lands in about a second,
+    // matching the cadence of a real token stream.
+    let shown = 0
+    function frame() {
+      shown = Math.min(answer.length, shown + 2)
+      target.textContent = answer.slice(0, shown)
+      if (shown < answer.length) {
+        requestAnimationFrame(frame)
+      } else {
+        setTimeout(() => target.classList.remove("streaming"), 1200)
+      }
+    }
+    requestAnimationFrame(frame)
   }
 
   const io = new IntersectionObserver(
     (entries) => {
       if (!entries.some((e) => e.isIntersecting)) return
       io.disconnect()
-      items.forEach((item, i) => {
-        setTimeout(() => item.classList.add("online"), 350 + i * 260)
+
+      let delay = 250
+      steps.forEach((step) => {
+        setTimeout(() => step.classList.add("shown"), delay)
+        delay += 500
       })
-      setTimeout(() => panel.classList.add("booted"), 350 + items.length * 260)
+      tools.forEach((tool) => {
+        setTimeout(() => tool.classList.add("running"), delay)
+        delay += 450
+        setTimeout(() => tool.classList.add("done"), delay)
+        delay += 120
+      })
+      setTimeout(streamAnswer, delay + 200)
     },
-    { threshold: 0.4 },
+    { threshold: 0.35 },
   )
 
   io.observe(panel)
 }
 
-/* ============ HUD readouts ============ */
-
-function initHud() {
-  const scrollEl = document.getElementById("hud-scroll")
-  const sectorEl = document.getElementById("hud-sector")
-  if (!scrollEl || !sectorEl) return
-
-  const sectors: Array<[string, HTMLElement | null]> = [
-    ["01", document.getElementById("top")],
-    ["02", document.getElementById("transmission")],
-    ["03", document.getElementById("systems")],
-    ["04", document.getElementById("deploy")],
-    ["05", document.getElementById("open-source")],
-  ]
-
-  let ticking = false
-
-  function update() {
-    ticking = false
-    const max = document.documentElement.scrollHeight - window.innerHeight
-    const pct = max > 0 ? Math.round((window.scrollY / max) * 100) : 0
-    scrollEl!.textContent = String(pct).padStart(3, "0")
-
-    const probe = window.scrollY + window.innerHeight * 0.45
-    let current = "01"
-    for (const [id, el] of sectors) {
-      if (el && el.offsetTop <= probe) current = id
-    }
-    sectorEl!.textContent = `SECTOR ${current}/05`
-  }
-
-  window.addEventListener(
-    "scroll",
-    () => {
-      if (!ticking) {
-        ticking = true
-        requestAnimationFrame(update)
-      }
-    },
-    { passive: true },
-  )
-  update()
-}
-
 initStarfield()
 initReveals()
 initTerminal()
-initBootLog()
-initHud()
+initAgentDemo()

--- a/www/src/scripts/main.ts
+++ b/www/src/scripts/main.ts
@@ -195,95 +195,318 @@ function initReveals() {
 
 /* ============ terminal typing ============ */
 
+/* Resolves once the snippet has finished typing, so the agent demo beside it can
+   start streaming only after the code it illustrates is on screen. */
 function initTerminal() {
   const terminal = document.getElementById("terminal")
-  if (!terminal) return
+  if (!terminal) return Promise.resolve()
   const lines = Array.from(terminal.querySelectorAll<HTMLElement>(".t-line"))
 
   if (reducedMotion) {
     lines.forEach((l) => l.classList.add("typed"))
-    return
+    return Promise.resolve()
   }
 
-  const io = new IntersectionObserver(
-    (entries) => {
-      if (!entries.some((e) => e.isIntersecting)) return
-      io.disconnect()
+  return new Promise<void>((resolve) => {
+    const io = new IntersectionObserver(
+      (entries) => {
+        if (!entries.some((e) => e.isIntersecting)) return
+        io.disconnect()
 
-      let delay = 300
-      for (const line of lines) {
-        const isCmd = line.dataset.type === "cmd"
-        setTimeout(() => line.classList.add("typed"), delay)
-        delay += isCmd ? 650 : 120
-      }
-    },
-    { threshold: 0.35 },
-  )
+        let delay = 300
+        for (const line of lines) {
+          const isCmd = line.dataset.type === "cmd"
+          setTimeout(() => line.classList.add("typed"), delay)
+          delay += isCmd ? 650 : 120
+        }
+        setTimeout(resolve, delay + 250)
+      },
+      { threshold: 0.35 },
+    )
 
-  io.observe(terminal)
+    io.observe(terminal)
+  })
 }
 
 /* ============ agent sidebar prototype ============ */
 
-/* Hardcoded stand-in for the shipped sidebar: replay one turn (user message,
-   tool calls, streamed answer) the first time the panel scrolls into view. */
-function initAgentDemo() {
+/* Canned replies for anything the visitor types. Hardcoded stand-in until the
+   real sidebar SDK can be embedded here. */
+const DEMO_REPLIES: Array<{ tool?: [string, string]; text: string }> = [
+  { tool: ["lookupOrder", "4830"], text: "Order 4830 shipped this morning. Tracking is already in her inbox." },
+  { tool: ["refund", "$9.00"], text: "Refunded the shipping fee too, since the delay was on us." },
+  { text: "Two similar tickets came in this week. Want me to group them into one thread?" },
+  { tool: ["addNote", "account"], text: "Done. I left a note on the account so the next agent has the context." },
+  { text: "Her plan renews on the 14th. I can pause it if she would rather wait." },
+  { text: "I only see the last four digits of the card, so payment details are out of scope for me." },
+  { tool: ["draftEmail", "reply"], text: "Drafted a reply for you to approve before it goes out." },
+  { text: "Nothing else is outstanding on this account right now." },
+  { tool: ["lookupOrder", "4830"], text: "That one ships from the Ohio warehouse, so delivery lands Thursday." },
+  { tool: ["escalate", "payments"], text: "Escalated to the payments team and linked this conversation for them." },
+]
+
+function initAgentDemo(codeReady: Promise<void>) {
   const panel = document.getElementById("agent-demo")
   if (!panel) return
-  const steps = Array.from(panel.querySelectorAll<HTMLElement>("[data-step]"))
-  const tools = Array.from(panel.querySelectorAll<HTMLElement>("[data-tool]"))
-  const stream = panel.querySelector<HTMLElement>("[data-stream]")
-  const answer = stream?.textContent?.trim() ?? ""
+  const composer = panel.querySelector<HTMLFormElement>("[data-composer]")
+  const input = panel.querySelector<HTMLInputElement>("[data-input]")
+  const replayButton = panel.querySelector<HTMLButtonElement>("[data-replay]")
+  const thread = panel.querySelector<HTMLElement>("[data-thread]")
+  if (!thread || !composer || !input) return
+  const feed = thread
 
-  if (stream) stream.textContent = answer
+  // The scripted transcript ships in the HTML so the panel is not empty without
+  // JavaScript. Playback detaches it and mounts one message at a time: leaving
+  // the hidden messages in flow would reserve their height, and scrolling the
+  // thread to the newest message would then start below the visible ones.
+  const scripted = Array.from(feed.children).filter(
+    (child): child is HTMLElement => child instanceof HTMLElement,
+  )
+  const answers = new Map<HTMLElement, string>()
+  for (const stream of feed.querySelectorAll<HTMLElement>("[data-stream]")) {
+    answers.set(stream, (stream.textContent ?? "").trim().replace(/\s+/gu, " "))
+  }
+
+  // Bumped by a replay or a visitor message so an in-flight intro can tell that
+  // it has been superseded. Visitor replies are never cancelled.
+  let intro = 0
+  const always = () => true
+
+  // Pauses in ms. The intro should read like a conversation happening in real
+  // time rather than a transcript being dumped into the panel.
+  const PACE = {
+    open: 450,
+    beforeUser: 1250,
+    beforeAgent: 750,
+    afterMessage: 650,
+    tool: 520,
+    betweenTools: 240,
+    widget: 400,
+    visitorReply: 900,
+  }
+
+  function wait(ms: number) {
+    return new Promise<void>((resolve) => setTimeout(resolve, ms))
+  }
+
+  function nextFrame() {
+    return new Promise<void>((resolve) => {
+      requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
+    })
+  }
+
+  function scrollToEnd() {
+    feed.scrollTop = feed.scrollHeight
+  }
+
+  function clear(message: HTMLElement) {
+    message.classList.remove("shown")
+    message.querySelectorAll(".agent-tool").forEach((tool) => {
+      tool.classList.remove("running", "done")
+    })
+    message.querySelectorAll(".agent-widget").forEach((widget) => widget.classList.remove("shown"))
+    message.querySelectorAll<HTMLElement>("[data-stream]").forEach((stream) => {
+      stream.classList.remove("streaming")
+      stream.textContent = ""
+    })
+  }
+
+  function finish(message: HTMLElement) {
+    message.classList.add("shown")
+    message.querySelectorAll(".agent-tool").forEach((tool) => tool.classList.add("running", "done"))
+    message.querySelectorAll(".agent-widget").forEach((widget) => widget.classList.add("shown"))
+    message.querySelectorAll<HTMLElement>("[data-stream]").forEach((stream) => {
+      stream.classList.remove("streaming")
+      stream.textContent = answers.get(stream) ?? ""
+    })
+  }
+
+  function reset() {
+    feed.replaceChildren()
+    scripted.forEach(clear)
+    feed.scrollTop = 0
+  }
+
+  /* Jump the intro to its end without touching anything the visitor has sent. */
+  function completeScripted() {
+    for (const message of scripted) {
+      if (!message.isConnected) feed.append(message)
+      finish(message)
+    }
+    scrollToEnd()
+  }
+
+  async function mount(message: HTMLElement) {
+    feed.append(message)
+    scrollToEnd()
+    // One frame with the message in flow at opacity 0, so the reveal transitions.
+    await nextFrame()
+    message.classList.add("shown")
+    scrollToEnd()
+  }
+
+  function streamText(stream: HTMLElement, text: string, alive: () => boolean) {
+    return new Promise<void>((resolve) => {
+      stream.classList.add("streaming")
+      let shown = 0
+      function frame() {
+        if (!alive()) return resolve()
+        // A few characters per frame reads like a real token stream.
+        shown = Math.min(text.length, shown + 2)
+        stream.textContent = text.slice(0, shown)
+        scrollToEnd()
+        if (shown < text.length) {
+          requestAnimationFrame(frame)
+        } else {
+          setTimeout(() => stream.classList.remove("streaming"), 900)
+          resolve()
+        }
+      }
+      requestAnimationFrame(frame)
+    })
+  }
+
+  async function playMessage(message: HTMLElement, alive: () => boolean) {
+    await mount(message)
+    if (!alive()) return
+
+    for (const tool of message.querySelectorAll<HTMLElement>("[data-tool]")) {
+      tool.classList.add("running")
+      scrollToEnd()
+      await wait(PACE.tool)
+      if (!alive()) return
+      tool.classList.add("done")
+      await wait(PACE.betweenTools)
+      if (!alive()) return
+    }
+
+    const widget = message.querySelector<HTMLElement>("[data-widget]")
+    if (widget) {
+      widget.classList.add("shown")
+      scrollToEnd()
+      await wait(PACE.widget)
+      if (!alive()) return
+    }
+
+    const stream = message.querySelector<HTMLElement>("[data-stream]")
+    if (stream) await streamText(stream, answers.get(stream) ?? "", alive)
+  }
+
+  async function play() {
+    const id = ++intro
+    const alive = () => id === intro
+    reset()
+    for (const [index, message] of scripted.entries()) {
+      const isUser = message.classList.contains("is-user")
+      await wait(index === 0 ? PACE.open : isUser ? PACE.beforeUser : PACE.beforeAgent)
+      if (!alive()) return
+      await playMessage(message, alive)
+      if (!alive()) return
+      await wait(PACE.afterMessage)
+      if (!alive()) return
+    }
+  }
+
+  function createUserMessage(text: string) {
+    const message = document.createElement("article")
+    message.className = "agent-msg is-user"
+    const body = document.createElement("p")
+    body.textContent = text
+    message.append(body)
+    return message
+  }
+
+  function createAgentMessage(reply: (typeof DEMO_REPLIES)[number]) {
+    const message = document.createElement("article")
+    message.className = "agent-msg is-agent"
+
+    if (reply.tool) {
+      const [name, argument] = reply.tool
+      const tools = document.createElement("ul")
+      tools.className = "agent-tools mono"
+      const item = document.createElement("li")
+      item.className = "agent-tool"
+      item.dataset.tool = ""
+      const dot = document.createElement("i")
+      dot.className = "tool-dot"
+      dot.setAttribute("aria-hidden", "true")
+      const toolName = document.createElement("span")
+      toolName.className = "tool-name"
+      toolName.textContent = name
+      const detail = document.createElement("b")
+      detail.textContent = argument
+      item.append(dot, toolName, detail)
+      tools.append(item)
+      message.append(tools)
+    }
+
+    const stream = document.createElement("p")
+    stream.className = "agent-stream"
+    stream.dataset.stream = ""
+    message.append(stream)
+    answers.set(stream, reply.text)
+    return message
+  }
+
+  composer.addEventListener("submit", (event) => {
+    event.preventDefault()
+    const text = input.value.trim()
+    if (!text) return
+    input.value = ""
+
+    // Supersede the intro and land it at its end, so the transcript above the
+    // visitor's message is never left half-revealed.
+    intro += 1
+    completeScripted()
+
+    const reply = DEMO_REPLIES[Math.floor(Math.random() * DEMO_REPLIES.length)]
+    if (!reply) return
+    const userMessage = createUserMessage(text)
+    const agentMessage = createAgentMessage(reply)
+
+    if (reducedMotion) {
+      feed.append(userMessage, agentMessage)
+      finish(userMessage)
+      finish(agentMessage)
+      scrollToEnd()
+      return
+    }
+
+    void (async () => {
+      await mount(userMessage)
+      await wait(PACE.visitorReply)
+      await playMessage(agentMessage, always)
+    })()
+  })
+
+  replayButton?.addEventListener("click", () => {
+    input.value = ""
+    if (reducedMotion) {
+      intro += 1
+      reset()
+      completeScripted()
+      return
+    }
+    void play()
+  })
 
   if (reducedMotion) {
-    steps.forEach((step) => step.classList.add("shown"))
-    tools.forEach((tool) => tool.classList.add("running", "done"))
+    completeScripted()
     return
   }
 
-  if (stream) stream.textContent = ""
-
-  function streamAnswer() {
-    if (!stream) return
-    // Rebind after the guard: the hoisted frame callback doesn't see narrowing.
-    const target = stream
-    target.classList.add("streaming")
-    // Reveal a few characters per frame so the answer lands in about a second,
-    // matching the cadence of a real token stream.
-    let shown = 0
-    function frame() {
-      shown = Math.min(answer.length, shown + 2)
-      target.textContent = answer.slice(0, shown)
-      if (shown < answer.length) {
-        requestAnimationFrame(frame)
-      } else {
-        setTimeout(() => target.classList.remove("streaming"), 1200)
-      }
-    }
-    requestAnimationFrame(frame)
-  }
-
+  reset()
   const io = new IntersectionObserver(
     (entries) => {
-      if (!entries.some((e) => e.isIntersecting)) return
+      if (!entries.some((entry) => entry.isIntersecting)) return
       io.disconnect()
-
-      let delay = 250
-      steps.forEach((step) => {
-        setTimeout(() => step.classList.add("shown"), delay)
-        delay += 500
+      void codeReady.then(() => {
+        // A zero here means nothing has interrupted the intro while the snippet
+        // was typing, so it is still safe to start it.
+        if (intro === 0) void play()
       })
-      tools.forEach((tool) => {
-        setTimeout(() => tool.classList.add("running"), delay)
-        delay += 450
-        setTimeout(() => tool.classList.add("done"), delay)
-        delay += 120
-      })
-      setTimeout(streamAnswer, delay + 200)
     },
-    { threshold: 0.35 },
+    { threshold: 0.3 },
   )
 
   io.observe(panel)
@@ -291,5 +514,4 @@ function initAgentDemo() {
 
 initStarfield()
 initReveals()
-initTerminal()
-initAgentDemo()
+initAgentDemo(initTerminal())

--- a/www/src/styles/global.css
+++ b/www/src/styles/global.css
@@ -265,24 +265,16 @@ a[href] {
 /* ---------- buttons ---------- */
 
 .btn {
-  --cut: 10px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   gap: 0.55rem;
+  border: 0;
   font-family: var(--font-mono);
   font-weight: 700;
   letter-spacing: 0.14em;
   white-space: nowrap;
   cursor: pointer;
-  clip-path: polygon(
-    var(--cut) 0,
-    100% 0,
-    100% calc(100% - var(--cut)),
-    calc(100% - var(--cut)) 100%,
-    0 100%,
-    0 var(--cut)
-  );
   transition:
     filter 0.2s,
     transform 0.15s,
@@ -307,12 +299,12 @@ a[href] {
   font-size: 0.74rem;
   color: var(--foreground);
   background: color-mix(in srgb, var(--card) 70%, transparent);
-  box-shadow: inset 0 0 0 1px var(--input);
+  border: 1px solid var(--input);
 }
 
 .btn-ghost:hover {
   color: var(--primary);
-  box-shadow: inset 0 0 0 1px var(--beam-soft);
+  border-color: var(--beam-soft);
   transform: translateY(-1px);
 }
 
@@ -451,34 +443,40 @@ main {
   gap: 1rem;
 }
 
-.hero-alt {
-  margin-top: 1.4rem;
-  font-size: 0.72rem;
-  letter-spacing: 0.2em;
-  color: var(--text-chrome);
-}
-
+/* The hero grows past 100svh on short viewports, so anchor the cue to the fold
+   itself rather than to the bottom of the section: the hero starts at the top of
+   the document, so this always lands just inside the first screen. */
 .scroll-cue {
   position: absolute;
-  bottom: 2.5rem;
+  top: calc(100svh - 3.75rem);
   left: 50%;
   transform: translateX(-50%);
   display: flex;
-  flex-direction: column;
   align-items: center;
-  gap: 0.55rem;
-  font-size: 0.66rem;
-  letter-spacing: 0.3em;
-  color: var(--text-chrome);
+  justify-content: center;
+  padding: 0.75rem 1.1rem;
 }
 
 .scroll-chevron {
-  width: 10px;
-  height: 10px;
-  border-right: 1px solid var(--primary);
-  border-bottom: 1px solid var(--primary);
+  width: 14px;
+  height: 14px;
+  border-right: 2px solid var(--primary);
+  border-bottom: 2px solid var(--primary);
+  filter: drop-shadow(0 0 8px var(--beam-soft));
   transform: rotate(45deg);
   animation: cue-drop 1.8s ease-in-out infinite;
+}
+
+/* Only the glow changes on hover: the cue-drop keyframes own `transform`, and an
+   animated property beats a normal declaration in the cascade. */
+.scroll-cue:hover .scroll-chevron {
+  border-color: var(--primary);
+  filter: drop-shadow(0 0 14px var(--primary));
+}
+
+.scroll-cue:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: 2px;
 }
 
 @keyframes cue-drop {
@@ -581,6 +579,10 @@ main {
   padding: 1.6rem 1.8rem 1.5rem;
 }
 
+.compare-panel .compare-note {
+  margin-top: auto;
+}
+
 .compare-panel.is-beam {
   background: color-mix(in srgb, var(--primary) 40%, transparent);
 }
@@ -600,112 +602,129 @@ main {
   color: var(--primary);
 }
 
-.compare-body {
-  position: relative;
-  flex: 1;
-  display: flex;
-  align-items: center;
-  margin: 1.5rem 0 0.4rem;
-  min-height: 15rem;
+.compare-art {
+  width: 100%;
+  height: auto;
+  margin: 1.4rem 0 0.9rem;
 }
 
-.compare-body.is-single {
-  flex-direction: column;
-  justify-content: center;
-  gap: 1.6rem;
+/* ---------- chaos side ---------- */
+
+.compare-art.is-chaos {
+  color: var(--destructive);
 }
 
-.tangle-art {
-  position: absolute;
-  inset: -0.4rem -0.6rem;
-  width: calc(100% + 1.2rem);
-  height: calc(100% + 0.8rem);
-  pointer-events: none;
+.compare-art .tangle path {
+  stroke: color-mix(in srgb, var(--destructive) 88%, transparent);
+  stroke-width: 1.5;
+  filter: drop-shadow(0 0 5px color-mix(in srgb, var(--destructive) 60%, transparent));
+  animation: tangle-drift 5s linear infinite;
 }
 
-.tangle-art .tangle path {
-  stroke: var(--danger-soft);
-  animation: tangle-drift 14s linear infinite;
+/* Mixed colors, speeds, and directions so no two wires read as one system. */
+.compare-art .tangle path:nth-child(2n) {
+  stroke: color-mix(in srgb, var(--chart-4) 80%, transparent);
+  filter: drop-shadow(0 0 5px color-mix(in srgb, var(--chart-4) 45%, transparent));
+  animation-duration: 3.4s;
+  animation-direction: reverse;
+}
+
+.compare-art .tangle path:nth-child(3n) {
+  stroke: color-mix(in srgb, var(--destructive) 65%, transparent);
+  animation-duration: 7.5s;
+}
+
+.compare-art .tangle path:nth-child(4n) {
+  stroke-width: 2;
+  animation-duration: 2.6s;
 }
 
 @keyframes tangle-drift {
   to {
-    stroke-dashoffset: -110;
+    stroke-dashoffset: -130;
   }
 }
 
-.stack-chips {
-  position: relative;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-  list-style: none;
+.node-set rect {
+  fill: var(--card);
+  stroke: var(--input);
 }
 
-.stack-chips li {
-  font-size: 0.74rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--text-muted);
-  background: color-mix(in srgb, var(--card) 92%, transparent);
-  border: 1px solid var(--input);
-  padding: 0.42rem 0.7rem;
+.node-set text {
+  fill: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-anchor: middle;
 }
 
-.stack-chips li::before {
-  content: "✕";
-  color: var(--destructive);
-  margin-right: 0.45rem;
-  font-size: 0.8em;
+.node-set.is-tangled rect {
+  fill: color-mix(in oklab, var(--card) 88%, var(--destructive));
+  stroke: color-mix(in srgb, var(--destructive) 70%, transparent);
+  stroke-width: 1.2;
 }
 
-.stack-chips.is-included li {
-  color: var(--foreground);
-  border-color: color-mix(in srgb, var(--primary) 45%, transparent);
-  background: color-mix(in srgb, var(--primary) 10%, transparent);
+.node-set.is-tangled text {
+  fill: var(--foreground);
+  font-weight: 700;
 }
 
-.stack-chips.is-included li::before {
-  content: "✓";
-  color: var(--primary);
+/* The positioning transform lives on the wrapper `g`, so the jitter animates an
+   inner group whose local origin is already the box center. transform-origin
+   must be pinned to that origin: the default 50% 50% resolves against the
+   viewBox, which would swing each node around the canvas center instead.
+   https://drafts.csswg.org/css-transforms-2/#transform-box */
+.node-set.is-tangled .node {
+  transform-box: view-box;
+  transform-origin: 0 0;
+  animation: node-jitter 2.9s ease-in-out infinite;
+  animation-delay: var(--jitter-delay, 0s);
 }
 
-.single-core {
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.8rem 0 0.2rem;
+@keyframes node-jitter {
+  0%,
+  100% {
+    transform: translate(0, 0) rotate(0deg);
+  }
+  25% {
+    transform: translate(1.5px, -1px) rotate(-1.1deg);
+  }
+  50% {
+    transform: translate(-1px, 1.5px) rotate(0.9deg);
+  }
+  75% {
+    transform: translate(1px, 1px) rotate(-0.5deg);
+  }
 }
 
-.single-beam {
-  position: absolute;
-  top: -1.6rem;
-  bottom: -1.6rem;
-  left: 50%;
-  width: 1px;
-  transform: translateX(-50%);
-  background: linear-gradient(
-    to bottom,
-    transparent,
-    color-mix(in srgb, var(--primary) 55%, transparent),
-    transparent
-  );
+/* ---------- beam side ---------- */
+
+.node-set.is-aligned rect {
+  fill: var(--card);
+  stroke: color-mix(in srgb, var(--primary) 45%, transparent);
 }
 
-.single-logo {
-  position: relative;
-  width: clamp(5rem, 12vw, 7rem);
-  height: auto;
-  filter: drop-shadow(0 0 18px color-mix(in srgb, var(--primary) 28%, transparent));
+.core-node rect {
+  fill: color-mix(in srgb, var(--primary) 12%, transparent);
+  stroke: var(--primary);
 }
 
-.single-name {
-  position: relative;
-  font-size: 0.7rem;
-  letter-spacing: 0.3em;
-  color: var(--primary);
+.core-wordmark {
+  filter: drop-shadow(0 0 6px color-mix(in srgb, var(--primary) 45%, transparent));
+}
+
+.beam-line {
+  stroke: var(--primary);
+  stroke-width: 2;
+  stroke-dasharray: 6 8;
+  filter: drop-shadow(0 0 6px var(--beam-soft));
+  animation: beam-flow 1.6s linear infinite;
+}
+
+@keyframes beam-flow {
+  to {
+    stroke-dashoffset: -28;
+  }
 }
 
 .compare-note {
@@ -731,18 +750,6 @@ main {
 .feature-panel:hover {
   background: var(--beam-soft);
   filter: drop-shadow(0 0 18px color-mix(in srgb, var(--primary) 16%, transparent));
-}
-
-.feature-head {
-  display: flex;
-  justify-content: space-between;
-  font-size: 0.7rem;
-  letter-spacing: 0.2em;
-  margin-bottom: 1.4rem;
-}
-
-.feature-id {
-  color: var(--primary);
 }
 
 .feature-icon svg {
@@ -794,9 +801,8 @@ main {
 
 .quickstart-grid {
   display: grid;
-  grid-template-columns: 1.35fr 1fr;
+  grid-template-columns: 1fr 1fr;
   gap: 1.5rem;
-  align-items: start;
 }
 
 /* `fr` tracks floor at min-content, so the pre-formatted terminal lines would
@@ -854,7 +860,7 @@ main {
 
 .terminal-body {
   padding: 1.3rem 1.4rem 1.5rem;
-  font-size: 0.84rem;
+  font-size: clamp(0.72rem, 1.15vw, 0.84rem);
   line-height: 1.75;
   overflow-x: auto;
   white-space: normal;
@@ -911,11 +917,21 @@ main {
 
 /* ---------- quickstart: agent sidebar prototype ---------- */
 
+/* The transcript grows as the visitor chats. If the panel were a normal grid
+   item, that growth would feed back into the auto row height and stretch both
+   boxes, so the panel is absolutely positioned inside its cell: it fills the row
+   the code panel establishes, and its content no longer sizes the row. */
+.agent-slot {
+  position: relative;
+  min-height: 26rem;
+}
+
 .agent-panel {
   --cut: 14px;
+  position: absolute;
+  inset: 0;
   display: flex;
   flex-direction: column;
-  min-height: 22rem;
 }
 
 .agent-bar {
@@ -923,23 +939,55 @@ main {
   align-items: center;
   justify-content: space-between;
   gap: 1rem;
-  padding: 0.8rem 1.1rem;
+  padding: 0.7rem 1.1rem;
   font-size: 0.7rem;
   letter-spacing: 0.18em;
   color: var(--text-chrome);
   border-bottom: 1px solid var(--border);
 }
 
-.agent-model {
-  color: var(--primary);
+.agent-replay {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.3rem 0.6rem;
+  font-family: var(--font-mono);
+  font-size: 0.62rem;
+  letter-spacing: 0.16em;
+  color: var(--text-chrome);
+  background: transparent;
+  border: 1px solid var(--border);
+  cursor: pointer;
+  transition:
+    color 0.2s,
+    border-color 0.2s;
 }
 
+.agent-replay:hover {
+  color: var(--primary);
+  border-color: var(--beam-soft);
+}
+
+.icon-replay {
+  width: 0.9em;
+  height: 0.9em;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.7;
+  stroke-linecap: round;
+}
+
+/* min-height: 0 lets the thread shrink below its content so the transcript
+   scrolls inside the panel instead of stretching it past the code panel. */
 .agent-thread {
   flex: 1;
+  min-height: 0;
+  overflow-y: auto;
   display: flex;
   flex-direction: column;
   gap: 0.9rem;
   padding: 1.1rem 1.1rem 1.3rem;
+  scrollbar-width: thin;
 }
 
 .agent-msg {
@@ -1028,8 +1076,66 @@ main {
   animation: none;
 }
 
+/* the host app's own component, rendered inline by the agent */
+.agent-widget {
+  margin-bottom: 0.8rem;
+  padding: 0.7rem 0.8rem 0.75rem;
+  border: 1px solid color-mix(in srgb, var(--primary) 38%, transparent);
+  background: color-mix(in srgb, var(--primary) 9%, transparent);
+  opacity: 0;
+  transform: translateY(6px);
+  transition:
+    opacity 0.3s,
+    transform 0.3s;
+}
+
+.agent-widget.shown {
+  opacity: 1;
+  transform: none;
+}
+
+.widget-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.8rem;
+  font-size: 0.66rem;
+  letter-spacing: 0.16em;
+  color: var(--primary);
+}
+
+.widget-badge {
+  color: var(--primary-foreground);
+  background: var(--primary);
+  padding: 0.1rem 0.35rem;
+  font-weight: 700;
+}
+
+.widget-rows {
+  display: grid;
+  gap: 0.3rem;
+  margin-top: 0.7rem;
+  font-size: 0.7rem;
+}
+
+.widget-rows > div {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.widget-rows dt {
+  color: var(--text-chrome);
+  letter-spacing: 0.06em;
+}
+
+.widget-rows dd {
+  color: var(--foreground);
+}
+
 .agent-stream {
-  min-height: 3.2em;
+  min-height: 1.6em;
 }
 
 .agent-stream::after {
@@ -1050,24 +1156,54 @@ main {
 .agent-composer {
   display: flex;
   align-items: center;
-  gap: 0.8rem;
+  gap: 0.6rem;
   margin: 0 1.1rem 1.1rem;
-  padding: 0.7rem 0.9rem;
+  padding: 0.45rem 0.5rem 0.45rem 0.75rem;
   border: 1px solid var(--input);
+  transition: border-color 0.2s;
+}
+
+.agent-composer:focus-within {
+  border-color: var(--beam-soft);
+}
+
+.agent-input {
+  flex: 1;
+  min-width: 0;
+  font: inherit;
   font-size: 0.9rem;
+  color: var(--foreground);
+  background: transparent;
+  border: 0;
+  outline: none;
+}
+
+.agent-input::placeholder {
   color: var(--text-chrome);
 }
 
 .agent-send {
-  margin-left: auto;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 1.5rem;
-  height: 1.5rem;
+  width: 1.7rem;
+  height: 1.7rem;
+  flex: none;
+  font-size: 0.8rem;
   color: var(--primary-foreground);
   background: var(--primary);
-  font-size: 0.8rem;
+  border: 0;
+  cursor: pointer;
+  transition: filter 0.2s;
+}
+
+.agent-send:hover {
+  filter: brightness(1.12);
+}
+
+:where(.agent-replay, .agent-send, .agent-input):focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: 2px;
 }
 
 /* ---------- open source ---------- */
@@ -1112,22 +1248,6 @@ main {
 .os-panel p {
   font-size: 0.93rem;
   color: var(--text-muted);
-}
-
-.os-standards {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.4rem;
-  margin-top: 0.9rem;
-  list-style: none;
-}
-
-.os-standards li {
-  font-size: 0.68rem;
-  letter-spacing: 0.1em;
-  color: var(--primary);
-  border: 1px solid color-mix(in srgb, var(--primary) 35%, transparent);
-  padding: 0.24rem 0.5rem;
 }
 
 .os-repo {
@@ -1271,9 +1391,6 @@ main {
   .compare-panel {
     padding: 1.4rem 1.2rem 1.3rem;
   }
-  .compare-body {
-    min-height: 0;
-  }
   /* Wrap the snippet instead of scrolling it: a horizontally scrollable code
      block inside a full-width page reads as a stuck page swipe on touch. */
   .terminal-body {
@@ -1289,9 +1406,6 @@ main {
   .terminal-bar {
     gap: 0.7rem;
     padding: 0.7rem 1.05rem;
-  }
-  .agent-panel {
-    min-height: 0;
   }
 }
 
@@ -1313,7 +1427,9 @@ main {
   .scroll-chevron,
   .blink-dot,
   .t-caret,
-  .tangle-art .tangle path {
+  .beam-line,
+  .compare-art .tangle path,
+  .node-set.is-tangled .node {
     animation: none;
   }
 
@@ -1324,7 +1440,8 @@ main {
   }
 
   .agent-msg,
-  .agent-tool {
+  .agent-tool,
+  .agent-widget {
     opacity: 1;
     transform: none;
     transition: none;

--- a/www/src/styles/global.css
+++ b/www/src/styles/global.css
@@ -8,11 +8,16 @@
 
 .light,
 .dark {
-  --panel: color-mix(in srgb, var(--card) 82%, transparent);
+  --panel: color-mix(in srgb, var(--card) 88%, transparent);
   --beam-soft: color-mix(in srgb, var(--primary) 45%, transparent);
   --beam-faint: color-mix(in srgb, var(--primary) 14%, transparent);
   --danger-soft: color-mix(in srgb, var(--destructive) 38%, transparent);
   --shadow: color-mix(in srgb, var(--background) 60%, transparent);
+  /* Body copy and small mono chrome sit under the scanline and vignette
+     overlays, so they are mixed toward --foreground rather than using
+     --muted-foreground directly, which read too dim against the backdrop. */
+  --text-muted: color-mix(in oklab, var(--foreground) 90%, var(--background));
+  --text-chrome: color-mix(in oklab, var(--foreground) 76%, var(--background));
   --font-display: "Anton", "Arial Narrow", sans-serif;
   --font-body: "Space Grotesk Variable", "Space Grotesk", system-ui, sans-serif;
   --font-mono: "JetBrains Mono", ui-monospace, "SF Mono", monospace;
@@ -25,10 +30,14 @@
   box-sizing: border-box;
 }
 
+/* `clip` on both the root and the body keeps any bleeding decoration from
+   creating a horizontal scrollbar without turning either into a scroll
+   container. https://developer.mozilla.org/en-US/docs/Web/CSS/overflow#clip */
 html {
   color-scheme: dark;
   scroll-behavior: smooth;
   background: var(--background);
+  overflow-x: clip;
 }
 
 body {
@@ -36,7 +45,7 @@ body {
   background: var(--background);
   color: var(--foreground);
   line-height: 1.6;
-  overflow-x: hidden;
+  overflow-x: clip;
   -webkit-font-smoothing: antialiased;
 }
 
@@ -48,6 +57,10 @@ body {
 a {
   color: inherit;
   text-decoration: none;
+}
+
+a[href] {
+  cursor: pointer;
 }
 
 .mono {
@@ -80,7 +93,7 @@ a {
   pointer-events: none;
   background: repeating-linear-gradient(
     0deg,
-    color-mix(in srgb, var(--foreground) 1.8%, transparent) 0 1px,
+    color-mix(in srgb, var(--foreground) 1.1%, transparent) 0 1px,
     transparent 1px 3px
   );
   mix-blend-mode: overlay;
@@ -115,7 +128,11 @@ a {
   inset: 0;
   z-index: 39;
   pointer-events: none;
-  background: radial-gradient(ellipse 90% 75% at 50% 45%, transparent 55%, var(--shadow));
+  background: radial-gradient(
+    ellipse 96% 84% at 50% 45%,
+    transparent 68%,
+    color-mix(in srgb, var(--background) 34%, transparent)
+  );
 }
 
 /* ---------- HUD chrome ---------- */
@@ -195,15 +212,17 @@ a {
 
 .hud-nav {
   display: flex;
-  gap: 1.9rem;
+  align-items: center;
+  gap: 1.7rem;
   margin-left: auto;
   font-family: var(--font-mono);
-  font-size: 0.72rem;
-  letter-spacing: 0.18em;
+  font-size: 0.76rem;
+  letter-spacing: 0.16em;
 }
 
 .hud-nav a {
-  color: var(--muted-foreground);
+  cursor: pointer;
+  color: var(--text-chrome);
   transition:
     color 0.2s,
     text-shadow 0.2s;
@@ -214,32 +233,17 @@ a {
   text-shadow: 0 0 12px var(--beam-soft);
 }
 
-.hud-bottom {
-  position: fixed;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  z-index: 50;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 0.55rem clamp(1.25rem, 4vw, 3rem);
-  font-family: var(--font-mono);
-  font-size: 0.64rem;
-  letter-spacing: 0.16em;
-  color: var(--muted-foreground);
-  background: linear-gradient(
-    to top,
-    color-mix(in srgb, var(--background) 90%, transparent),
-    transparent
-  );
-  pointer-events: none;
-}
-
-.hud-readout {
+.hud-nav-github {
   display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.45rem;
+}
+
+.icon-github {
+  width: 1.05em;
+  height: 1.05em;
+  fill: currentColor;
+  flex: none;
 }
 
 .blink-dot {
@@ -265,6 +269,7 @@ a {
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  gap: 0.55rem;
   font-family: var(--font-mono);
   font-weight: 700;
   letter-spacing: 0.14em;
@@ -280,18 +285,34 @@ a {
   );
   transition:
     filter 0.2s,
-    transform 0.15s;
+    transform 0.15s,
+    color 0.2s,
+    box-shadow 0.2s;
 }
 
 .btn-primary {
   background: var(--primary);
   color: var(--primary-foreground);
   padding: 0.7rem 1.4rem;
-  font-size: 0.72rem;
+  font-size: 0.74rem;
 }
 
 .btn-primary:hover {
   filter: brightness(1.12) drop-shadow(0 0 14px var(--beam-soft));
+  transform: translateY(-1px);
+}
+
+.btn-ghost {
+  padding: 0.7rem 1.4rem;
+  font-size: 0.74rem;
+  color: var(--foreground);
+  background: color-mix(in srgb, var(--card) 70%, transparent);
+  box-shadow: inset 0 0 0 1px var(--input);
+}
+
+.btn-ghost:hover {
+  color: var(--primary);
+  box-shadow: inset 0 0 0 1px var(--beam-soft);
   transform: translateY(-1px);
 }
 
@@ -393,11 +414,12 @@ main {
 
 .eyebrow {
   font-family: var(--font-mono);
-  font-size: clamp(0.66rem, 1.4vw, 0.8rem);
-  letter-spacing: 0.42em;
+  font-size: clamp(0.7rem, 1.4vw, 0.84rem);
+  letter-spacing: 0.3em;
   color: var(--primary);
   text-shadow: 0 0 14px var(--beam-soft);
   margin-bottom: 1.5rem;
+  text-wrap: balance;
 }
 
 .hero-title {
@@ -415,9 +437,9 @@ main {
 
 .hero-sub {
   margin: 1.8rem auto 0;
-  max-width: 36rem;
-  font-size: clamp(0.98rem, 2vw, 1.15rem);
-  color: var(--muted-foreground);
+  max-width: 38rem;
+  font-size: clamp(1.06rem, 2vw, 1.22rem);
+  color: var(--text-muted);
 }
 
 .hero-ctas {
@@ -426,30 +448,14 @@ main {
   flex-wrap: wrap;
   align-items: center;
   justify-content: center;
-  gap: 1.4rem;
+  gap: 1rem;
 }
 
 .hero-alt {
-  font-size: 0.66rem;
-  letter-spacing: 0.22em;
-  color: var(--muted-foreground);
-}
-
-.hero-readouts {
-  margin-top: clamp(2.5rem, 6vh, 4.5rem);
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  gap: 0.5rem 1.6rem;
-  font-size: 0.6rem;
-  letter-spacing: 0.14em;
-  color: color-mix(in srgb, var(--muted-foreground) 75%, transparent);
-  max-width: min(90rem, 94vw);
-}
-
-.readout-chip b {
-  color: var(--primary);
-  font-weight: 400;
+  margin-top: 1.4rem;
+  font-size: 0.72rem;
+  letter-spacing: 0.2em;
+  color: var(--text-chrome);
 }
 
 .scroll-cue {
@@ -461,9 +467,9 @@ main {
   flex-direction: column;
   align-items: center;
   gap: 0.55rem;
-  font-size: 0.6rem;
-  letter-spacing: 0.34em;
-  color: var(--muted-foreground);
+  font-size: 0.66rem;
+  letter-spacing: 0.3em;
+  color: var(--text-chrome);
 }
 
 .scroll-chevron {
@@ -501,14 +507,6 @@ main {
   margin-bottom: 3.5rem;
 }
 
-.section-tag {
-  font-size: 0.68rem;
-  letter-spacing: 0.4em;
-  color: var(--primary);
-  text-shadow: 0 0 12px var(--beam-soft);
-  margin-bottom: 1.2rem;
-}
-
 .section-title {
   font-size: clamp(2.3rem, 6vw, 4.6rem);
   text-shadow:
@@ -519,8 +517,8 @@ main {
 
 .section-sub {
   margin-top: 1.5rem;
-  color: var(--muted-foreground);
-  font-size: clamp(0.95rem, 1.8vw, 1.06rem);
+  color: var(--text-muted);
+  font-size: clamp(1.03rem, 1.8vw, 1.14rem);
   max-width: 40rem;
 }
 
@@ -561,15 +559,15 @@ main {
 }
 
 .panel-label {
-  font-size: 0.66rem;
-  letter-spacing: 0.26em;
-  color: var(--muted-foreground);
+  font-size: 0.72rem;
+  letter-spacing: 0.24em;
+  color: var(--text-chrome);
   display: flex;
   align-items: center;
   gap: 0.6rem;
 }
 
-/* ---------- 01 compare ---------- */
+/* ---------- compare ---------- */
 
 .compare-grid {
   display: grid;
@@ -578,7 +576,9 @@ main {
 }
 
 .compare-panel {
-  padding: 1.6rem 1.8rem 1.4rem;
+  display: flex;
+  flex-direction: column;
+  padding: 1.6rem 1.8rem 1.5rem;
 }
 
 .compare-panel.is-beam {
@@ -600,13 +600,30 @@ main {
   color: var(--primary);
 }
 
-.compare-art {
-  width: 100%;
-  height: auto;
-  margin: 1.4rem 0 0.6rem;
+.compare-body {
+  position: relative;
+  flex: 1;
+  display: flex;
+  align-items: center;
+  margin: 1.5rem 0 0.4rem;
+  min-height: 15rem;
 }
 
-.compare-art .tangle path {
+.compare-body.is-single {
+  flex-direction: column;
+  justify-content: center;
+  gap: 1.6rem;
+}
+
+.tangle-art {
+  position: absolute;
+  inset: -0.4rem -0.6rem;
+  width: calc(100% + 1.2rem);
+  height: calc(100% + 0.8rem);
+  pointer-events: none;
+}
+
+.tangle-art .tangle path {
   stroke: var(--danger-soft);
   animation: tangle-drift 14s linear infinite;
 }
@@ -617,93 +634,118 @@ main {
   }
 }
 
-.node-set rect {
-  fill: var(--card);
-  stroke: var(--input);
+.stack-chips {
+  position: relative;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  list-style: none;
 }
 
-.node-set text {
-  fill: var(--muted-foreground);
-  font-family: var(--font-mono);
-  font-size: 10px;
-  letter-spacing: 0.14em;
-  text-anchor: middle;
+.stack-chips li {
+  font-size: 0.74rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  background: color-mix(in srgb, var(--card) 92%, transparent);
+  border: 1px solid var(--input);
+  padding: 0.42rem 0.7rem;
 }
 
-.node-set.is-aligned rect {
-  stroke: color-mix(in srgb, var(--primary) 40%, transparent);
+.stack-chips li::before {
+  content: "✕";
+  color: var(--destructive);
+  margin-right: 0.45rem;
+  font-size: 0.8em;
 }
 
-.core-node rect {
-  fill: color-mix(in srgb, var(--primary) 10%, transparent);
-  stroke: var(--primary);
+.stack-chips.is-included li {
+  color: var(--foreground);
+  border-color: color-mix(in srgb, var(--primary) 45%, transparent);
+  background: color-mix(in srgb, var(--primary) 10%, transparent);
 }
 
-.core-node text {
-  fill: var(--primary);
-  font-weight: 700;
+.stack-chips.is-included li::before {
+  content: "✓";
+  color: var(--primary);
 }
 
-.beam-line {
-  stroke: var(--primary);
-  stroke-width: 2;
-  stroke-dasharray: 6 8;
-  filter: drop-shadow(0 0 6px var(--beam-soft));
-  animation: beam-flow 1.6s linear infinite;
+.single-core {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.8rem 0 0.2rem;
 }
 
-@keyframes beam-flow {
-  to {
-    stroke-dashoffset: -28;
-  }
+.single-beam {
+  position: absolute;
+  top: -1.6rem;
+  bottom: -1.6rem;
+  left: 50%;
+  width: 1px;
+  transform: translateX(-50%);
+  background: linear-gradient(
+    to bottom,
+    transparent,
+    color-mix(in srgb, var(--primary) 55%, transparent),
+    transparent
+  );
+}
+
+.single-logo {
+  position: relative;
+  width: clamp(5rem, 12vw, 7rem);
+  height: auto;
+  filter: drop-shadow(0 0 18px color-mix(in srgb, var(--primary) 28%, transparent));
+}
+
+.single-name {
+  position: relative;
+  font-size: 0.7rem;
+  letter-spacing: 0.3em;
+  color: var(--primary);
 }
 
 .compare-note {
-  font-size: 0.85rem;
-  color: var(--muted-foreground);
-  padding-top: 0.6rem;
+  font-size: 0.94rem;
+  color: var(--text-muted);
+  padding-top: 0.8rem;
+  border-top: 1px solid var(--border);
 }
 
-/* ---------- 02 systems ---------- */
+/* ---------- features ---------- */
 
-.systems-grid {
+.features-grid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   gap: 1.25rem;
 }
 
-.sys-panel {
+.feature-panel {
   padding: 1.5rem 1.6rem 1.7rem;
   transition: filter 0.25s;
 }
 
-.sys-panel:hover {
-  --edge-hover: 1;
+.feature-panel:hover {
   background: var(--beam-soft);
   filter: drop-shadow(0 0 18px color-mix(in srgb, var(--primary) 16%, transparent));
 }
 
-.sys-head {
+.feature-head {
   display: flex;
   justify-content: space-between;
-  font-size: 0.64rem;
+  font-size: 0.7rem;
   letter-spacing: 0.2em;
-  color: var(--muted-foreground);
-  margin-bottom: 1.5rem;
+  margin-bottom: 1.4rem;
 }
 
-.sys-id {
+.feature-id {
   color: var(--primary);
 }
 
-.sys-status {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.45rem;
-  opacity: 0.8;
-}
-
-.sys-icon svg {
+.feature-icon svg {
   width: 34px;
   height: 34px;
   stroke: var(--primary);
@@ -713,22 +755,22 @@ main {
   filter: drop-shadow(0 0 8px color-mix(in srgb, var(--primary) 35%, transparent));
 }
 
-.sys-icon svg .fill {
+.feature-icon svg .fill {
   fill: var(--primary);
   stroke: none;
 }
 
-.sys-name {
+.feature-name {
   margin-top: 1.1rem;
-  font-size: 1.05rem;
+  font-size: 1.08rem;
   font-weight: 600;
   letter-spacing: 0.02em;
 }
 
-.sys-desc {
+.feature-desc {
   margin-top: 0.6rem;
-  font-size: 0.88rem;
-  color: var(--muted-foreground);
+  font-size: 0.95rem;
+  color: var(--text-muted);
 }
 
 .panel-corner {
@@ -744,61 +786,23 @@ main {
   z-index: 1;
 }
 
-.sys-panel:hover .panel-corner {
+.feature-panel:hover .panel-corner {
   opacity: 1;
 }
 
-.aux-row {
-  margin-top: 2.6rem;
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 1rem 1.4rem;
-}
+/* ---------- quickstart ---------- */
 
-.aux-label {
-  font-size: 0.66rem;
-  letter-spacing: 0.3em;
-  color: var(--primary);
-}
-
-.aux-chips {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.6rem;
-  list-style: none;
-}
-
-.aux-chips li {
-  font-size: 0.64rem;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-  color: var(--muted-foreground);
-  border: 1px solid var(--border);
-  padding: 0.42rem 0.8rem;
-  transition:
-    border-color 0.2s,
-    color 0.2s;
-}
-
-.aux-chips li:hover {
-  border-color: var(--beam-soft);
-  color: var(--primary);
-}
-
-/* ---------- 03 deploy ---------- */
-
-.deploy-grid {
+.quickstart-grid {
   display: grid;
-  grid-template-columns: 1.5fr 1fr;
+  grid-template-columns: 1.35fr 1fr;
   gap: 1.5rem;
   align-items: start;
 }
 
 /* `fr` tracks floor at min-content, so the pre-formatted terminal lines would
-   widen the grid past the viewport instead of scrolling inside .terminal-body.
-   https://www.w3.org/TR/css-grid-1/#min-size-auto */
-.deploy-grid > * {
+   widen the grid past the viewport instead of wrapping or scrolling inside
+   .terminal-body. https://www.w3.org/TR/css-grid-1/#min-size-auto */
+.quickstart-grid > * {
   min-width: 0;
 }
 
@@ -811,9 +815,9 @@ main {
   align-items: center;
   gap: 1rem;
   padding: 0.8rem 1.2rem;
-  font-size: 0.64rem;
+  font-size: 0.7rem;
   letter-spacing: 0.18em;
-  color: var(--muted-foreground);
+  color: var(--text-chrome);
   border-bottom: 1px solid var(--border);
 }
 
@@ -850,7 +854,7 @@ main {
 
 .terminal-body {
   padding: 1.3rem 1.4rem 1.5rem;
-  font-size: 0.82rem;
+  font-size: 0.84rem;
   line-height: 1.75;
   overflow-x: auto;
   white-space: normal;
@@ -873,13 +877,7 @@ main {
 }
 
 .t-line[data-type="out"] {
-  color: var(--muted-foreground);
-}
-
-.t-line[data-type="ok"] {
-  color: var(--primary);
-  font-weight: 700;
-  text-shadow: 0 0 12px var(--beam-soft);
+  color: var(--text-chrome);
 }
 
 .t-prompt {
@@ -911,77 +909,168 @@ main {
   animation: blink 1.1s steps(2, start) infinite;
 }
 
-.boot-panel {
-  --cut: 14px;
-  padding: 1.4rem 1.5rem 1.5rem;
-}
+/* ---------- quickstart: agent sidebar prototype ---------- */
 
-.boot-list {
-  list-style: none;
-  margin-top: 1.4rem;
+.agent-panel {
+  --cut: 14px;
   display: flex;
   flex-direction: column;
-  gap: 1.05rem;
+  min-height: 22rem;
 }
 
-.boot-item {
-  display: grid;
-  grid-template-columns: auto 1fr auto;
-  align-items: center;
-  gap: 0.8rem;
-  font-size: 0.68rem;
-  letter-spacing: 0.16em;
-  color: var(--muted-foreground);
-}
-
-.boot-track {
-  height: 1px;
-  background: var(--border);
-  position: relative;
-  overflow: hidden;
-}
-
-.boot-track::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background: var(--primary);
-  box-shadow: 0 0 8px var(--beam-soft);
-  transform: translateX(-101%);
-  transition: transform 0.9s cubic-bezier(0.16, 1, 0.3, 1);
-}
-
-.boot-item.online .boot-track::after {
-  transform: translateX(0);
-}
-
-.boot-state {
-  opacity: 0;
-  color: var(--primary);
-  transition: opacity 0.3s 0.5s;
-}
-
-.boot-item.online .boot-state {
-  opacity: 1;
-}
-
-.boot-foot {
-  margin-top: 1.6rem;
-  font-size: 0.64rem;
-  letter-spacing: 0.26em;
-  color: var(--primary);
+.agent-bar {
   display: flex;
   align-items: center;
-  gap: 0.6rem;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.8rem 1.1rem;
+  font-size: 0.7rem;
+  letter-spacing: 0.18em;
+  color: var(--text-chrome);
+  border-bottom: 1px solid var(--border);
+}
+
+.agent-model {
+  color: var(--primary);
+}
+
+.agent-thread {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  padding: 1.1rem 1.1rem 1.3rem;
+}
+
+.agent-msg {
   opacity: 0;
-  transition: opacity 0.4s 2s;
+  transform: translateY(8px);
+  transition:
+    opacity 0.35s,
+    transform 0.35s;
 }
 
-.boot-panel.booted .boot-foot {
+.agent-msg.shown {
   opacity: 1;
+  transform: none;
 }
 
-/* ---------- 04 open source ---------- */
+.agent-msg.is-user {
+  align-self: flex-end;
+  max-width: 88%;
+  padding: 0.6rem 0.85rem;
+  font-size: 0.92rem;
+  background: color-mix(in srgb, var(--primary) 14%, transparent);
+  border: 1px solid color-mix(in srgb, var(--primary) 32%, transparent);
+}
+
+.agent-msg.is-agent {
+  font-size: 0.92rem;
+  color: var(--text-muted);
+}
+
+.agent-tools {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  margin-bottom: 0.8rem;
+  list-style: none;
+}
+
+.agent-tool {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 0.6rem;
+  font-size: 0.7rem;
+  letter-spacing: 0.04em;
+  color: var(--text-chrome);
+  border: 1px solid var(--border);
+  background: color-mix(in srgb, var(--card) 80%, transparent);
+  opacity: 0;
+  transform: translateY(6px);
+  transition:
+    opacity 0.3s,
+    transform 0.3s,
+    border-color 0.3s;
+}
+
+.agent-tool.running {
+  opacity: 1;
+  transform: none;
+}
+
+.agent-tool.done {
+  border-color: color-mix(in srgb, var(--primary) 30%, transparent);
+}
+
+.agent-tool b {
+  margin-left: auto;
+  font-weight: 400;
+  color: var(--text-muted);
+}
+
+.tool-dot {
+  width: 6px;
+  height: 6px;
+  flex: none;
+  border-radius: 50%;
+  background: var(--warning);
+}
+
+.agent-tool.running .tool-dot {
+  animation: blink 0.9s steps(2, start) infinite;
+}
+
+.agent-tool.done .tool-dot {
+  background: var(--primary);
+  box-shadow: 0 0 8px var(--beam-soft);
+  animation: none;
+}
+
+.agent-stream {
+  min-height: 3.2em;
+}
+
+.agent-stream::after {
+  content: "";
+  display: none;
+  width: 7px;
+  height: 1em;
+  margin-left: 2px;
+  vertical-align: text-bottom;
+  background: var(--primary);
+}
+
+.agent-stream.streaming::after {
+  display: inline-block;
+  animation: blink 1.1s steps(2, start) infinite;
+}
+
+.agent-composer {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  margin: 0 1.1rem 1.1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid var(--input);
+  font-size: 0.9rem;
+  color: var(--text-chrome);
+}
+
+.agent-send {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  color: var(--primary-foreground);
+  background: var(--primary);
+  font-size: 0.8rem;
+}
+
+/* ---------- open source ---------- */
 
 /* The watermark bleeds off the right edge by design; clip horizontally so it
    cannot extend the document scroll width. `clip` rather than `hidden` avoids
@@ -1014,18 +1103,48 @@ main {
 }
 
 .os-name {
-  font-size: 0.72rem;
-  letter-spacing: 0.26em;
+  font-size: 0.76rem;
+  letter-spacing: 0.24em;
   color: var(--primary);
   margin-bottom: 0.9rem;
 }
 
 .os-panel p {
-  font-size: 0.86rem;
-  color: var(--muted-foreground);
+  font-size: 0.93rem;
+  color: var(--text-muted);
 }
 
-/* ---------- 05 launch ---------- */
+.os-standards {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-top: 0.9rem;
+  list-style: none;
+}
+
+.os-standards li {
+  font-size: 0.68rem;
+  letter-spacing: 0.1em;
+  color: var(--primary);
+  border: 1px solid color-mix(in srgb, var(--primary) 35%, transparent);
+  padding: 0.24rem 0.5rem;
+}
+
+.os-repo {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 1rem 1.4rem;
+  margin-top: 2.4rem;
+}
+
+.os-repo-path {
+  font-size: 0.76rem;
+  letter-spacing: 0.1em;
+  color: var(--text-chrome);
+}
+
+/* ---------- launch ---------- */
 
 .launch {
   text-align: center;
@@ -1072,12 +1191,11 @@ main {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  justify-content: space-between;
-  gap: 0.8rem;
+  gap: 0.8rem 1.6rem;
   padding: 1.3rem clamp(1.25rem, 4vw, 3rem) 2.6rem;
-  font-size: 0.62rem;
-  letter-spacing: 0.2em;
-  color: var(--muted-foreground);
+  font-size: 0.7rem;
+  letter-spacing: 0.16em;
+  color: var(--text-chrome);
   border-top: 1px solid var(--border);
   max-width: 78rem;
   margin: 0 auto;
@@ -1087,27 +1205,45 @@ main {
   color: var(--primary);
 }
 
-.footer-status {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-}
-
 /* ---------- responsive ---------- */
 
 @media (max-width: 900px) {
   .compare-grid,
-  .deploy-grid {
+  .quickstart-grid {
     grid-template-columns: 1fr;
   }
-  .systems-grid {
+  .features-grid {
     grid-template-columns: repeat(2, 1fr);
   }
   .os-grid {
     grid-template-columns: repeat(2, 1fr);
   }
-  .hud-readout-mid {
+  .hud-nav {
+    gap: 1.2rem;
+    font-size: 0.72rem;
+    letter-spacing: 0.12em;
+  }
+}
+
+/* The wordmark, four nav links, and the CTA stop fitting on one line before
+   the nav is dropped entirely at 640px, so tighten them first. */
+@media (max-width: 820px) {
+  .hud-top {
+    gap: 1.25rem;
+  }
+  .hud-brand-wordmark {
+    height: 20px;
+  }
+  .hud-nav {
+    gap: 0.85rem;
+    font-size: 0.66rem;
+  }
+  .hud-nav-label {
     display: none;
+  }
+  .hud-cta {
+    font-size: 0.66rem;
+    padding: 0.62rem 1rem;
   }
 }
 
@@ -1121,35 +1257,41 @@ main {
   }
   .hud-cta {
     margin-left: auto;
-    font-size: 0.6rem;
+    font-size: 0.62rem;
     padding: 0.6rem 0.9rem;
     letter-spacing: 0.1em;
   }
   .hud-brand-wordmark {
     height: clamp(16px, 4.6vw, 18px);
   }
-  .systems-grid,
+  .features-grid,
   .os-grid {
     grid-template-columns: 1fr;
   }
-  .hero-readouts {
-    display: none;
+  .compare-panel {
+    padding: 1.4rem 1.2rem 1.3rem;
   }
-  .hud-bottom {
-    justify-content: center;
+  .compare-body {
+    min-height: 0;
   }
-  .hud-bottom .hud-readout:first-child {
-    display: none;
-  }
-  /* The widest snippet line is 45 mono chars (27em at JetBrains Mono's 0.6em
-     advance), so scale the type down to keep it inside a phone viewport. */
+  /* Wrap the snippet instead of scrolling it: a horizontally scrollable code
+     block inside a full-width page reads as a stuck page swipe on touch. */
   .terminal-body {
     padding: 1rem 1.05rem 1.2rem;
-    font-size: clamp(0.58rem, 2.6vw, 0.82rem);
+    font-size: 0.76rem;
+  }
+  .terminal-body .t-line {
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+    padding-left: 1.2em;
+    text-indent: -1.2em;
   }
   .terminal-bar {
     gap: 0.7rem;
     padding: 0.7rem 1.05rem;
+  }
+  .agent-panel {
+    min-height: 0;
   }
 }
 
@@ -1166,17 +1308,12 @@ main {
     transition: none;
   }
 
-  .reveal.hero-readouts {
-    transform: translateX(-50%);
-  }
-
   .fx-scanlines::after,
   .hero-beam,
   .scroll-chevron,
   .blink-dot,
   .t-caret,
-  .beam-line,
-  .compare-art .tangle path {
+  .tangle-art .tangle path {
     animation: none;
   }
 
@@ -1185,16 +1322,15 @@ main {
     transform: none;
     transition: none;
   }
-  .boot-item .boot-track::after {
-    transform: translateX(0);
+
+  .agent-msg,
+  .agent-tool {
+    opacity: 1;
+    transform: none;
     transition: none;
   }
-  .boot-item .boot-state {
-    opacity: 1;
-    transition: none;
-  }
-  .boot-foot {
-    opacity: 1;
-    transition: none;
+
+  .agent-tool .tool-dot {
+    animation: none;
   }
 }


### PR DESCRIPTION
Copy & structure
- Nav/section renamed Systems → Features (#features, feature-* classes); "Deploy" → "Quickstart".
- "Join the Waitlist" → "Join Waitlist" (all 3 spots); eyebrow → "OPEN SOURCE AI AGENT INFRASTRUCTURE" (also in the OG image).
- Removed all //01 TRANSMISSION-style section tags, the hero STREAMING: RESUMABLE … readout strip, the AUX SYSTEMS chip list, and the whole bottom HUD line (sys status / sector / scroll % / AGPL readout) plus its scroll JS.
- Section headings/subs rewritten: "LIFT OFF IN FIVE MINUTES", features sub now feature-led, quickstart sub de-duplicated, open-source sub refreshed. Metered Billing & Rate Limits title (feature names title-cased for consistency), prompts & evals description cleaned up, "Multiple vendors, months of integration…", "Start with the entire platform, or adopt it incrementally, piece by piece."
- Open standards listed as chips: AG-UI, MCP, OpenResponses.

Comparison section
- The tangle SVG's tiny 10px labels are gone: both panels now list the same seven responsibilities as readable chips — ✕/dim on the left over the animated tangle, ✓/teal on the right — and the "With AstralBeam" panel centers the AstralBeam logo mark on the beam instead of a text box.

GitHub
- Linked from the navbar (icon + label), a "Star on GitHub" hero button, a "Browse the source" button in the open-source section, and the footer.

Readability
- New --text-muted / --text-chrome tokens mixed toward --foreground replace --muted-foreground for all prose and mono chrome; the vignette and scanline overlays (which sit above content) were softened.
- Bumped body/secondary sizes: hero sub, section subs, feature/OS/compare copy, chips, nav, footer — mobile minimums are now ~16–17px.
- cursor: pointer on .hud-nav a and globally on a[href].

Mobile scroll fix
- overflow-x: clip on both html and body, and the code snippet now wraps with a hanging indent under 640px instead of being a horizontally-scrollable block (that swipe was the "horizontal scroll").

Sidebar prototype
- The subsystem boot log is replaced with a hardcoded agent sidebar: header, user message, three tool calls that go pending → done, a streamed answer with a caret, and a composer. Sequenced on scroll-in via initAgentDemo(), full static state under prefers-reduced-motion.

Metadata
- siteMetadata.description now matches the hero subheading; llms.txt rewritten (features, deployment, standards, repo link, no aux systems); OG-image eyebrow updated; README structure notes updated. Legal pages picked up the same higher-contrast prose token.

Skipped as ambiguous: "two examples under each (??)", "database??", and the "for later" page list (team/changelog/etc.).

Two things to flag: I kept the © 2026 / GitHub / email / Terms / Privacy / Licenses footer row (only its "ALL SYSTEMS NOMINAL" status is gone) since it carries the legal links — say the word if you wanted that row gone too. And I had no browser tooling in this session, so the changes are verified by build + tests + static review, not visually — deno task dev on port 3001 to eyeball it.