### PR TITLE
Set up react-email and email providers

### DIFF
--- a/webapp/.env.development
+++ b/webapp/.env.development
@@ -1,6 +1,7 @@
 # https://vite.dev/guide/env-and-mode.html#env-files
 DATABASE_URL=${DATABASE_URL:-postgres://${POSTGRES_USER:-astralbeam}:${POSTGRES_PASSWORD:-astralbeam}@${POSTGRES_HOST:-127.0.0.1}:${POSTGRES_HOST_PORT:-5432}/${POSTGRES_DB:-astralbeam}}
 VALKEY_URL=${VALKEY_URL:-valkey://${VALKEY_HOST:-127.0.0.1}:${VALKEY_HOST_PORT:-6379}}
+APP_BASE_URL=${APP_BASE_URL:-http://localhost:3000}
 EMAIL_PROVIDER=${EMAIL_PROVIDER:-resend}
 # Resend's shared sandbox sender, which needs no verified domain. https://resend.com/docs/dashboard/emails/send-test-emails
 EMAIL_FROM_ADDRESS=${EMAIL_FROM_ADDRESS:-onboarding@resend.dev}

--- a/webapp/.env.development
+++ b/webapp/.env.development
@@ -1,3 +1,6 @@
 # https://vite.dev/guide/env-and-mode.html#env-files
 DATABASE_URL=${DATABASE_URL:-postgres://${POSTGRES_USER:-astralbeam}:${POSTGRES_PASSWORD:-astralbeam}@${POSTGRES_HOST:-127.0.0.1}:${POSTGRES_HOST_PORT:-5432}/${POSTGRES_DB:-astralbeam}}
 VALKEY_URL=${VALKEY_URL:-valkey://${VALKEY_HOST:-127.0.0.1}:${VALKEY_HOST_PORT:-6379}}
+EMAIL_PROVIDER=${EMAIL_PROVIDER:-resend}
+# Resend's shared sandbox sender, which needs no verified domain. https://resend.com/docs/dashboard/emails/send-test-emails
+EMAIL_FROM_ADDRESS=${EMAIL_FROM_ADDRESS:-onboarding@resend.dev}

--- a/webapp/.env.example
+++ b/webapp/.env.example
@@ -1,6 +1,7 @@
 # Local service defaults come from .env.development. Copy the variables you need to override into .env.local or provide them through the shell or deployment environment.
 # DATABASE_URL=
 # VALKEY_URL=
+# APP_BASE_URL=
 
 # Required by /api/chat; set it in .env or the shell, never in a committed file.
 # OPENAI_API_KEY=

--- a/webapp/.env.example
+++ b/webapp/.env.example
@@ -5,8 +5,10 @@
 # Required by /api/chat; set it in .env or the shell, never in a committed file.
 # OPENAI_API_KEY=
 
-# Default provider for src/emails `sendEmail`; each call can override it with the `provider` option.
+# Defaults for src/emails `sendEmail`; local values come from .env.development and each call can
+# override them with the `provider` and `from` options.
 # EMAIL_PROVIDER=resend
+# EMAIL_FROM_ADDRESS=
 
 # Required only by the provider you actually send through.
 # RESEND_API_KEY=

--- a/webapp/.env.example
+++ b/webapp/.env.example
@@ -4,3 +4,12 @@
 
 # Required by /api/chat; set it in .env or the shell, never in a committed file.
 # OPENAI_API_KEY=
+
+# Default provider for src/emails `sendEmail`; each call can override it with the `provider` option.
+# EMAIL_PROVIDER=resend
+
+# Required only by the provider you actually send through.
+# RESEND_API_KEY=
+# AWS_REGION=
+# AWS_ACCESS_KEY_ID=
+# AWS_SECRET_ACCESS_KEY=

--- a/webapp/AGENTS.md
+++ b/webapp/AGENTS.md
@@ -11,7 +11,7 @@
   - Let Knip delete unreachable registry files, while suppressing only generated export-level noise.
 - `src/components` contains other common components used throught the application
   - build components using the proper shadcn-ui primitives, instead of raw HTML elements
-  - always use icons from
+  - always use icons from the configured icon library in `components.json`
 
 - `src/routes` contains routes, as expected by TanStack Router:
   - Prefer `routes/my/route/path/index.ts/tsx` to `route/my/route/path.ts/tsx` in general for better code organization
@@ -72,7 +72,7 @@
   - `sendEmail` loads only the selected `providers/*.ts` module, through a static map of dynamic imports
   - `provider`, `from`, and `replyTo` default to `EMAIL_PROVIDER`, `EMAIL_FROM_ADDRESS`, and the resolved `from`
   - Templates cannot resolve relative paths, so build absolute URLs from `APP_BASE_URL`; attachment `path` is a URL, a `data:` URI, or bare base64
-  - Preview with `deno task email`, which runs a server as configured in `scripts/preview-emails.ts` 
+  - Preview with `deno task email`, which runs a server as configured in `scripts/preview-emails.ts`
 
 - Server functions and server routes should generally be guarded by middleware e.g. authMiddleware unless there's strong reason not to
 

--- a/webapp/AGENTS.md
+++ b/webapp/AGENTS.md
@@ -67,7 +67,7 @@
   - `index.ts` is server-only despite the name and exports `sendEmail`; never import it from browser code
   - `types.ts` defines the caller contract (`SendEmailOptions`) and the normalized `ProviderEmailInput` every `sendProviderEmail` receives
   - `providers/*.ts` each export one `sendProviderEmail`; `sendEmail` reaches them through a static map of dynamic imports so only the selected provider's SDK loads
-  - Pick the provider per call with the `provider` option, or fall back to the `EMAIL_PROVIDER` environment variable
+  - The `provider` and `from` options override the `EMAIL_PROVIDER` and `EMAIL_FROM_ADDRESS` defaults, both read from `src/lib/config.server.ts`
   - Attachment `path` is an HTTP(S) URL, a `data:` URI, or bare base64; `index.ts` resolves it to bytes so providers never fetch
   - `templates/*.tsx` are react-email templates with a default export and `PreviewProps`; preview them with `deno task email`
   - That task runs `scripts/preview-emails.ts`, a `Deno.serve` preview server, instead of react-email's own CLI: the CLI respawns itself until node's `--experimental-vm-modules` appears in `process.execArgv`, which loops forever under Deno's node shim

--- a/webapp/AGENTS.md
+++ b/webapp/AGENTS.md
@@ -1,13 +1,17 @@
 ## Codebase Structure and Guidelines
 
-- This is TanStack Start React app, and all app code lives inside `src`, everything outside is configuration
-  - `deno` is the runtime cum package manager. all useful commands are listed in `package.json`
+- This is TanStack Start React app
+  - Tech stack: TanStack Router, Tailwind, Shadcn UI, Better Auth, Drizzle ORM, React Email
+  - `deno` is the runtime and package manager, all useful commands are listed in `package.json`
+  - all the application code lives in `src/`
+  - custom scripts are placed in `scripts/`, and invoked using `package.json` commands
 
 - `src/components/ui` contains shadcn-ui components and should never be edited/linted/formatted
   - New components should only be added using `deno x shadcn@latest <component>`
-  - Use a `// Added with: deno task ui add <component>` top comment with every intentional local change; do not include `--overwrite` or `-y` in that comment.
   - Let Knip delete unreachable registry files, while suppressing only generated export-level noise.
-- `src/components` contains common components used throught the application
+- `src/components` contains other common components used throught the application
+  - build components using the proper shadcn-ui primitives, instead of raw HTML elements
+  - always use icons from
 
 - `src/routes` contains routes, as expected by TanStack Router:
   - Prefer `routes/my/route/path/index.ts/tsx` to `route/my/route/path.ts/tsx` in general for better code organization
@@ -64,11 +68,14 @@
   - avoid creating new files in `src/lib`, use new code goes into one of the above files or into a module-specific `-lib` folder.
 
 - `src/emails` contains emails powered by react-email
-  - `index.ts` is server-only despite the name and exports `sendEmail`; never import it from browser code
+  - `index.ts` is server-only despite the name and exports `sendEmail` plus one `send<Template>Email` wrapper per template; never import it from browser code
+  - A wrapper takes a single `options` argument with an inline type: its own template props plus a required `to` and optional `from`, `replyTo`, and `provider`; it owns the subject and passes those four through to `sendEmail`
+  - `utils.server.ts` holds every helper `sendEmail` composes: the provider registry, option resolution, rendering, and attachment decoding
   - `types.ts` defines the caller contract (`SendEmailOptions`) and the normalized `ProviderEmailInput` every `sendProviderEmail` receives
   - `providers/*.ts` each export one `sendProviderEmail`; `sendEmail` reaches them through a static map of dynamic imports so only the selected provider's SDK loads
-  - The `provider` and `from` options override the `EMAIL_PROVIDER` and `EMAIL_FROM_ADDRESS` defaults, both read from `src/lib/config.server.ts`
-  - Attachment `path` is an HTTP(S) URL, a `data:` URI, or bare base64; `index.ts` resolves it to bytes so providers never fetch
+  - The `provider` and `from` options override the `EMAIL_PROVIDER` and `EMAIL_FROM_ADDRESS` defaults, both read from `src/lib/config.server.ts`; `replyTo` defaults to the resolved `from`
+  - Templates cannot resolve relative paths, so build absolute image and link URLs from `APP_BASE_URL`
+  - Attachment `path` is an HTTP(S) URL, a `data:` URI, or bare base64; `utils.server.ts` resolves it to bytes so providers never fetch
   - `templates/*.tsx` are react-email templates with a default export and `PreviewProps`; preview them with `deno task email`
   - That task runs `scripts/preview-emails.ts`, a `Deno.serve` preview server, instead of react-email's own CLI: the CLI respawns itself until node's `--experimental-vm-modules` appears in `process.execArgv`, which loops forever under Deno's node shim
 

--- a/webapp/AGENTS.md
+++ b/webapp/AGENTS.md
@@ -63,7 +63,14 @@
   - `auth.ts` contains the better-auth setup for authentication
   - avoid creating new files in `src/lib`, use new code goes into one of the above files or into a module-specific `-lib` folder.
 
-- `src/emails` contains emails powered by react-email (TODO: not set up yet, add more docs later)
+- `src/emails` contains emails powered by react-email
+  - `index.ts` is server-only despite the name and exports `sendEmail`; never import it from browser code
+  - `types.ts` defines the caller contract (`SendEmailOptions`) and the normalized `ProviderEmailInput` every `sendProviderEmail` receives
+  - `providers/*.ts` each export one `sendProviderEmail`; `sendEmail` reaches them through a static map of dynamic imports so only the selected provider's SDK loads
+  - Pick the provider per call with the `provider` option, or fall back to the `EMAIL_PROVIDER` environment variable
+  - Attachment `path` is an HTTP(S) URL, a `data:` URI, or bare base64; `index.ts` resolves it to bytes so providers never fetch
+  - `templates/*.tsx` are react-email templates with a default export and `PreviewProps`; preview them with `deno task email`
+  - That task runs `scripts/preview-emails.ts`, a `Deno.serve` preview server, instead of react-email's own CLI: the CLI respawns itself until node's `--experimental-vm-modules` appears in `process.execArgv`, which loops forever under Deno's node shim
 
 - Server functions and server routes should generally be guarded by middleware e.g. authMiddleware unless there's strong reason not to
 

--- a/webapp/AGENTS.md
+++ b/webapp/AGENTS.md
@@ -68,16 +68,11 @@
   - avoid creating new files in `src/lib`, use new code goes into one of the above files or into a module-specific `-lib` folder.
 
 - `src/emails` contains emails powered by react-email
-  - `index.ts` is server-only despite the name and exports `sendEmail` plus one `send<Template>Email` wrapper per template; never import it from browser code
-  - A wrapper takes a single `options` argument with an inline type: its own template props plus a required `to` and optional `from`, `replyTo`, and `provider`; it owns the subject and passes those four through to `sendEmail`
-  - `utils.server.ts` holds every helper `sendEmail` composes: the provider registry, option resolution, rendering, and attachment decoding
-  - `types.ts` defines the caller contract (`SendEmailOptions`) and the normalized `ProviderEmailInput` every `sendProviderEmail` receives
-  - `providers/*.ts` each export one `sendProviderEmail`; `sendEmail` reaches them through a static map of dynamic imports so only the selected provider's SDK loads
-  - The `provider` and `from` options override the `EMAIL_PROVIDER` and `EMAIL_FROM_ADDRESS` defaults, both read from `src/lib/config.server.ts`; `replyTo` defaults to the resolved `from`
-  - Templates cannot resolve relative paths, so build absolute image and link URLs from `APP_BASE_URL`
-  - Attachment `path` is an HTTP(S) URL, a `data:` URI, or bare base64; `utils.server.ts` resolves it to bytes so providers never fetch
-  - `templates/*.tsx` are react-email templates with a default export and `PreviewProps`; preview them with `deno task email`
-  - That task runs `scripts/preview-emails.ts`, a `Deno.serve` preview server, instead of react-email's own CLI: the CLI respawns itself until node's `--experimental-vm-modules` appears in `process.execArgv`, which loops forever under Deno's node shim
+  - `index.ts` exports `sendEmail` plus one `send<Template>Email` wrapper per template, each owning its own subject and props
+  - `sendEmail` loads only the selected `providers/*.ts` module, through a static map of dynamic imports
+  - `provider`, `from`, and `replyTo` default to `EMAIL_PROVIDER`, `EMAIL_FROM_ADDRESS`, and the resolved `from`
+  - Templates cannot resolve relative paths, so build absolute URLs from `APP_BASE_URL`; attachment `path` is a URL, a `data:` URI, or bare base64
+  - Preview with `deno task email`, which runs a server as configured in `scripts/preview-emails.ts` 
 
 - Server functions and server routes should generally be guarded by middleware e.g. authMiddleware unless there's strong reason not to
 
@@ -94,6 +89,6 @@
   - In every server function, you might need to check if the current user is authorized to access & update the data
   - In every databsae query, you might need to ensures that the right filters are applied to avoid leaking data accidentally
   - Errors in the backend must be handled, logged and gracefully shown to a user to convey why something didn't work without leaking critical info that might compromise the application security.
-  - Server-only code should typically go into `*.server.ts` files. be careful not to leak server environment vars into the client.
+  - Server-only code should typically go into `*.server.ts` files (except `index.ts` files where you can use a "server-only" import from TanStack Start as the guard). be careful not to leak server environment vars into the client.
 
 TODO: add common commands

--- a/webapp/deno.lock
+++ b/webapp/deno.lock
@@ -1,6 +1,7 @@
 {
   "version": "5",
   "specifiers": {
+    "npm:@aws-sdk/client-sesv2@^3.1115.0": "3.1115.0",
     "npm:@base-ui/react@^1.6.0": "1.7.0_@types+react@19.2.18_react@19.2.8_react-dom@19.2.8__react@19.2.8",
     "npm:@csstools/color-helpers@6.1.0": "6.1.0",
     "npm:@csstools/css-color-parser@4.1.10": "4.1.10_@csstools+css-parser-algorithms@4.0.0__@csstools+css-tokenizer@4.0.0_@csstools+css-tokenizer@4.0.0",
@@ -30,7 +31,10 @@
     "npm:nitro@3.0.260610-beta": "3.0.260610-beta_vite@8.2.1_drizzle-orm@1.0.0-rc.5-ab785fc__effect@4.0.0-rc.108__postgres@3.4.9__zod@4.4.3_effect@4.0.0-rc.108_postgres@3.4.9_zod@4.4.3",
     "npm:postgres@^3.4.9": "3.4.9",
     "npm:react-dom@^19.2.6": "19.2.8_react@19.2.8",
+    "npm:react-email@6.9.2": "6.9.2_react@19.2.8_react-dom@19.2.8__react@19.2.8",
+    "npm:react-email@^6.9.2": "6.9.2_react@19.2.8_react-dom@19.2.8__react@19.2.8",
     "npm:react@^19.2.6": "19.2.8",
+    "npm:resend@^6.21.0": "6.21.0",
     "npm:shadcn@^4.13.0": "4.18.0_typescript@6.0.3",
     "npm:sharp@~0.34.3": "0.34.5",
     "npm:tailwind-merge@^3.6.0": "3.6.0",
@@ -51,6 +55,183 @@
       "optionalPeers": [
         "zod@4.4.3"
       ]
+    },
+    "@aws-sdk/client-sesv2@3.1115.0": {
+      "integrity": "sha512-QgLB4msrEp4cau8s4ozBkv0+7SC65nnfb/T2N0ysNvsvQvm9/2bASnwHCqWj6tMqYh22JmrjCZrmzlyVDqfNjA==",
+      "dependencies": [
+        "@aws-sdk/core",
+        "@aws-sdk/credential-provider-node",
+        "@aws-sdk/signature-v4-multi-region",
+        "@aws-sdk/types",
+        "@smithy/core",
+        "@smithy/fetch-http-handler",
+        "@smithy/node-http-handler",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/core@3.977.8": {
+      "integrity": "sha512-7+Kcrkvrk9lM/m7jRhHpT4jCdvzGHsuaSRbF8TdzzkY1mRzp/Ogwf9c7H29k4gGhey0BBWhCWr16+t0J61gwmg==",
+      "dependencies": [
+        "@aws-sdk/types",
+        "@aws-sdk/xml-builder",
+        "@aws/lambda-invoke-store",
+        "@smithy/core",
+        "@smithy/signature-v4",
+        "@smithy/types",
+        "bowser",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/credential-provider-env@3.972.69": {
+      "integrity": "sha512-AreCFzcB4kH2HF9031Ot0jSJr3KXvRg6e8uDeub20JEVdZU3Bv0sTq1plc7VsT3KiqutlzH7l0j50UcCWHUioA==",
+      "dependencies": [
+        "@aws-sdk/core",
+        "@aws-sdk/types",
+        "@smithy/core",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/credential-provider-http@3.972.71": {
+      "integrity": "sha512-A8ObcqVmDMnk4F9NozZ7JwmUu9Q4xyBJkmyq1C5U+wNM9ht9J7+EuuyabsLWXZnOoTqFaJuYBYTKf5CTipkEjA==",
+      "dependencies": [
+        "@aws-sdk/core",
+        "@aws-sdk/types",
+        "@smithy/core",
+        "@smithy/fetch-http-handler",
+        "@smithy/node-http-handler",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/credential-provider-ini@3.973.14": {
+      "integrity": "sha512-7c+Wti2LsERNWMfm7ySz3/6RPopFW3Nmn7s63Xpcq6R/tRuY5hpvkHA2xVgi5ukJbvok9l0IDtVEvqTtg+X7dw==",
+      "dependencies": [
+        "@aws-sdk/core",
+        "@aws-sdk/credential-provider-env",
+        "@aws-sdk/credential-provider-http",
+        "@aws-sdk/credential-provider-login",
+        "@aws-sdk/credential-provider-process",
+        "@aws-sdk/credential-provider-sso",
+        "@aws-sdk/credential-provider-web-identity",
+        "@aws-sdk/nested-clients",
+        "@aws-sdk/types",
+        "@smithy/core",
+        "@smithy/credential-provider-imds",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/credential-provider-login@3.972.76": {
+      "integrity": "sha512-LVixwOnEJfrrfKHeZjBA8pIMTZjNDq8ak8VpcoWUuCJDrSnBNU8POJksULMgvN089P0MXtQYH2Zs627/MK1K0g==",
+      "dependencies": [
+        "@aws-sdk/core",
+        "@aws-sdk/nested-clients",
+        "@aws-sdk/types",
+        "@smithy/core",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/credential-provider-node@3.972.80": {
+      "integrity": "sha512-bE2qh8ww4iClO1jHsBXdOE8FUgzDbdxbyorNjSCoPSkQd51k3jODItuPZfuwcLHZqDXsH+bI4AMHhqtuyR7mSg==",
+      "dependencies": [
+        "@aws-sdk/credential-provider-env",
+        "@aws-sdk/credential-provider-http",
+        "@aws-sdk/credential-provider-ini",
+        "@aws-sdk/credential-provider-process",
+        "@aws-sdk/credential-provider-sso",
+        "@aws-sdk/credential-provider-web-identity",
+        "@aws-sdk/types",
+        "@smithy/core",
+        "@smithy/credential-provider-imds",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/credential-provider-process@3.972.69": {
+      "integrity": "sha512-9kpTNdZTrcqXTfhxM7fgl9Z68ek3Fu5oe3Yf+A/pJGibEqpgZxz2tSY7SinmyCIU2PJ+ygY4FPoBBnLpocMtrQ==",
+      "dependencies": [
+        "@aws-sdk/core",
+        "@aws-sdk/types",
+        "@smithy/core",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/credential-provider-sso@3.973.13": {
+      "integrity": "sha512-Oc81qauMPzUoTnAS2YKpNwY6sY/LUyQTEeaf6yP197WMxkEBQfcKLR1MFpD7+pNTubXnfkH6gwpji+Gc7iyD2Q==",
+      "dependencies": [
+        "@aws-sdk/core",
+        "@aws-sdk/nested-clients",
+        "@aws-sdk/token-providers",
+        "@aws-sdk/types",
+        "@smithy/core",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/credential-provider-web-identity@3.972.75": {
+      "integrity": "sha512-YPN6uoGDgjjjeVFZrcOeCJqmB6zpXoeeNgIjqe+DexJaWqdjVfCCe+VAZwli9Z2h8KhFW8oxkO39emQ1tyz/Mw==",
+      "dependencies": [
+        "@aws-sdk/core",
+        "@aws-sdk/nested-clients",
+        "@aws-sdk/types",
+        "@smithy/core",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/nested-clients@3.997.43": {
+      "integrity": "sha512-bit+VpqWNyi3wHxFoTsTliNXimCSL2r2OeDTm7ZrG+YsTZ2D7ofDJ6r/t9PVBn80i6/v0X2h9Tgw6QP2MAKfPw==",
+      "dependencies": [
+        "@aws-sdk/core",
+        "@aws-sdk/signature-v4-multi-region",
+        "@aws-sdk/types",
+        "@smithy/core",
+        "@smithy/fetch-http-handler",
+        "@smithy/node-http-handler",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/signature-v4-multi-region@3.996.45": {
+      "integrity": "sha512-bBuyztukzXq6plzFGHAWiQt0QXo+HL8b8lX5cFTzkez/74PtS1c0qPFCIVuHkyoT+miH2qOjAcm1/yoro2ESPA==",
+      "dependencies": [
+        "@aws-sdk/types",
+        "@smithy/signature-v4",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/token-providers@3.1111.0": {
+      "integrity": "sha512-JfljgoVtl+s3Qy21n9a7Z48uCQaOXcN74KJ3TEQfPoB293GrXFSt6HSQJF1sTZ8c/5QedEvd3NjJQMO4u9qa5A==",
+      "dependencies": [
+        "@aws-sdk/core",
+        "@aws-sdk/nested-clients",
+        "@aws-sdk/types",
+        "@smithy/core",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/types@3.974.4": {
+      "integrity": "sha512-dSFDNG00MEz0/xl5gxL62giLd1iYyJsTxZ1I1DOj6lC+bbgLB4TRsYClJg3b62dhXT1uATzsTNXPnC+33EJV3A==",
+      "dependencies": [
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/xml-builder@3.972.39": {
+      "integrity": "sha512-FTti8DS5MMWXNUWiRwXAJeYS+0GHHiMy0+7XOhcwk63ILHmfS2UFy2z/HNpZCSOJJ3P3dnWY6hfYNW3DF0nXUA==",
+      "dependencies": [
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@aws/lambda-invoke-store@0.3.0": {
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ=="
     },
     "@babel/code-frame@7.27.1": {
       "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
@@ -79,9 +260,9 @@
         "@babel/helper-compilation-targets",
         "@babel/helper-module-transforms",
         "@babel/helpers",
-        "@babel/parser",
+        "@babel/parser@7.29.8",
         "@babel/template",
-        "@babel/traverse",
+        "@babel/traverse@7.29.8",
         "@babel/types",
         "@jridgewell/remapping",
         "convert-source-map",
@@ -94,7 +275,7 @@
     "@babel/generator@7.29.8": {
       "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
       "dependencies": [
-        "@babel/parser",
+        "@babel/parser@7.29.8",
         "@babel/types",
         "@jridgewell/gen-mapping",
         "@jridgewell/trace-mapping",
@@ -113,7 +294,7 @@
         "@babel/compat-data",
         "@babel/helper-validator-option",
         "browserslist",
-        "lru-cache",
+        "lru-cache@5.1.1",
         "semver@6.3.1"
       ]
     },
@@ -126,7 +307,7 @@
         "@babel/helper-optimise-call-expression",
         "@babel/helper-replace-supers",
         "@babel/helper-skip-transparent-expression-wrappers",
-        "@babel/traverse",
+        "@babel/traverse@7.29.8",
         "semver@6.3.1"
       ]
     },
@@ -136,14 +317,14 @@
     "@babel/helper-member-expression-to-functions@7.29.7": {
       "integrity": "sha512-j+7JYmk1JYDtACIGj0QJqqWZjoUpMoEikQGADMaHgCMCSDqd2+P32rfcibUNrGOMWrlzK1WJBdxrB3JJQZwWtg==",
       "dependencies": [
-        "@babel/traverse",
+        "@babel/traverse@7.29.8",
         "@babel/types"
       ]
     },
     "@babel/helper-module-imports@7.29.7": {
       "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dependencies": [
-        "@babel/traverse",
+        "@babel/traverse@7.29.8",
         "@babel/types"
       ]
     },
@@ -153,7 +334,7 @@
         "@babel/core",
         "@babel/helper-module-imports",
         "@babel/helper-validator-identifier",
-        "@babel/traverse"
+        "@babel/traverse@7.29.8"
       ]
     },
     "@babel/helper-optimise-call-expression@7.29.7": {
@@ -171,13 +352,13 @@
         "@babel/core",
         "@babel/helper-member-expression-to-functions",
         "@babel/helper-optimise-call-expression",
-        "@babel/traverse"
+        "@babel/traverse@7.29.8"
       ]
     },
     "@babel/helper-skip-transparent-expression-wrappers@7.29.7": {
       "integrity": "sha512-brcMGQaVzIeUb+6/bs1Av0f8YuNNjKY2JyvfRCsFuFsdKccEQ5Ges2y74D74NZ1Rz8lKJ9ksJkfqwQFJ/iNEyQ==",
       "dependencies": [
-        "@babel/traverse",
+        "@babel/traverse@7.29.8",
         "@babel/types"
       ]
     },
@@ -196,6 +377,13 @@
         "@babel/template",
         "@babel/types"
       ]
+    },
+    "@babel/parser@7.29.2": {
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "dependencies": [
+        "@babel/types"
+      ],
+      "bin": true
     },
     "@babel/parser@7.29.8": {
       "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
@@ -255,8 +443,20 @@
       "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dependencies": [
         "@babel/code-frame@7.29.7",
-        "@babel/parser",
+        "@babel/parser@7.29.8",
         "@babel/types"
+      ]
+    },
+    "@babel/traverse@7.29.0": {
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dependencies": [
+        "@babel/code-frame@7.29.7",
+        "@babel/generator",
+        "@babel/helper-globals",
+        "@babel/parser@7.29.8",
+        "@babel/template",
+        "@babel/types",
+        "debug"
       ]
     },
     "@babel/traverse@7.29.8": {
@@ -265,7 +465,7 @@
         "@babel/code-frame@7.29.7",
         "@babel/generator",
         "@babel/helper-globals",
-        "@babel/parser",
+        "@babel/parser@7.29.8",
         "@babel/template",
         "@babel/types",
         "debug"
@@ -342,10 +542,10 @@
       "dependencies": [
         "@dotenvx/primitives",
         "commander@11.1.0",
-        "conf",
+        "conf@10.2.0",
         "dotenv",
         "enquirer",
-        "env-paths",
+        "env-paths@2.2.1",
         "execa@5.1.1",
         "fdir",
         "ignore",
@@ -389,8 +589,18 @@
       "os": ["aix"],
       "cpu": ["ppc64"]
     },
+    "@esbuild/aix-ppc64@0.28.2": {
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "os": ["aix"],
+      "cpu": ["ppc64"]
+    },
     "@esbuild/android-arm64@0.25.12": {
       "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "os": ["android"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/android-arm64@0.28.2": {
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
       "os": ["android"],
       "cpu": ["arm64"]
     },
@@ -399,8 +609,18 @@
       "os": ["android"],
       "cpu": ["arm"]
     },
+    "@esbuild/android-arm@0.28.2": {
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "os": ["android"],
+      "cpu": ["arm"]
+    },
     "@esbuild/android-x64@0.25.12": {
       "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "os": ["android"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/android-x64@0.28.2": {
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
       "os": ["android"],
       "cpu": ["x64"]
     },
@@ -409,8 +629,18 @@
       "os": ["darwin"],
       "cpu": ["arm64"]
     },
+    "@esbuild/darwin-arm64@0.28.2": {
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "os": ["darwin"],
+      "cpu": ["arm64"]
+    },
     "@esbuild/darwin-x64@0.25.12": {
       "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "os": ["darwin"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/darwin-x64@0.28.2": {
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
       "os": ["darwin"],
       "cpu": ["x64"]
     },
@@ -419,8 +649,18 @@
       "os": ["freebsd"],
       "cpu": ["arm64"]
     },
+    "@esbuild/freebsd-arm64@0.28.2": {
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "os": ["freebsd"],
+      "cpu": ["arm64"]
+    },
     "@esbuild/freebsd-x64@0.25.12": {
       "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "os": ["freebsd"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/freebsd-x64@0.28.2": {
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
       "os": ["freebsd"],
       "cpu": ["x64"]
     },
@@ -429,8 +669,18 @@
       "os": ["linux"],
       "cpu": ["arm64"]
     },
+    "@esbuild/linux-arm64@0.28.2": {
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
+    },
     "@esbuild/linux-arm@0.25.12": {
       "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "os": ["linux"],
+      "cpu": ["arm"]
+    },
+    "@esbuild/linux-arm@0.28.2": {
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
       "os": ["linux"],
       "cpu": ["arm"]
     },
@@ -439,8 +689,18 @@
       "os": ["linux"],
       "cpu": ["ia32"]
     },
+    "@esbuild/linux-ia32@0.28.2": {
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "os": ["linux"],
+      "cpu": ["ia32"]
+    },
     "@esbuild/linux-loong64@0.25.12": {
       "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "os": ["linux"],
+      "cpu": ["loong64"]
+    },
+    "@esbuild/linux-loong64@0.28.2": {
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
       "os": ["linux"],
       "cpu": ["loong64"]
     },
@@ -449,8 +709,18 @@
       "os": ["linux"],
       "cpu": ["mips64el"]
     },
+    "@esbuild/linux-mips64el@0.28.2": {
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "os": ["linux"],
+      "cpu": ["mips64el"]
+    },
     "@esbuild/linux-ppc64@0.25.12": {
       "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "os": ["linux"],
+      "cpu": ["ppc64"]
+    },
+    "@esbuild/linux-ppc64@0.28.2": {
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
       "os": ["linux"],
       "cpu": ["ppc64"]
     },
@@ -459,8 +729,18 @@
       "os": ["linux"],
       "cpu": ["riscv64"]
     },
+    "@esbuild/linux-riscv64@0.28.2": {
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "os": ["linux"],
+      "cpu": ["riscv64"]
+    },
     "@esbuild/linux-s390x@0.25.12": {
       "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "os": ["linux"],
+      "cpu": ["s390x"]
+    },
+    "@esbuild/linux-s390x@0.28.2": {
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
       "os": ["linux"],
       "cpu": ["s390x"]
     },
@@ -469,8 +749,18 @@
       "os": ["linux"],
       "cpu": ["x64"]
     },
+    "@esbuild/linux-x64@0.28.2": {
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "os": ["linux"],
+      "cpu": ["x64"]
+    },
     "@esbuild/netbsd-arm64@0.25.12": {
       "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "os": ["netbsd"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/netbsd-arm64@0.28.2": {
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
       "os": ["netbsd"],
       "cpu": ["arm64"]
     },
@@ -479,8 +769,18 @@
       "os": ["netbsd"],
       "cpu": ["x64"]
     },
+    "@esbuild/netbsd-x64@0.28.2": {
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "os": ["netbsd"],
+      "cpu": ["x64"]
+    },
     "@esbuild/openbsd-arm64@0.25.12": {
       "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "os": ["openbsd"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/openbsd-arm64@0.28.2": {
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
       "os": ["openbsd"],
       "cpu": ["arm64"]
     },
@@ -489,8 +789,18 @@
       "os": ["openbsd"],
       "cpu": ["x64"]
     },
+    "@esbuild/openbsd-x64@0.28.2": {
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "os": ["openbsd"],
+      "cpu": ["x64"]
+    },
     "@esbuild/openharmony-arm64@0.25.12": {
       "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "os": ["openharmony"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/openharmony-arm64@0.28.2": {
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
       "os": ["openharmony"],
       "cpu": ["arm64"]
     },
@@ -499,8 +809,18 @@
       "os": ["sunos"],
       "cpu": ["x64"]
     },
+    "@esbuild/sunos-x64@0.28.2": {
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "os": ["sunos"],
+      "cpu": ["x64"]
+    },
     "@esbuild/win32-arm64@0.25.12": {
       "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "os": ["win32"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/win32-arm64@0.28.2": {
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
       "os": ["win32"],
       "cpu": ["arm64"]
     },
@@ -509,8 +829,18 @@
       "os": ["win32"],
       "cpu": ["ia32"]
     },
+    "@esbuild/win32-ia32@0.28.2": {
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "os": ["win32"],
+      "cpu": ["ia32"]
+    },
     "@esbuild/win32-x64@0.25.12": {
       "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "os": ["win32"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/win32-x64@0.28.2": {
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
       "os": ["win32"],
       "cpu": ["x64"]
     },
@@ -1161,6 +1491,17 @@
         "react-dom"
       ]
     },
+    "@react-email/render@2.1.0_react@19.2.8_react-dom@19.2.8__react@19.2.8": {
+      "integrity": "sha512-F+zE3O6d6sW6Aj2UjvZAA17R7tJKM7kcq2mgV6k4HCT8jeLLFaVP2txMtH1lgqYFRMZ0Gxsd37q2PRyiXLXXxA==",
+      "dependencies": [
+        "entities",
+        "html-to-text",
+        "html5parser",
+        "prettier",
+        "react",
+        "react-dom"
+      ]
+    },
     "@rolldown/binding-android-arm64@1.2.4": {
       "integrity": "sha512-jHC2cnyKz5xU2fhECtFl8OZ83cYNt13GZQD+0uMJ/X3o+ijmd56okHhTUwxVSHPx1IRVIJEZ1/1pPzeLCU6XKA==",
       "os": ["android"],
@@ -1249,8 +1590,63 @@
     "@sec-ant/readable-stream@0.4.1": {
       "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg=="
     },
+    "@selderee/plugin-htmlparser2@0.11.0": {
+      "integrity": "sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==",
+      "dependencies": [
+        "domhandler",
+        "selderee"
+      ]
+    },
     "@sindresorhus/merge-streams@4.0.0": {
       "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ=="
+    },
+    "@smithy/core@3.33.3": {
+      "integrity": "sha512-CsOeKq/9kA3y6VJHt+/+VTCtBaxJ4OTFpgrjIUhPpDIKxBci1k2bJaQASF2h/ELWrulGp+t97DZ0mevfAD8idg==",
+      "dependencies": [
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@smithy/credential-provider-imds@4.5.2": {
+      "integrity": "sha512-A9uSdn72ozbRUSit0eib0TW7nXuNPlaeM0zcGkJ+nE6tFcSDbnmtwoxbTCFBukVQcszDAyvsd7+rTduPTXpygg==",
+      "dependencies": [
+        "@smithy/core",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@smithy/fetch-http-handler@5.7.2": {
+      "integrity": "sha512-nZyWTmSpJEXl6VtWVMBJve/7x12DZu6sIX1z1a+ZMaHlQQRs9Zpu6NbTe/gmxYXVRpkjxyDYpZ5gx2IM6f/Wkw==",
+      "dependencies": [
+        "@smithy/core",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@smithy/node-http-handler@4.11.3": {
+      "integrity": "sha512-2jY1tSpERfPfWqyBV2pH+iGFaghVsIJszJNsT7hxtQYhVJpWDyc0LqOWI+nXOxOAHaEfZ4PXXtp1wW1TGpHhkA==",
+      "dependencies": [
+        "@smithy/core",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@smithy/signature-v4@5.7.3": {
+      "integrity": "sha512-7ImGm+FkHRLcBaRttIAMZ6bzJZWb2cJGoYjq46F2UjycujWzrL9GEN9h4w7eQyXJYnltrUhxbbieBAIRrdqpow==",
+      "dependencies": [
+        "@smithy/core",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@smithy/types@4.17.2": {
+      "integrity": "sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@socket.io/component-emitter@3.1.2": {
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA=="
     },
     "@solid-primitives/event-listener@2.4.6_solid-js@1.9.14": {
       "integrity": "sha512-5I0YJcTVYIWoMmgBSROBZGcz+ymhew/pGTg2dHW74BUjFKsV8Li4bOZYl0YAGP4mHw5o4UBd9/BEesqBci3wxw==",
@@ -1298,6 +1694,9 @@
         "solid-js"
       ]
     },
+    "@stablelib/base64@1.0.1": {
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ=="
+    },
     "@standard-schema/spec@1.1.0": {
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="
     },
@@ -1306,7 +1705,7 @@
       "dependencies": [
         "@jridgewell/remapping",
         "enhanced-resolve",
-        "jiti",
+        "jiti@2.7.0",
         "lightningcss@1.32.0",
         "magic-string",
         "source-map-js",
@@ -1608,7 +2007,7 @@
       "integrity": "sha512-qds8Fl+VY5KU1xlTUHRT12hXSujr8TW3TqE1hwotDjh3SGMQ/uEO6gF57FiEZNIg3L896f3XLZ30JgF8C7WbGw==",
       "dependencies": [
         "@tanstack/router-generator",
-        "chokidar",
+        "chokidar@5.0.0",
         "yargs"
       ],
       "bin": true
@@ -1641,7 +2040,7 @@
         "@tanstack/router-core",
         "@tanstack/router-utils",
         "@tanstack/virtual-file-routes",
-        "jiti",
+        "jiti@2.7.0",
         "magic-string",
         "prettier",
         "zod@4.4.3"
@@ -1657,7 +2056,7 @@
         "@tanstack/router-core",
         "@tanstack/router-generator",
         "@tanstack/router-utils",
-        "chokidar",
+        "chokidar@5.0.0",
         "unplugin",
         "vite",
         "zod@4.4.3"
@@ -1671,7 +2070,7 @@
       "integrity": "sha512-hTWqJtqIFFdvuCl8WXNyrodp2L9zo2G37xKRrcVmVRWpAB2h+U1LuRAfS4tsFTiWOIoE/B+WDVFB8JpoEdw6jQ==",
       "dependencies": [
         "@babel/generator",
-        "@babel/parser",
+        "@babel/parser@7.29.8",
         "@babel/types",
         "ansis",
         "babel-dead-code-elimination",
@@ -1766,11 +2165,23 @@
         "assertion-error"
       ]
     },
+    "@types/cors@2.8.19": {
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "dependencies": [
+        "@types/node"
+      ]
+    },
     "@types/deep-eql@4.0.2": {
       "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="
     },
     "@types/estree@1.0.9": {
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="
+    },
+    "@types/node@26.2.0": {
+      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
+      "dependencies": [
+        "undici-types"
+      ]
     },
     "@types/react-dom@19.2.4_@types+react@19.2.18": {
       "integrity": "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==",
@@ -1786,6 +2197,12 @@
     },
     "@types/validate-npm-package-name@4.0.2": {
       "integrity": "sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw=="
+    },
+    "@types/ws@8.18.1": {
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dependencies": [
+        "@types/node"
+      ]
     },
     "@vitejs/plugin-react@6.0.5_@rolldown+plugin-babel@0.2.3__@babel+core@7.29.7__rolldown@1.2.4__vite@8.2.1_babel-plugin-react-compiler@1.0.0_vite@8.2.1_@babel+core@7.29.7_rolldown@1.2.4": {
       "integrity": "sha512-BOVzne/NL162sMdResB25mUv+vWMF5NoAjNf09TeGlE7ZpszZWSD3winycicLJw72yeVsoCn/2kOhEuCvEShMA==",
@@ -1856,11 +2273,18 @@
         "tinyrainbow"
       ]
     },
+    "accepts@1.3.8": {
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "dependencies": [
+        "mime-types@2.1.35",
+        "negotiator@0.6.3"
+      ]
+    },
     "accepts@2.0.0": {
       "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
       "dependencies": [
-        "mime-types",
-        "negotiator"
+        "mime-types@3.0.2",
+        "negotiator@1.0.0"
       ]
     },
     "ajv-formats@2.1.1_ajv@8.20.0": {
@@ -1923,12 +2347,19 @@
     "atomically@1.7.0": {
       "integrity": "sha512-Xcz9l0z7y9yQ9rdDaxlmaI4uJHf/T8g9hOEzJcsEqX2SjCj4J20uK7+ldkDHMbpJDK76wF7xEIgxc/vSlsfw5w=="
     },
+    "atomically@2.1.1": {
+      "integrity": "sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ==",
+      "dependencies": [
+        "stubborn-fs",
+        "when-exit"
+      ]
+    },
     "babel-dead-code-elimination@1.0.12": {
       "integrity": "sha512-GERT7L2TiYcYDtYk1IpD+ASAYXjKbLTDPhBtYj7X1NuRMDTMtAx9kyBenub1Ev41lo91OHCKdmP+egTDmfQ7Ig==",
       "dependencies": [
         "@babel/core",
-        "@babel/parser",
-        "@babel/traverse",
+        "@babel/parser@7.29.8",
+        "@babel/traverse@7.29.8",
         "@babel/types"
       ]
     },
@@ -1940,6 +2371,9 @@
     },
     "balanced-match@4.0.4": {
       "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="
+    },
+    "base64id@2.0.0": {
+      "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog=="
     },
     "baseline-browser-mapping@2.11.15": {
       "integrity": "sha512-FwMjJJ7HnyZpWe+oWxegG0fezZyBZUagI5LZEoO3GCbtbKNwRfMH9Ue5d5v01PNePBy1QSfPSDTTeVL0Hb9EzA==",
@@ -1958,6 +2392,9 @@
         "raw-body",
         "type-is"
       ]
+    },
+    "bowser@2.14.1": {
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="
     },
     "brace-expansion@5.0.9": {
       "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
@@ -2017,11 +2454,20 @@
     "chalk@5.6.2": {
       "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="
     },
+    "chokidar@4.0.3": {
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dependencies": [
+        "readdirp@4.1.2"
+      ]
+    },
     "chokidar@5.0.0": {
       "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
       "dependencies": [
-        "readdirp"
+        "readdirp@5.1.1"
       ]
+    },
+    "citty@0.2.2": {
+      "integrity": "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w=="
     },
     "class-variance-authority@0.7.1": {
       "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
@@ -2064,6 +2510,9 @@
     "commander@11.1.0": {
       "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="
     },
+    "commander@13.1.0": {
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw=="
+    },
     "commander@14.0.3": {
       "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="
     },
@@ -2072,14 +2521,28 @@
       "dependencies": [
         "ajv",
         "ajv-formats@2.1.1_ajv@8.20.0",
-        "atomically",
-        "debounce-fn",
-        "dot-prop",
-        "env-paths",
+        "atomically@1.7.0",
+        "debounce-fn@4.0.0",
+        "dot-prop@6.0.1",
+        "env-paths@2.2.1",
         "json-schema-typed@7.0.3",
         "onetime@5.1.2",
         "pkg-up",
         "semver@7.8.5"
+      ]
+    },
+    "conf@15.1.0": {
+      "integrity": "sha512-Uy5YN9KEu0WWDaZAVJ5FAmZoaJt9rdK6kH+utItPyGsCqCgaTKkrmZx3zoE0/3q6S3bcp3Ihkk+ZqPxWxFK5og==",
+      "dependencies": [
+        "ajv",
+        "ajv-formats@3.0.1_ajv@8.20.0",
+        "atomically@2.1.1",
+        "debounce-fn@6.0.0",
+        "dot-prop@10.2.0",
+        "env-paths@3.0.0",
+        "json-schema-typed@8.0.2",
+        "semver@7.8.5",
+        "uint8array-extras"
       ]
     },
     "consola@3.4.2": {
@@ -2116,7 +2579,7 @@
     "cosmiconfig@9.0.2_typescript@6.0.3": {
       "integrity": "sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg==",
       "dependencies": [
-        "env-paths",
+        "env-paths@2.2.1",
         "import-fresh",
         "js-yaml",
         "parse-json",
@@ -2143,6 +2606,13 @@
         "srvx"
       ]
     },
+    "css-tree@3.2.1": {
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dependencies": [
+        "mdn-data",
+        "source-map-js"
+      ]
+    },
     "cssesc@3.0.0": {
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
       "bin": true
@@ -2167,6 +2637,15 @@
       "dependencies": [
         "mimic-fn@3.1.0"
       ]
+    },
+    "debounce-fn@6.0.0": {
+      "integrity": "sha512-rBMW+F2TXryBwB54Q0d8drNEI+TfoS9JpNTAoVpukbWEhjXQq4rySFYLaqXMFXwdv61Zb2OHtj5bviSoimqxRQ==",
+      "dependencies": [
+        "mimic-function"
+      ]
+    },
+    "debounce@2.2.0": {
+      "integrity": "sha512-Xks6RUDLZFdz8LIdR6q0MTH44k7FikOmnh5xkSjMig6ch45afc8sjTjRQf3P6ax8dMgcQrYO/AR2RGWURrruqw=="
     },
     "debug@4.4.3": {
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
@@ -2205,6 +2684,37 @@
     "diff@8.0.4": {
       "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="
     },
+    "dom-serializer@2.0.0": {
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dependencies": [
+        "domelementtype",
+        "domhandler",
+        "entities"
+      ]
+    },
+    "domelementtype@2.3.0": {
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="
+    },
+    "domhandler@5.0.3": {
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dependencies": [
+        "domelementtype"
+      ]
+    },
+    "domutils@3.2.2": {
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "dependencies": [
+        "dom-serializer",
+        "domelementtype",
+        "domhandler"
+      ]
+    },
+    "dot-prop@10.2.0": {
+      "integrity": "sha512-BTJ9aZYL3vCfZlZOBLy9v8TUqWGQ0pzFnygKwFZt5udj6viBoFIBviKPUoZLDCPn1FoXffv6McQFDenrm5Krfw==",
+      "dependencies": [
+        "type-fest"
+      ]
+    },
     "dot-prop@6.0.1": {
       "integrity": "sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==",
       "dependencies": [
@@ -2219,9 +2729,9 @@
       "dependencies": [
         "@drizzle-team/brocli",
         "@js-temporal/polyfill",
-        "esbuild",
+        "esbuild@0.25.12",
         "get-tsconfig",
-        "jiti"
+        "jiti@2.7.0"
       ],
       "bin": true
     },
@@ -2271,6 +2781,24 @@
     "encodeurl@2.0.0": {
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="
     },
+    "engine.io-parser@5.2.3": {
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q=="
+    },
+    "engine.io@6.6.9": {
+      "integrity": "sha512-clKkw4C7nJ22mGgoVcCg6V/W/TxdNyIOTr89k2ONZu81qqkddPFDF0LXcbAwhzPD8DjkiRCjzuiO6Y+fkpD4vg==",
+      "dependencies": [
+        "@types/cors",
+        "@types/node",
+        "@types/ws",
+        "accepts@1.3.8",
+        "base64id",
+        "cookie",
+        "cors",
+        "debug",
+        "engine.io-parser",
+        "ws"
+      ]
+    },
     "enhanced-resolve@5.24.5": {
       "integrity": "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==",
       "dependencies": [
@@ -2285,8 +2813,14 @@
         "strip-ansi@6.0.1"
       ]
     },
+    "entities@4.5.0": {
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="
+    },
     "env-paths@2.2.1": {
       "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="
+    },
+    "env-paths@3.0.0": {
+      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A=="
     },
     "env-runner@0.1.16": {
       "integrity": "sha512-2LRJM4P2KLX6J83QZZrMqvgCDt/D5ea7wPcI3yYiy5cG/9rX5QwdwZFx0D7ktWnjdRyZxYjttGGorb5nFqb1CA==",
@@ -2322,32 +2856,65 @@
     "esbuild@0.25.12": {
       "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
       "optionalDependencies": [
-        "@esbuild/aix-ppc64",
-        "@esbuild/android-arm",
-        "@esbuild/android-arm64",
-        "@esbuild/android-x64",
-        "@esbuild/darwin-arm64",
-        "@esbuild/darwin-x64",
-        "@esbuild/freebsd-arm64",
-        "@esbuild/freebsd-x64",
-        "@esbuild/linux-arm",
-        "@esbuild/linux-arm64",
-        "@esbuild/linux-ia32",
-        "@esbuild/linux-loong64",
-        "@esbuild/linux-mips64el",
-        "@esbuild/linux-ppc64",
-        "@esbuild/linux-riscv64",
-        "@esbuild/linux-s390x",
-        "@esbuild/linux-x64",
-        "@esbuild/netbsd-arm64",
-        "@esbuild/netbsd-x64",
-        "@esbuild/openbsd-arm64",
-        "@esbuild/openbsd-x64",
-        "@esbuild/openharmony-arm64",
-        "@esbuild/sunos-x64",
-        "@esbuild/win32-arm64",
-        "@esbuild/win32-ia32",
-        "@esbuild/win32-x64"
+        "@esbuild/aix-ppc64@0.25.12",
+        "@esbuild/android-arm@0.25.12",
+        "@esbuild/android-arm64@0.25.12",
+        "@esbuild/android-x64@0.25.12",
+        "@esbuild/darwin-arm64@0.25.12",
+        "@esbuild/darwin-x64@0.25.12",
+        "@esbuild/freebsd-arm64@0.25.12",
+        "@esbuild/freebsd-x64@0.25.12",
+        "@esbuild/linux-arm@0.25.12",
+        "@esbuild/linux-arm64@0.25.12",
+        "@esbuild/linux-ia32@0.25.12",
+        "@esbuild/linux-loong64@0.25.12",
+        "@esbuild/linux-mips64el@0.25.12",
+        "@esbuild/linux-ppc64@0.25.12",
+        "@esbuild/linux-riscv64@0.25.12",
+        "@esbuild/linux-s390x@0.25.12",
+        "@esbuild/linux-x64@0.25.12",
+        "@esbuild/netbsd-arm64@0.25.12",
+        "@esbuild/netbsd-x64@0.25.12",
+        "@esbuild/openbsd-arm64@0.25.12",
+        "@esbuild/openbsd-x64@0.25.12",
+        "@esbuild/openharmony-arm64@0.25.12",
+        "@esbuild/sunos-x64@0.25.12",
+        "@esbuild/win32-arm64@0.25.12",
+        "@esbuild/win32-ia32@0.25.12",
+        "@esbuild/win32-x64@0.25.12"
+      ],
+      "scripts": true,
+      "bin": true
+    },
+    "esbuild@0.28.2": {
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "optionalDependencies": [
+        "@esbuild/aix-ppc64@0.28.2",
+        "@esbuild/android-arm@0.28.2",
+        "@esbuild/android-arm64@0.28.2",
+        "@esbuild/android-x64@0.28.2",
+        "@esbuild/darwin-arm64@0.28.2",
+        "@esbuild/darwin-x64@0.28.2",
+        "@esbuild/freebsd-arm64@0.28.2",
+        "@esbuild/freebsd-x64@0.28.2",
+        "@esbuild/linux-arm@0.28.2",
+        "@esbuild/linux-arm64@0.28.2",
+        "@esbuild/linux-ia32@0.28.2",
+        "@esbuild/linux-loong64@0.28.2",
+        "@esbuild/linux-mips64el@0.28.2",
+        "@esbuild/linux-ppc64@0.28.2",
+        "@esbuild/linux-riscv64@0.28.2",
+        "@esbuild/linux-s390x@0.28.2",
+        "@esbuild/linux-x64@0.28.2",
+        "@esbuild/netbsd-arm64@0.28.2",
+        "@esbuild/netbsd-x64@0.28.2",
+        "@esbuild/openbsd-arm64@0.28.2",
+        "@esbuild/openbsd-x64@0.28.2",
+        "@esbuild/openharmony-arm64@0.28.2",
+        "@esbuild/sunos-x64@0.28.2",
+        "@esbuild/win32-arm64@0.28.2",
+        "@esbuild/win32-ia32@0.28.2",
+        "@esbuild/win32-x64@0.28.2"
       ],
       "scripts": true,
       "bin": true
@@ -2425,7 +2992,7 @@
     "express@5.2.1": {
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "dependencies": [
-        "accepts",
+        "accepts@2.0.0",
         "body-parser",
         "content-disposition",
         "content-type@1.0.5",
@@ -2440,7 +3007,7 @@
         "fresh",
         "http-errors",
         "merge-descriptors",
-        "mime-types",
+        "mime-types@3.0.2",
         "on-finished",
         "once",
         "parseurl",
@@ -2476,6 +3043,9 @@
         "merge2",
         "micromatch"
       ]
+    },
+    "fast-sha256@1.3.0": {
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ=="
     },
     "fast-uri@3.1.5": {
       "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw=="
@@ -2621,6 +3191,14 @@
         "is-glob"
       ]
     },
+    "glob@13.0.6": {
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dependencies": [
+        "minimatch",
+        "minipass",
+        "path-scurry"
+      ]
+    },
     "goober@2.1.19_csstype@3.2.3": {
       "integrity": "sha512-U7veizMqxyKlM58+Z5j2ngJBH/r9siDmxpvNxSw0PylF6WQvrASJEZrxh1hidRBJc2jqoBVSyOban5u8m+6Rxg==",
       "dependencies": [
@@ -2667,6 +3245,28 @@
     },
     "hookable@6.1.1": {
       "integrity": "sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ=="
+    },
+    "html-to-text@9.0.5": {
+      "integrity": "sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==",
+      "dependencies": [
+        "@selderee/plugin-htmlparser2",
+        "deepmerge",
+        "dom-serializer",
+        "htmlparser2",
+        "selderee"
+      ]
+    },
+    "html5parser@3.0.0": {
+      "integrity": "sha512-iNpSopa+4YHX50UOk825tBy7MghmXHo/ZpLskBYN0kAr1xhH8GlIMk5bLRXcZlfP3AnLUcSuFMu8C4MdOUxA8A=="
+    },
+    "htmlparser2@8.0.2": {
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "dependencies": [
+        "domelementtype",
+        "domhandler",
+        "domutils",
+        "entities"
+      ]
     },
     "http-errors@2.0.1": {
       "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
@@ -2799,6 +3399,10 @@
     "isexe@3.1.5": {
       "integrity": "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w=="
     },
+    "jiti@2.6.1": {
+      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "bin": true
+    },
     "jiti@2.7.0": {
       "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
       "bin": true
@@ -2860,7 +3464,7 @@
         "fdir",
         "formatly",
         "get-tsconfig",
-        "jiti",
+        "jiti@2.7.0",
         "oxc-parser@0.143.0",
         "oxc-resolver",
         "picomatch@4.0.5",
@@ -2882,6 +3486,9 @@
         "picocolors",
         "shell-quote"
       ]
+    },
+    "leac@0.6.0": {
+      "integrity": "sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg=="
     },
     "lightningcss-android-arm64@1.32.0": {
       "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
@@ -3048,6 +3655,16 @@
         "is-unicode-supported@1.3.0"
       ]
     },
+    "log-symbols@7.0.1": {
+      "integrity": "sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==",
+      "dependencies": [
+        "is-unicode-supported@2.1.0",
+        "yoctocolors"
+      ]
+    },
+    "lru-cache@11.5.2": {
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g=="
+    },
     "lru-cache@5.1.1": {
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dependencies": [
@@ -3060,8 +3677,15 @@
         "@jridgewell/sourcemap-codec"
       ]
     },
+    "marked@15.0.12": {
+      "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+      "bin": true
+    },
     "math-intrinsics@1.1.0": {
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
+    },
+    "mdn-data@2.27.1": {
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ=="
     },
     "media-typer@1.1.1": {
       "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ=="
@@ -3082,13 +3706,22 @@
         "picomatch@2.3.2"
       ]
     },
+    "mime-db@1.52.0": {
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
+    },
     "mime-db@1.54.0": {
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="
+    },
+    "mime-types@2.1.35": {
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": [
+        "mime-db@1.52.0"
+      ]
     },
     "mime-types@3.0.2": {
       "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "dependencies": [
-        "mime-db"
+        "mime-db@1.54.0"
       ]
     },
     "mimic-fn@2.1.0": {
@@ -3108,6 +3741,9 @@
     },
     "minimist@1.2.8": {
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="
+    },
+    "minipass@7.1.3": {
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="
     },
     "ms@2.1.3": {
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
@@ -3137,6 +3773,9 @@
     "nanoid@3.3.18": {
       "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "bin": true
+    },
+    "negotiator@0.6.3": {
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
     },
     "negotiator@1.0.0": {
       "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="
@@ -3178,6 +3817,9 @@
     "node-releases@2.0.53": {
       "integrity": "sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ=="
     },
+    "normalize-path@3.0.0": {
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
+    },
     "npm-run-path@4.0.1": {
       "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
       "dependencies": [
@@ -3190,6 +3832,15 @@
         "path-key@4.0.0",
         "unicorn-magic"
       ]
+    },
+    "nypm@0.6.6": {
+      "integrity": "sha512-vRyr0r4cbBapw07Xw8xrj9Teq3o7MUD35rSaTcanDbW+aK2XHDgJFiU6ZTj2GBw7Q12ysdsyFss+Vdz4hQ0Y6Q==",
+      "dependencies": [
+        "citty",
+        "pathe",
+        "tinyexec"
+      ],
+      "bin": true
     },
     "object-assign@4.1.1": {
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
@@ -3275,7 +3926,7 @@
         "cli-spinners",
         "is-interactive",
         "is-unicode-supported@2.1.0",
-        "log-symbols",
+        "log-symbols@6.0.0",
         "stdin-discarder",
         "string-width@7.2.0",
         "strip-ansi@7.2.0"
@@ -3393,6 +4044,13 @@
     "parse-ms@4.0.0": {
       "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw=="
     },
+    "parseley@0.12.1": {
+      "integrity": "sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==",
+      "dependencies": [
+        "leac",
+        "peberminta"
+      ]
+    },
     "parseurl@1.3.3": {
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
     },
@@ -3411,11 +4069,21 @@
     "path-key@4.0.0": {
       "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="
     },
+    "path-scurry@2.0.2": {
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dependencies": [
+        "lru-cache@11.5.2",
+        "minipass"
+      ]
+    },
     "path-to-regexp@8.4.2": {
       "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="
     },
     "pathe@2.0.3": {
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="
+    },
+    "peberminta@0.9.0": {
+      "integrity": "sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ=="
     },
     "picocolors@1.1.1": {
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
@@ -3426,6 +4094,9 @@
     "picomatch@4.0.5": {
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="
     },
+    "picospinner@3.1.2": {
+      "integrity": "sha512-0Z++uU8mvB0EvCPAEUq9BGiPcSravzJ+RPdXfjYlzXffqsogisiKRQqI6ctrSSJ6n985vxrgKtQ5n4sRINcJZg=="
+    },
     "pkce-challenge@5.0.1": {
       "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="
     },
@@ -3434,6 +4105,9 @@
       "dependencies": [
         "find-up"
       ]
+    },
+    "postal-mime@2.7.5": {
+      "integrity": "sha512-GNEXKvWFQnbgO5NlrGzVa0FmWzBZ24PersAWErttSg1Hjpf0ATxTwS5DOMGaOpTG6bUh5cTr7xi0jAD942wCJA=="
     },
     "postcss-selector-parser@7.1.5": {
       "integrity": "sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==",
@@ -3468,6 +4142,9 @@
       "dependencies": [
         "parse-ms"
       ]
+    },
+    "prismjs@1.30.0": {
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw=="
     },
     "prompts@2.4.2": {
       "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
@@ -3515,8 +4192,41 @@
         "scheduler"
       ]
     },
+    "react-email@6.9.2_react@19.2.8_react-dom@19.2.8__react@19.2.8": {
+      "integrity": "sha512-A6SiRdH1U7qJcfgpaJ1BYGud8GbnPwDw61l3PP3JR1qMAmBgTlL02UuCPwPOClwc1x+saUU9OxJfPQHMNaTBMA==",
+      "dependencies": [
+        "@babel/parser@7.29.2",
+        "@babel/traverse@7.29.0",
+        "@react-email/render",
+        "chokidar@4.0.3",
+        "commander@13.1.0",
+        "conf@15.1.0",
+        "css-tree",
+        "debounce",
+        "esbuild@0.28.2",
+        "glob",
+        "jiti@2.6.1",
+        "log-symbols@7.0.1",
+        "marked",
+        "mime-types@3.0.2",
+        "normalize-path",
+        "nypm",
+        "picospinner",
+        "prismjs",
+        "prompts",
+        "react",
+        "react-dom",
+        "socket.io",
+        "tailwindcss",
+        "tsconfig-paths"
+      ],
+      "bin": true
+    },
     "react@19.2.8": {
       "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw=="
+    },
+    "readdirp@4.1.2": {
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="
     },
     "readdirp@5.1.1": {
       "integrity": "sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA=="
@@ -3539,6 +4249,13 @@
     },
     "reselect@5.2.0": {
       "integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw=="
+    },
+    "resend@6.21.0": {
+      "integrity": "sha512-XT1eP2iA8rZ51NSO2CJlL1ZE2baBoPpOGMgz2p0o2uluz/YU3XfItpGymXDlL0Sp2Mc+y9+Xxsfdccfi4f2FzQ==",
+      "dependencies": [
+        "postal-mime",
+        "standardwebhooks"
+      ]
     },
     "resolve-from@4.0.0": {
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
@@ -3608,6 +4325,12 @@
     "scheduler@0.27.0": {
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="
     },
+    "selderee@0.11.0": {
+      "integrity": "sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==",
+      "dependencies": [
+        "parseley"
+      ]
+    },
     "semver@6.3.1": {
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "bin": true
@@ -3625,7 +4348,7 @@
         "etag",
         "fresh",
         "http-errors",
-        "mime-types",
+        "mime-types@3.0.2",
         "ms",
         "on-finished",
         "range-parser",
@@ -3666,7 +4389,7 @@
       "integrity": "sha512-tUFZgkYmfVNQVm3xX7lhSzOvDsp+O14ac5dwgXIr5mIsr79ISueb/Mu+ZtWMz0DH6v77u4eYyvbQ9TTMpSn3aw==",
       "dependencies": [
         "@babel/core",
-        "@babel/parser",
+        "@babel/parser@7.29.8",
         "@babel/plugin-transform-typescript",
         "@babel/preset-typescript",
         "@dotenvx/dotenvx",
@@ -3802,6 +4525,32 @@
     "smol-toml@1.8.0": {
       "integrity": "sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ=="
     },
+    "socket.io-adapter@2.5.8": {
+      "integrity": "sha512-6Oy52pbg+kvdCVvjcN+FnY7BvxZ7cIHNScbvztT/It5d0vbwoJoVZmF2gjJmnV0/4WlXRfG15zc45ySk9Ah8bw==",
+      "dependencies": [
+        "debug",
+        "ws"
+      ]
+    },
+    "socket.io-parser@4.2.7": {
+      "integrity": "sha512-IH/iSeO9T6gz1KkFleGDWkG9N3dl4jXVYUtMhIqH10Md0ttMer8nUNWiP1DKuNrybD2xBrixLJdCC9J6ECoYkg==",
+      "dependencies": [
+        "@socket.io/component-emitter",
+        "debug"
+      ]
+    },
+    "socket.io@4.8.3": {
+      "integrity": "sha512-2Dd78bqzzjE6KPkD5fHZmDAKRNe3J15q+YHDrIsy9WEkqttc7GY+kT9OBLSMaPbQaEd0x1BjcmtMtXkfpc+T5A==",
+      "dependencies": [
+        "accepts@1.3.8",
+        "base64id",
+        "cors",
+        "debug",
+        "engine.io",
+        "socket.io-adapter",
+        "socket.io-parser"
+      ]
+    },
     "socks@2.8.9": {
       "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
       "dependencies": [
@@ -3832,6 +4581,13 @@
     },
     "stackback@0.0.2": {
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="
+    },
+    "standardwebhooks@1.0.0": {
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "dependencies": [
+        "@stablelib/base64",
+        "fast-sha256"
+      ]
     },
     "statuses@2.0.2": {
       "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="
@@ -3890,10 +4646,22 @@
     "strip-json-comments@5.0.3": {
       "integrity": "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw=="
     },
+    "stubborn-fs@2.0.0": {
+      "integrity": "sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==",
+      "dependencies": [
+        "stubborn-utils"
+      ]
+    },
+    "stubborn-utils@1.0.2": {
+      "integrity": "sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg=="
+    },
     "systeminformation@5.33.1": {
       "integrity": "sha512-DEN6ICHk3Tk0Uf/hrAHh7xlt7iL5CJFBtPZinA0H62DrGG/KPKqq/Nzj6lCXPS4Ay/sf/14zNnk9LpqKzBIc+w==",
       "os": ["darwin", "linux", "win32", "freebsd", "openbsd", "netbsd", "sunos", "android"],
       "bin": true
+    },
+    "tagged-tag@1.0.0": {
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng=="
     },
     "tailwind-merge@3.6.0": {
       "integrity": "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w=="
@@ -3953,12 +4721,18 @@
     "tw-animate-css@1.4.0": {
       "integrity": "sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ=="
     },
+    "type-fest@5.8.0": {
+      "integrity": "sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==",
+      "dependencies": [
+        "tagged-tag"
+      ]
+    },
     "type-is@2.1.0": {
       "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "dependencies": [
         "content-type@2.1.0",
         "media-typer",
-        "mime-types"
+        "mime-types@3.0.2"
       ]
     },
     "typescript@6.0.3": {
@@ -3968,8 +4742,14 @@
     "ufo@1.6.4": {
       "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA=="
     },
+    "uint8array-extras@1.5.0": {
+      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A=="
+    },
     "unbash@4.0.10": {
       "integrity": "sha512-b7zoBQvpWp0vuN5q2vK2RRBR2SvuruQAs50DApdDveBSn3eSYd84IaHodFqQIMlvY9K2VnyBUEXgwOBuGU9GBg=="
+    },
+    "undici-types@8.3.0": {
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="
     },
     "undici@7.29.0": {
       "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw=="
@@ -4097,6 +4877,9 @@
     "webpack-virtual-modules@0.6.2": {
       "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ=="
     },
+    "when-exit@2.1.5": {
+      "integrity": "sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg=="
+    },
     "which@2.0.2": {
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "dependencies": [
@@ -4199,6 +4982,7 @@
   "workspace": {
     "packageJson": {
       "dependencies": [
+        "npm:@aws-sdk/client-sesv2@^3.1115.0",
         "npm:@base-ui/react@^1.6.0",
         "npm:@csstools/color-helpers@6.1.0",
         "npm:@csstools/css-color-parser@4.1.10",
@@ -4228,7 +5012,9 @@
         "npm:nitro@3.0.260610-beta",
         "npm:postgres@^3.4.9",
         "npm:react-dom@^19.2.6",
+        "npm:react-email@^6.9.2",
         "npm:react@^19.2.6",
+        "npm:resend@^6.21.0",
         "npm:shadcn@^4.13.0",
         "npm:sharp@~0.34.3",
         "npm:tailwind-merge@^3.6.0",

--- a/webapp/knip.jsonc
+++ b/webapp/knip.jsonc
@@ -18,10 +18,14 @@
   },
   // shadcn uses this package when generating components for the configured Phosphor icon library.
   "ignoreDependencies": ["@phosphor-icons/react"],
-  // Keep Deno-run generators, the server-only database client, and reusable PostgreSQL column helpers as explicit application extension points.
+  // Keep Deno-run generators, the server-only database client, reusable PostgreSQL column helpers,
+  // and the email sender as explicit application extension points. Email templates are entries too:
+  // `scripts/preview-emails.ts` discovers them by reading the directory, not by importing them.
   "entry": [
     "scripts/*.ts",
     "src/db/index.server.ts",
-    "src/db/postgresql-types.server.ts"
+    "src/db/postgresql-types.server.ts",
+    "src/emails/index.ts",
+    "src/emails/templates/*.tsx"
   ]
 }

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -14,6 +14,7 @@
     "db": "drizzle-kit",
     "format": "deno fmt",
     "format:check": "deno fmt --check",
+    "email": "deno run -P=tooling scripts/preview-emails.ts",
     "generate:png": "deno run -P=tooling scripts/export-png.ts",
     "knip": "knip",
     "knip:fix": "knip --fix --allow-remove-files && knip --fix --allow-remove-files && SHARP_IGNORE_GLOBAL_LIBVIPS=1 deno install",
@@ -26,6 +27,7 @@
     "ui": "shadcn"
   },
   "dependencies": {
+    "@aws-sdk/client-sesv2": "^3.1115.0",
     "@base-ui/react": "^1.6.0",
     "@csstools/color-helpers": "6.1.0",
     "@csstools/css-color-parser": "4.1.10",
@@ -47,6 +49,8 @@
     "postgres": "^3.4.9",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
+    "react-email": "^6.9.2",
+    "resend": "^6.21.0",
     "shadcn": "^4.13.0",
     "tailwind-merge": "^3.6.0",
     "tw-animate-css": "^1.4.0"

--- a/webapp/scripts/preview-emails.ts
+++ b/webapp/scripts/preview-emails.ts
@@ -1,0 +1,98 @@
+// tsconfig.json declares only ES2025 and DOM libs, so the Deno namespace is pulled in per file.
+/// <reference lib="deno.ns" />
+import { readdir, stat } from "node:fs/promises"
+import { dirname, join } from "node:path"
+import process from "node:process"
+import { fileURLToPath } from "node:url"
+import { createElement } from "react"
+import type { ComponentType } from "react"
+import { render } from "react-email"
+
+const templatesDirectory = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "src",
+  "emails",
+  "templates",
+)
+
+const port = Number(process.env.PORT ?? "3002")
+
+if (!Number.isInteger(port) || port <= 0) {
+  throw new Error(`PORT must be a positive integer; received ${process.env.PORT}`)
+}
+
+interface TemplateModule {
+  default: ComponentType<Record<string, unknown>> & { PreviewProps?: Record<string, unknown> }
+}
+
+async function listTemplateNames() {
+  const entries = await readdir(templatesDirectory, { withFileTypes: true })
+  return entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".tsx"))
+    .map((entry) => entry.name.slice(0, -".tsx".length))
+    .toSorted()
+}
+
+async function renderTemplate(name: string, plainText: boolean) {
+  const path = join(templatesDirectory, `${name}.tsx`)
+  // Bust Deno's module cache with the file's mtime so edits show up on reload without a restart.
+  const { mtimeMs } = await stat(path)
+  const module: TemplateModule = await import(`${path}?mtime=${mtimeMs}`)
+  const Template = module.default
+
+  if (typeof Template !== "function") {
+    throw new Error(`'${name}.tsx' must default-export a template component`)
+  }
+
+  // `render` discriminates its options on a literal `plainText`, so a boolean variable cannot be
+  // forwarded as one argument.
+  const element = createElement(Template, Template.PreviewProps ?? {})
+  return plainText ? await render(element, { plainText: true }) : await render(element)
+}
+
+function renderIndex(names: string[]) {
+  const items = names
+    .map((name) =>
+      `<li><a href="/${name}">${name}</a> <a href="/${name}?text=1" class="text">plain text</a></li>`
+    )
+    .join("")
+  return `<!doctype html><meta charset="utf-8"><title>Email previews</title>
+<style>
+  body { font: 16px/1.5 system-ui, sans-serif; margin: 3rem auto; max-width: 40rem; }
+  li { margin-block: 0.5rem; }
+  .text { color: #6b7280; font-size: 0.8rem; margin-inline-start: 0.5rem; }
+</style>
+<h1>Email previews</h1>
+${names.length > 0 ? `<ul>${items}</ul>` : "<p>No templates found.</p>"}`
+}
+
+Deno.serve({ port }, async (request) => {
+  const url = new URL(request.url)
+  const name = url.pathname.slice(1)
+
+  try {
+    const names = await listTemplateNames()
+
+    if (name === "") {
+      return new Response(renderIndex(names), {
+        headers: { "content-type": "text/html; charset=utf-8" },
+      })
+    }
+
+    if (!names.includes(name)) {
+      return new Response(`Unknown template '${name}'`, { status: 404 })
+    }
+
+    const plainText = url.searchParams.has("text")
+    return new Response(await renderTemplate(name, plainText), {
+      headers: {
+        "content-type": plainText ? "text/plain; charset=utf-8" : "text/html; charset=utf-8",
+      },
+    })
+  } catch (error) {
+    console.error(error)
+    const message = error instanceof Error ? error.message : String(error)
+    return new Response(`Failed to render '${name}': ${message}`, { status: 500 })
+  }
+})

--- a/webapp/src/emails/index.ts
+++ b/webapp/src/emails/index.ts
@@ -2,45 +2,12 @@
  * Server-only email dispatch. Importing this from browser code would pull provider SDKs and
  * credentials into the client bundle; keep it behind server functions and server routes.
  */
-import { Buffer } from "node:buffer"
-import { render } from "react-email"
-import { EMAIL_FROM_ADDRESS, EMAIL_PROVIDER } from "../lib/config.server.ts"
-import type {
-  EmailAttachment,
-  EmailProvider,
-  ProviderEmailInput,
-  ResolvedEmailAttachment,
-  SendEmailOptions,
-  SendEmailResult,
-  SendProviderEmail,
-} from "./types.ts"
-
-/**
- * Static map of dynamic imports: the selected provider's SDK is the only one ever loaded, while
- * the literal specifiers stay statically analyzable for bundling and unused-file detection.
- */
-const providerLoaders: Record<
-  EmailProvider,
-  () => Promise<{ sendProviderEmail: SendProviderEmail }>
-> = {
-  resend: () => import("./providers/resend.ts"),
-  ses: () => import("./providers/ses.ts"),
-}
-
-const CONTENT_TYPES_BY_EXTENSION: Record<string, string> = {
-  csv: "text/csv",
-  gif: "image/gif",
-  html: "text/html",
-  ics: "text/calendar",
-  jpeg: "image/jpeg",
-  jpg: "image/jpeg",
-  json: "application/json",
-  pdf: "application/pdf",
-  png: "image/png",
-  svg: "image/svg+xml",
-  txt: "text/plain",
-  zip: "application/zip",
-}
+import { createElement } from "react"
+import { APP_BASE_URL } from "../lib/config.server.ts"
+import { APP_NAME } from "../lib/config.ts"
+import EmailVerificationEmail from "./templates/email-verification.tsx"
+import type { EmailProvider, SendEmailOptions, SendEmailResult } from "./types.ts"
+import { buildProviderEmailInput, providerLoaders, resolveProvider } from "./utils.server.ts"
 
 export async function sendEmail(options: SendEmailOptions): Promise<SendEmailResult> {
   const provider = resolveProvider(options.provider)
@@ -50,91 +17,28 @@ export async function sendEmail(options: SendEmailOptions): Promise<SendEmailRes
   return { ...result, provider }
 }
 
-function resolveProvider(provider: SendEmailOptions["provider"]): EmailProvider {
-  const resolved = provider ?? EMAIL_PROVIDER
-  if (!resolved) {
-    throw new Error("No email provider given and 'EMAIL_PROVIDER' environment variable is not set")
-  }
-  if (!(resolved in providerLoaders)) {
-    throw new Error(`Unknown email provider '${resolved}'`)
-  }
-  return resolved as EmailProvider
-}
-
-async function buildProviderEmailInput(options: SendEmailOptions): Promise<ProviderEmailInput> {
-  const { react } = options
-  const html = options.html ?? (react ? await render(react) : undefined)
-  if (!html) {
-    throw new Error("An email needs either a 'react' template or 'html' content")
-  }
-
-  const from = options.from ?? EMAIL_FROM_ADDRESS
-  if (!from) {
-    throw new Error(
-      "No 'from' address given and 'EMAIL_FROM_ADDRESS' environment variable is not set",
-    )
-  }
-
-  const text = options.text ?? (react ? await render(react, { plainText: true }) : undefined)
-
-  return {
-    to: toArray(options.to),
-    from,
-    subject: options.subject,
-    html,
-    ...text ? { text } : {},
-    replyTo: toArray(options.replyTo),
-    attachments: await Promise.all((options.attachments ?? []).map(resolveAttachment)),
-  }
-}
-
-function toArray(value: string | string[] | undefined): string[] {
-  if (!value) return []
-  return Array.isArray(value) ? value : [value]
-}
-
-/**
- * Attachments are resolved to bytes here rather than per provider, because SES has to build its own
- * MIME parts and cannot fetch a remote attachment the way Resend can.
- */
-async function resolveAttachment(attachment: EmailAttachment): Promise<ResolvedEmailAttachment> {
-  const { filename, path } = attachment
-  const resolved = /^https?:\/\//i.test(path) ? await fetchAttachment(path) : decodeBase64(path)
-  return {
-    filename,
-    contentType: resolved.contentType ?? guessContentType(filename),
-    content: resolved.content,
-  }
-}
-
-interface ResolvedAttachmentContent {
-  content: Uint8Array
-  /** Media type reported by the source, when it reports one. */
-  contentType?: string | undefined
-}
-
-async function fetchAttachment(url: string): Promise<ResolvedAttachmentContent> {
-  const response = await fetch(url)
-  if (!response.ok) {
-    throw new Error(`Failed to fetch email attachment '${url}': ${response.status}`)
-  }
-  return {
-    content: new Uint8Array(await response.arrayBuffer()),
-    contentType: response.headers.get("content-type")?.split(";")[0]?.trim() || undefined,
-  }
-}
-
-/** Accepts either a bare base64 payload or a full `data:` URI. */
-function decodeBase64(path: string): ResolvedAttachmentContent {
-  const dataUri = /^data:([^;,]*)?(?:;[^,]*)*,/i.exec(path)
-  const base64 = dataUri ? path.slice(dataUri[0].length) : path
-  return {
-    content: new Uint8Array(Buffer.from(base64, "base64")),
-    contentType: dataUri?.[1] || undefined,
-  }
-}
-
-function guessContentType(filename: string): string {
-  const extension = filename.split(".").pop()?.toLowerCase() ?? ""
-  return CONTENT_TYPES_BY_EXTENSION[extension] ?? "application/octet-stream"
+// One `send<Template>Email` wrapper per template in `./templates`: it owns that template's subject
+// and props, and passes `from`, `replyTo`, and `provider` through so `sendEmail` applies the
+// defaults for whichever the caller leaves out.
+export async function sendVerificationEmail(options: {
+  to: string
+  from?: string | undefined
+  replyTo?: string | string[] | undefined
+  provider?: EmailProvider | undefined
+  verificationUrl: string
+  expiryMinutes: number
+}): Promise<SendEmailResult> {
+  return await sendEmail({
+    to: options.to,
+    from: options.from,
+    replyTo: options.replyTo,
+    provider: options.provider,
+    subject: `Verify your email on ${APP_NAME}`,
+    react: createElement(EmailVerificationEmail, {
+      logoUrl: `${APP_BASE_URL}/astralbeam-logo-light.png`,
+      verificationUrl: options.verificationUrl,
+      expiryMinutes: options.expiryMinutes,
+      email: options.to,
+    }),
+  })
 }

--- a/webapp/src/emails/index.ts
+++ b/webapp/src/emails/index.ts
@@ -1,0 +1,133 @@
+/**
+ * Server-only email dispatch. Importing this from browser code would pull provider SDKs and
+ * credentials into the client bundle; keep it behind server functions and server routes.
+ */
+import process from "node:process"
+import { Buffer } from "node:buffer"
+import { render } from "react-email"
+import type {
+  EmailAttachment,
+  EmailProvider,
+  ProviderEmailInput,
+  ResolvedEmailAttachment,
+  SendEmailOptions,
+  SendEmailResult,
+  SendProviderEmail,
+} from "./types.ts"
+
+/**
+ * Static map of dynamic imports: the selected provider's SDK is the only one ever loaded, while
+ * the literal specifiers stay statically analyzable for bundling and unused-file detection.
+ */
+const providerLoaders: Record<
+  EmailProvider,
+  () => Promise<{ sendProviderEmail: SendProviderEmail }>
+> = {
+  resend: () => import("./providers/resend.ts"),
+  ses: () => import("./providers/ses.ts"),
+}
+
+const CONTENT_TYPES_BY_EXTENSION: Record<string, string> = {
+  csv: "text/csv",
+  gif: "image/gif",
+  html: "text/html",
+  ics: "text/calendar",
+  jpeg: "image/jpeg",
+  jpg: "image/jpeg",
+  json: "application/json",
+  pdf: "application/pdf",
+  png: "image/png",
+  svg: "image/svg+xml",
+  txt: "text/plain",
+  zip: "application/zip",
+}
+
+export async function sendEmail(options: SendEmailOptions): Promise<SendEmailResult> {
+  const provider = resolveProvider(options.provider)
+  const input = await buildProviderEmailInput(options)
+  const { sendProviderEmail } = await providerLoaders[provider]()
+  const result = await sendProviderEmail(input)
+  return { ...result, provider }
+}
+
+function resolveProvider(provider: SendEmailOptions["provider"]): EmailProvider {
+  const resolved = provider ?? process.env.EMAIL_PROVIDER
+  if (!resolved) {
+    throw new Error("No email provider given and 'EMAIL_PROVIDER' environment variable is not set")
+  }
+  if (!(resolved in providerLoaders)) {
+    throw new Error(`Unknown email provider '${resolved}'`)
+  }
+  return resolved as EmailProvider
+}
+
+async function buildProviderEmailInput(options: SendEmailOptions): Promise<ProviderEmailInput> {
+  const { react } = options
+  const html = options.html ?? (react ? await render(react) : undefined)
+  if (!html) {
+    throw new Error("An email needs either a 'react' template or 'html' content")
+  }
+
+  const text = options.text ?? (react ? await render(react, { plainText: true }) : undefined)
+
+  return {
+    to: toArray(options.to),
+    from: options.from,
+    subject: options.subject,
+    html,
+    ...text ? { text } : {},
+    replyTo: toArray(options.replyTo),
+    attachments: await Promise.all((options.attachments ?? []).map(resolveAttachment)),
+  }
+}
+
+function toArray(value: string | string[] | undefined): string[] {
+  if (!value) return []
+  return Array.isArray(value) ? value : [value]
+}
+
+/**
+ * Attachments are resolved to bytes here rather than per provider, because SES has to build its own
+ * MIME parts and cannot fetch a remote attachment the way Resend can.
+ */
+async function resolveAttachment(attachment: EmailAttachment): Promise<ResolvedEmailAttachment> {
+  const { filename, path } = attachment
+  const resolved = /^https?:\/\//i.test(path) ? await fetchAttachment(path) : decodeBase64(path)
+  return {
+    filename,
+    contentType: resolved.contentType ?? guessContentType(filename),
+    content: resolved.content,
+  }
+}
+
+interface ResolvedAttachmentContent {
+  content: Uint8Array
+  /** Media type reported by the source, when it reports one. */
+  contentType?: string | undefined
+}
+
+async function fetchAttachment(url: string): Promise<ResolvedAttachmentContent> {
+  const response = await fetch(url)
+  if (!response.ok) {
+    throw new Error(`Failed to fetch email attachment '${url}': ${response.status}`)
+  }
+  return {
+    content: new Uint8Array(await response.arrayBuffer()),
+    contentType: response.headers.get("content-type")?.split(";")[0]?.trim() || undefined,
+  }
+}
+
+/** Accepts either a bare base64 payload or a full `data:` URI. */
+function decodeBase64(path: string): ResolvedAttachmentContent {
+  const dataUri = /^data:([^;,]*)?(?:;[^,]*)*,/i.exec(path)
+  const base64 = dataUri ? path.slice(dataUri[0].length) : path
+  return {
+    content: new Uint8Array(Buffer.from(base64, "base64")),
+    contentType: dataUri?.[1] || undefined,
+  }
+}
+
+function guessContentType(filename: string): string {
+  const extension = filename.split(".").pop()?.toLowerCase() ?? ""
+  return CONTENT_TYPES_BY_EXTENSION[extension] ?? "application/octet-stream"
+}

--- a/webapp/src/emails/index.ts
+++ b/webapp/src/emails/index.ts
@@ -2,9 +2,9 @@
  * Server-only email dispatch. Importing this from browser code would pull provider SDKs and
  * credentials into the client bundle; keep it behind server functions and server routes.
  */
-import process from "node:process"
 import { Buffer } from "node:buffer"
 import { render } from "react-email"
+import { EMAIL_FROM_ADDRESS, EMAIL_PROVIDER } from "../lib/config.server.ts"
 import type {
   EmailAttachment,
   EmailProvider,
@@ -51,7 +51,7 @@ export async function sendEmail(options: SendEmailOptions): Promise<SendEmailRes
 }
 
 function resolveProvider(provider: SendEmailOptions["provider"]): EmailProvider {
-  const resolved = provider ?? process.env.EMAIL_PROVIDER
+  const resolved = provider ?? EMAIL_PROVIDER
   if (!resolved) {
     throw new Error("No email provider given and 'EMAIL_PROVIDER' environment variable is not set")
   }
@@ -68,11 +68,18 @@ async function buildProviderEmailInput(options: SendEmailOptions): Promise<Provi
     throw new Error("An email needs either a 'react' template or 'html' content")
   }
 
+  const from = options.from ?? EMAIL_FROM_ADDRESS
+  if (!from) {
+    throw new Error(
+      "No 'from' address given and 'EMAIL_FROM_ADDRESS' environment variable is not set",
+    )
+  }
+
   const text = options.text ?? (react ? await render(react, { plainText: true }) : undefined)
 
   return {
     to: toArray(options.to),
-    from: options.from,
+    from,
     subject: options.subject,
     html,
     ...text ? { text } : {},

--- a/webapp/src/emails/index.ts
+++ b/webapp/src/emails/index.ts
@@ -1,13 +1,10 @@
-/**
- * Server-only email dispatch. Importing this from browser code would pull provider SDKs and
- * credentials into the client bundle; keep it behind server functions and server routes.
- */
 import { createElement } from "react"
 import { APP_BASE_URL } from "../lib/config.server.ts"
 import { APP_NAME } from "../lib/config.ts"
 import EmailVerificationEmail from "./templates/email-verification.tsx"
 import type { EmailProvider, SendEmailOptions, SendEmailResult } from "./types.ts"
 import { buildProviderEmailInput, providerLoaders, resolveProvider } from "./utils.server.ts"
+import "@tanstack/react-start/server-only"
 
 export async function sendEmail(options: SendEmailOptions): Promise<SendEmailResult> {
   const provider = resolveProvider(options.provider)
@@ -17,9 +14,6 @@ export async function sendEmail(options: SendEmailOptions): Promise<SendEmailRes
   return { ...result, provider }
 }
 
-// One `send<Template>Email` wrapper per template in `./templates`: it owns that template's subject
-// and props, and passes `from`, `replyTo`, and `provider` through so `sendEmail` applies the
-// defaults for whichever the caller leaves out.
 export async function sendVerificationEmail(options: {
   to: string
   from?: string | undefined

--- a/webapp/src/emails/providers/resend.ts
+++ b/webapp/src/emails/providers/resend.ts
@@ -1,0 +1,31 @@
+import { Buffer } from "node:buffer"
+import { Resend } from "resend"
+import { requireResendConfig } from "../../lib/config.server.ts"
+import type { SendProviderEmail } from "../types.ts"
+
+let client: Resend | undefined
+
+function getClient(): Resend {
+  if (!client) client = new Resend(requireResendConfig().apiKey)
+  return client
+}
+
+export const sendProviderEmail: SendProviderEmail = async (input) => {
+  const { data, error } = await getClient().emails.send({
+    from: input.from,
+    to: input.to,
+    subject: input.subject,
+    html: input.html,
+    ...input.text ? { text: input.text } : {},
+    ...input.replyTo.length > 0 ? { replyTo: input.replyTo } : {},
+    attachments: input.attachments.map(({ filename, contentType, content }) => ({
+      filename,
+      contentType,
+      content: Buffer.from(content),
+    })),
+  })
+  if (error) {
+    throw new Error(`Resend failed to send email: ${error.name}: ${error.message}`)
+  }
+  return { messageId: data?.id }
+}

--- a/webapp/src/emails/providers/ses.ts
+++ b/webapp/src/emails/providers/ses.ts
@@ -1,0 +1,114 @@
+import { Buffer } from "node:buffer"
+import { SendEmailCommand, SESv2Client } from "@aws-sdk/client-sesv2"
+import { requireSesConfig } from "../../lib/config.server.ts"
+import type { ProviderEmailInput, ResolvedEmailAttachment, SendProviderEmail } from "../types.ts"
+
+let client: SESv2Client | undefined
+
+function getClient(): SESv2Client {
+  if (!client) {
+    const { region, accessKeyId, secretAccessKey } = requireSesConfig()
+    client = new SESv2Client({
+      region,
+      // Omitting `credentials` falls through to the SDK's default credential chain (instance role,
+      // SSO, profile). https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html
+      ...accessKeyId && secretAccessKey ? { credentials: { accessKeyId, secretAccessKey } } : {},
+    })
+  }
+  return client
+}
+
+export const sendProviderEmail: SendProviderEmail = async (input) => {
+  const response = await getClient().send(
+    new SendEmailCommand({
+      FromEmailAddress: input.from,
+      Destination: { ToAddresses: input.to },
+      ...input.replyTo.length > 0 ? { ReplyToAddresses: input.replyTo } : {},
+      // SESv2 Simple content cannot carry attachments, so those sends go out as raw MIME.
+      // https://docs.aws.amazon.com/ses/latest/APIReference-V2/API_EmailContent.html
+      Content: input.attachments.length > 0 ? { Raw: { Data: buildMimeMessage(input) } } : {
+        Simple: {
+          Subject: { Data: input.subject, Charset: "UTF-8" },
+          Body: {
+            Html: { Data: input.html, Charset: "UTF-8" },
+            ...input.text ? { Text: { Data: input.text, Charset: "UTF-8" } } : {},
+          },
+        },
+      },
+    }),
+  )
+  return { messageId: response.MessageId }
+}
+
+function buildMimeMessage(input: ProviderEmailInput): Uint8Array {
+  const mixedBoundary = `mixed_${crypto.randomUUID()}`
+  const headers = [
+    `From: ${input.from}`,
+    `To: ${input.to.join(", ")}`,
+    ...input.replyTo.length > 0 ? [`Reply-To: ${input.replyTo.join(", ")}`] : [],
+    `Subject: ${encodeHeaderValue(input.subject)}`,
+    "MIME-Version: 1.0",
+    `Content-Type: multipart/mixed; boundary="${mixedBoundary}"`,
+  ]
+
+  const parts = [
+    `--${mixedBoundary}`,
+    buildBodyPart(input),
+    ...input.attachments.map((attachment) =>
+      `--${mixedBoundary}\r\n${buildAttachmentPart(attachment)}`
+    ),
+    `--${mixedBoundary}--`,
+  ]
+
+  return new TextEncoder().encode(`${headers.join("\r\n")}\r\n\r\n${parts.join("\r\n")}\r\n`)
+}
+
+/** A `multipart/alternative` body when a plain-text alternative exists, otherwise just the HTML. */
+function buildBodyPart(input: ProviderEmailInput): string {
+  const html = textPart("text/html", input.html)
+  if (!input.text) return html
+
+  // Least-preferred alternative first, as required by RFC 2046.
+  // https://datatracker.ietf.org/doc/html/rfc2046#section-5.1.4
+  const boundary = `alt_${crypto.randomUUID()}`
+  return [
+    `Content-Type: multipart/alternative; boundary="${boundary}"`,
+    "",
+    `--${boundary}`,
+    textPart("text/plain", input.text),
+    `--${boundary}`,
+    html,
+    `--${boundary}--`,
+  ].join("\r\n")
+}
+
+function textPart(contentType: string, body: string): string {
+  return [
+    `Content-Type: ${contentType}; charset=UTF-8`,
+    "Content-Transfer-Encoding: base64",
+    "",
+    wrapBase64(Buffer.from(body, "utf8").toString("base64")),
+  ].join("\r\n")
+}
+
+function buildAttachmentPart(attachment: ResolvedEmailAttachment): string {
+  const filename = encodeHeaderValue(attachment.filename)
+  return [
+    `Content-Type: ${attachment.contentType}; name="${filename}"`,
+    `Content-Disposition: attachment; filename="${filename}"`,
+    "Content-Transfer-Encoding: base64",
+    "",
+    wrapBase64(Buffer.from(attachment.content).toString("base64")),
+  ].join("\r\n")
+}
+
+/** RFC 2045 caps encoded lines at 76 characters. https://datatracker.ietf.org/doc/html/rfc2045#section-6.8 */
+function wrapBase64(base64: string): string {
+  return (base64.match(/.{1,76}/g) ?? []).join("\r\n")
+}
+
+/** RFC 2047 encoded-word, so non-ASCII header values survive transport. */
+function encodeHeaderValue(value: string): string {
+  if (!/[^\x20-\x7E]/.test(value)) return value
+  return `=?UTF-8?B?${Buffer.from(value, "utf8").toString("base64")}?=`
+}

--- a/webapp/src/emails/templates/email-verification.tsx
+++ b/webapp/src/emails/templates/email-verification.tsx
@@ -14,8 +14,7 @@ import {
   Tailwind,
   Text,
 } from "react-email"
-
-const APP_NAME = "AstralBeam"
+import { APP_NAME } from "../../lib/config.ts"
 
 interface EmailVerificationEmailProps {
   logoUrl: string

--- a/webapp/src/emails/templates/email-verification.tsx
+++ b/webapp/src/emails/templates/email-verification.tsx
@@ -1,0 +1,98 @@
+import {
+  Body,
+  Button,
+  Container,
+  Head,
+  Heading,
+  Hr,
+  Html,
+  Img,
+  Link,
+  pixelBasedPreset,
+  Preview,
+  Section,
+  Tailwind,
+  Text,
+} from "react-email"
+
+const APP_NAME = "AstralBeam"
+
+interface EmailVerificationEmailProps {
+  logoUrl: string
+  verificationUrl: string
+  email: string
+  expiryMinutes: number
+}
+
+export default function EmailVerificationEmail({
+  logoUrl,
+  verificationUrl,
+  email,
+  expiryMinutes,
+}: EmailVerificationEmailProps) {
+  return (
+    <Html>
+      <Head />
+      <Tailwind
+        config={{
+          presets: [pixelBasedPreset],
+        }}
+      >
+        <Body className="bg-white font-sans text-gray-900">
+          <Preview>Verify your email on {APP_NAME}</Preview>
+          <Container className="px-4">
+            <Section className="w-md max-w-md border border-gray-200 my-8 p-4">
+              <Img
+                src={logoUrl}
+                width="48"
+                height="48"
+                alt={`${APP_NAME} logo`}
+                className="mx-auto block my-6 object-contain"
+              />
+
+              <Heading className="text-2xl text-center font-normal my-6">
+                {"Verify your email on "}
+                <span className="font-bold">{APP_NAME}</span>
+              </Heading>
+
+              <Text className="text-sm my-6">
+                Click the button below to verify your email and finish setting up your account:
+              </Text>
+
+              <Section className="text-center my-6">
+                <Button
+                  href={verificationUrl}
+                  className="bg-black text-white text-sm font-semibold px-6 py-3 rounded"
+                >
+                  Verify email
+                </Button>
+              </Section>
+
+              <Section className="my-6">
+                <Text className="text-xs m-0">or copy and paste this URL into your browser:</Text>
+                <Link href={verificationUrl} className="text-blue-600 no-underline text-xs m-0">
+                  {verificationUrl}
+                </Link>
+              </Section>
+
+              <Hr />
+
+              <Text className="text-xs my-6 text-gray-600 leading-normal">
+                This link was sent to{" "}
+                <span className="font-semibold">{email}</span>. If you did not request it, you can
+                safely ignore this email. The link will expire in {expiryMinutes} minutes.
+              </Text>
+            </Section>
+          </Container>
+        </Body>
+      </Tailwind>
+    </Html>
+  )
+}
+
+EmailVerificationEmail.PreviewProps = {
+  verificationUrl: "https://example.com/api/auth/verify-email?token=sdfsfsdfsfsdf",
+  email: "test@example.com",
+  logoUrl: "http://localhost:3000/astralbeam-logo-light.png",
+  expiryMinutes: 10,
+} satisfies EmailVerificationEmailProps

--- a/webapp/src/emails/types.ts
+++ b/webapp/src/emails/types.ts
@@ -21,6 +21,7 @@ export interface SendEmailOptions {
   html?: string | undefined
   /** Plain-text alternative; derived from `react` when omitted. */
   text?: string | undefined
+  /** Defaults to the resolved `from` address. */
   replyTo?: string | string[] | undefined
   attachments?: EmailAttachment[] | undefined
   /** Defaults to the `EMAIL_PROVIDER` environment variable. */

--- a/webapp/src/emails/types.ts
+++ b/webapp/src/emails/types.ts
@@ -12,7 +12,8 @@ export interface EmailAttachment {
 
 export interface SendEmailOptions {
   to: string | string[]
-  from: string
+  /** Defaults to the `EMAIL_FROM_ADDRESS` environment variable. */
+  from?: string | undefined
   subject: string
   /** A react-email template element; rendered to both HTML and plain text. */
   react?: ReactElement | undefined

--- a/webapp/src/emails/types.ts
+++ b/webapp/src/emails/types.ts
@@ -1,0 +1,56 @@
+import type { ReactElement } from "react"
+
+/** Providers `sendEmail` can dispatch to; each maps to one `src/emails/providers` module. */
+export type EmailProvider = "resend" | "ses"
+
+/** An attachment as callers declare it: a name plus its content. */
+export interface EmailAttachment {
+  filename: string
+  /** An HTTP(S) URL to fetch, a `data:` URI, or a bare base64-encoded payload. */
+  path: string
+}
+
+export interface SendEmailOptions {
+  to: string | string[]
+  from: string
+  subject: string
+  /** A react-email template element; rendered to both HTML and plain text. */
+  react?: ReactElement | undefined
+  /** Pre-rendered HTML, used instead of `react`. */
+  html?: string | undefined
+  /** Plain-text alternative; derived from `react` when omitted. */
+  text?: string | undefined
+  replyTo?: string | string[] | undefined
+  attachments?: EmailAttachment[] | undefined
+  /** Defaults to the `EMAIL_PROVIDER` environment variable. */
+  provider?: EmailProvider | undefined
+}
+
+/** An attachment resolved to bytes, so every provider receives the same shape. */
+export interface ResolvedEmailAttachment {
+  filename: string
+  contentType: string
+  content: Uint8Array
+}
+
+/** The normalized, fully rendered payload every `sendProviderEmail` receives. */
+export interface ProviderEmailInput {
+  to: string[]
+  from: string
+  subject: string
+  html: string
+  text?: string | undefined
+  replyTo: string[]
+  attachments: ResolvedEmailAttachment[]
+}
+
+interface ProviderEmailResult {
+  /** Provider-assigned message identifier, when the provider returns one. */
+  messageId?: string | undefined
+}
+
+export type SendProviderEmail = (input: ProviderEmailInput) => Promise<ProviderEmailResult>
+
+export interface SendEmailResult extends ProviderEmailResult {
+  provider: EmailProvider
+}

--- a/webapp/src/emails/utils.server.ts
+++ b/webapp/src/emails/utils.server.ts
@@ -1,0 +1,131 @@
+import { Buffer } from "node:buffer"
+import { render } from "react-email"
+import { EMAIL_FROM_ADDRESS, EMAIL_PROVIDER } from "../lib/config.server.ts"
+import type {
+  EmailAttachment,
+  EmailProvider,
+  ProviderEmailInput,
+  ResolvedEmailAttachment,
+  SendEmailOptions,
+  SendProviderEmail,
+} from "./types.ts"
+
+/**
+ * Static map of dynamic imports: the selected provider's SDK is the only one ever loaded, while
+ * the literal specifiers stay statically analyzable for bundling and unused-file detection. It
+ * doubles as the set of provider names `resolveProvider` accepts.
+ */
+export const providerLoaders: Record<
+  EmailProvider,
+  () => Promise<{ sendProviderEmail: SendProviderEmail }>
+> = {
+  resend: () => import("./providers/resend.ts"),
+  ses: () => import("./providers/ses.ts"),
+}
+
+const CONTENT_TYPES_BY_EXTENSION: Record<string, string> = {
+  csv: "text/csv",
+  gif: "image/gif",
+  html: "text/html",
+  ics: "text/calendar",
+  jpeg: "image/jpeg",
+  jpg: "image/jpeg",
+  json: "application/json",
+  pdf: "application/pdf",
+  png: "image/png",
+  svg: "image/svg+xml",
+  txt: "text/plain",
+  zip: "application/zip",
+}
+
+export function resolveProvider(provider: SendEmailOptions["provider"]): EmailProvider {
+  const resolved = provider ?? EMAIL_PROVIDER
+  if (!resolved) {
+    throw new Error("No email provider given and 'EMAIL_PROVIDER' environment variable is not set")
+  }
+  if (!(resolved in providerLoaders)) {
+    throw new Error(`Unknown email provider '${resolved}'`)
+  }
+  return resolved as EmailProvider
+}
+
+export async function buildProviderEmailInput(
+  options: SendEmailOptions,
+): Promise<ProviderEmailInput> {
+  const { react } = options
+  const html = options.html ?? (react ? await render(react) : undefined)
+  if (!html) {
+    throw new Error("An email needs either a 'react' template or 'html' content")
+  }
+
+  const from = options.from ?? EMAIL_FROM_ADDRESS
+  if (!from) {
+    throw new Error(
+      "No 'from' address given and 'EMAIL_FROM_ADDRESS' environment variable is not set",
+    )
+  }
+
+  const text = options.text ?? (react ? await render(react, { plainText: true }) : undefined)
+  const replyTo = toArray(options.replyTo)
+
+  return {
+    to: toArray(options.to),
+    from,
+    subject: options.subject,
+    html,
+    ...text ? { text } : {},
+    replyTo: replyTo.length > 0 ? replyTo : [from],
+    attachments: await Promise.all((options.attachments ?? []).map(resolveAttachment)),
+  }
+}
+
+function toArray(value: string | string[] | undefined): string[] {
+  if (!value) return []
+  return Array.isArray(value) ? value : [value]
+}
+
+/**
+ * Attachments are resolved to bytes here rather than per provider, because SES has to build its own
+ * MIME parts and cannot fetch a remote attachment the way Resend can.
+ */
+async function resolveAttachment(attachment: EmailAttachment): Promise<ResolvedEmailAttachment> {
+  const { filename, path } = attachment
+  const resolved = /^https?:\/\//i.test(path) ? await fetchAttachment(path) : decodeBase64(path)
+  return {
+    filename,
+    contentType: resolved.contentType ?? guessContentType(filename),
+    content: resolved.content,
+  }
+}
+
+interface ResolvedAttachmentContent {
+  content: Uint8Array
+  /** Media type reported by the source, when it reports one. */
+  contentType?: string | undefined
+}
+
+async function fetchAttachment(url: string): Promise<ResolvedAttachmentContent> {
+  const response = await fetch(url)
+  if (!response.ok) {
+    throw new Error(`Failed to fetch email attachment '${url}': ${response.status}`)
+  }
+  return {
+    content: new Uint8Array(await response.arrayBuffer()),
+    contentType: response.headers.get("content-type")?.split(";")[0]?.trim() || undefined,
+  }
+}
+
+/** Accepts either a bare base64 payload or a full `data:` URI. */
+function decodeBase64(path: string): ResolvedAttachmentContent {
+  const dataUri = /^data:([^;,]*)?(?:;[^,]*)*,/i.exec(path)
+  const base64 = dataUri ? path.slice(dataUri[0].length) : path
+  return {
+    content: new Uint8Array(Buffer.from(base64, "base64")),
+    contentType: dataUri?.[1] || undefined,
+  }
+}
+
+function guessContentType(filename: string): string {
+  const extension = filename.split(".").pop()?.toLowerCase() ?? ""
+  return CONTENT_TYPES_BY_EXTENSION[extension] ?? "application/octet-stream"
+}

--- a/webapp/src/lib/config.server.ts
+++ b/webapp/src/lib/config.server.ts
@@ -8,6 +8,9 @@ function ensureServerEnv(key: string) {
 
 export const DATABASE_URL = ensureServerEnv("DATABASE_URL")
 
+// Absolute origin used to build links and image sources for emails, which cannot resolve relative paths.
+export const APP_BASE_URL = ensureServerEnv("APP_BASE_URL")
+
 // Defaults for `src/emails`; every `sendEmail` call can override either one.
 export const EMAIL_PROVIDER = process.env.EMAIL_PROVIDER
 export const EMAIL_FROM_ADDRESS = process.env.EMAIL_FROM_ADDRESS

--- a/webapp/src/lib/config.server.ts
+++ b/webapp/src/lib/config.server.ts
@@ -7,3 +7,17 @@ function ensureServerEnv(key: string) {
 }
 
 export const DATABASE_URL = ensureServerEnv("DATABASE_URL")
+
+// Provider credentials are read through functions, not module constants, so a deployment only needs
+// the variables for the email providers it actually sends through.
+export function requireResendConfig() {
+  return { apiKey: ensureServerEnv("RESEND_API_KEY") }
+}
+
+export function requireSesConfig() {
+  return {
+    region: ensureServerEnv("AWS_REGION"),
+    accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+  }
+}

--- a/webapp/src/lib/config.server.ts
+++ b/webapp/src/lib/config.server.ts
@@ -8,6 +8,10 @@ function ensureServerEnv(key: string) {
 
 export const DATABASE_URL = ensureServerEnv("DATABASE_URL")
 
+// Defaults for `src/emails`; every `sendEmail` call can override either one.
+export const EMAIL_PROVIDER = process.env.EMAIL_PROVIDER
+export const EMAIL_FROM_ADDRESS = process.env.EMAIL_FROM_ADDRESS
+
 // Provider credentials are read through functions, not module constants, so a deployment only needs
 // the variables for the email providers it actually sends through.
 export function requireResendConfig() {

--- a/webapp/src/lib/config.ts
+++ b/webapp/src/lib/config.ts
@@ -1,0 +1,1 @@
+export const APP_NAME = "AstralBeam"


### PR DESCRIPTION
Original prompt:

> let's add react email to the project step by step. install the package, add the npm command to preview emails, set up a sample email in src/emails/templates (content for a template is pasted below). create a file src/emails/index.ts (mark it server-only) which exports a sendEmail function that takes a react, html, subject, text, previewText, to, from, replyTo, attachments (filename & path). the provider for now can be ses or resend. now, i want to support multilpe providers like aws and ses and the switch should be based on a process.env variable, and more importantly, i'd like the provider-specific code to be loaded only if it is the selected one. actually, now that i think of it, let's pass the provider as an option to sendEmail so that I can decide per email what to do and use mutiple providers if need be. but still keep the dynamic loading. and let's put the provider specific logic in src/emails/providers and let's also have src/emails/types that define the contract of the input and output to the various sendProviderEmail functions that wrap the provider-specific stuff

Adds react-email to `webapp` with a provider-agnostic `sendEmail`, Resend and SES backends, and a local preview server.

## `src/emails`

- `types.ts` defines both contracts: `SendEmailOptions` for callers, and `ProviderEmailInput` / `SendProviderEmail` for the normalized, already-rendered payload each provider receives
- `index.ts` exports `sendEmail`, which renders `react` to HTML and plain text, resolves attachments to bytes, and delegates to the selected provider
- `index.ts` is server-only despite the name: it pulls in provider SDKs and credentials, so it must stay behind server functions and server routes
- `providers/resend.ts` and `providers/ses.ts` each export one `sendProviderEmail` and memoize their client
- Provider selection is a static map of dynamic imports, so only the chosen provider's SDK is ever loaded while the literal specifiers stay analyzable for bundling and knip
- Pick the provider per call with the `provider` option, falling back to the `EMAIL_PROVIDER` environment variable
- Attachment `path` accepts an HTTP(S) URL, a `data:` URI, or bare base64; resolution to bytes happens once in `index.ts` so no provider fetches on its own
- SES sends through SESv2 `Simple` content normally and switches to hand-built raw MIME only when attachments are present, since `Simple` cannot carry them
- SES omits `credentials` when no static key pair is configured, falling through to the SDK's default chain (instance role, SSO, profile)
- `templates/email-verification.tsx` is the sample template, branded to AstralBeam against the existing `/astralbeam-logo-light.png`

## Configuration

- `requireResendConfig()` and `requireSesConfig()` in `src/lib/config.server.ts` read credentials through functions rather than module constants, so a deployment only needs the variables for the providers it actually sends through
- `.env.example` documents `EMAIL_PROVIDER`, `RESEND_API_KEY`, `AWS_REGION`, `AWS_ACCESS_KEY_ID`, and `AWS_SECRET_ACCESS_KEY`
- Adds `react-email`, `resend`, and `@aws-sdk/client-sesv2`; `react-email` is a runtime dependency because `sendEmail` calls its `render()`
- knip keeps `src/emails/index.ts` and `src/emails/templates/*.tsx` as explicit entries, since nothing imports them yet and the preview server discovers templates by reading the directory
- `EMAIL_PROVIDER` and `EMAIL_FROM_ADDRESS` are the defaults for `sendEmail`, exported from `src/lib/config.server.ts` and overridable per call via the `provider` and `from` options
- `.env.development` sets both with the repo's `${VAR:-default}` form so shell and deployment values take precedence, defaulting locally to `resend` and Resend's sandbox sender
- 
## Preview

- `deno task email` runs `scripts/preview-emails.ts`, a `Deno.serve` server: `/` lists templates, `/<name>` renders with the template's `PreviewProps`, and `/<name>?text=1` shows the plain-text version
- Templates are re-imported with an mtime cache-buster, so an edit shows up on reload without a restart
- Defaults to port 3002 and honors `PORT`, leaving 3001 to `www`
- This replaces react-email's own CLI, which cannot run under Deno: it re-execs itself until node's `--experimental-vm-modules` appears in `process.execArgv`, which never happens under Deno's node shim, so it forks until killed
- The script needs a file-local `/// <reference lib="deno.ns" />` because `tsconfig.json` declares only the `ES2025` and `DOM` libs

## Notes

- `previewText` was in the original ask but is not in the final contract: neither provider has such a field, the only implementation would be injecting a hidden preheader into the HTML, and react-email's `<Preview>` already does exactly that inside the template
- No call site exists yet, so the Resend and SES paths are unexercised against a live provider; the first real send will be the first test of both
- `deno task check`, `deno task test`, and `deno task build` pass; the preview server was verified serving the index and the rendered template
