### PR TITLE
Make webapp symbol names globally unique

### DIFF
--- a/webapp/AGENTS.md
+++ b/webapp/AGENTS.md
@@ -1,6 +1,7 @@
 ## Codebase Structure and Guidelines
 
 - Use plain data and helper functions with explicit options objects for application logic; do not use classes or closure-based state factories. Isolate framework-required classes such as React error boundaries.
+- Keep named functions, function-valued variables, and module-level constants globally unique within `webapp`; use concise domain qualifiers when needed, while retaining framework-mandated names such as TanStack Router's `Route` export.
 
 - This is TanStack Start React app
   - Tech stack: TanStack Router, Tailwind, Shadcn UI, Better Auth, Drizzle ORM, React Email

--- a/webapp/src/components/auth/forgot-password.tsx
+++ b/webapp/src/components/auth/forgot-password.tsx
@@ -1,5 +1,5 @@
 // Added with: deno task ui add @better-auth-ui/auth
-// Local changes: Remove the unconfigured CAPTCHA surface; use browser-safe globals; preserve return paths when browser storage is unavailable, strict typing, and a semantic heading.
+// Local changes: Remove the unconfigured CAPTCHA surface; use browser-safe globals and domain-specific function names; preserve return paths when browser storage is unavailable, strict typing, and a semantic heading.
 
 "use client"
 
@@ -66,7 +66,7 @@ export function ForgotPassword({ className }: ForgotPasswordProps) {
     },
   )
 
-  function handleSubmit(e: SyntheticEvent<HTMLFormElement>) {
+  function submitPasswordResetRequest(e: SyntheticEvent<HTMLFormElement>) {
     e.preventDefault()
     const formData = new FormData(e.currentTarget)
     requestPasswordReset({
@@ -96,7 +96,7 @@ export function ForgotPassword({ className }: ForgotPasswordProps) {
       </CardHeader>
 
       <CardContent>
-        <form onSubmit={handleSubmit}>
+        <form onSubmit={submitPasswordResetRequest}>
           <FieldGroup>
             <Field data-invalid={!!fieldErrors.email}>
               <FieldLabel htmlFor="email">{localization.auth.email}</FieldLabel>

--- a/webapp/src/components/auth/organization/create-organization-dialog.tsx
+++ b/webapp/src/components/auth/organization/create-organization-dialog.tsx
@@ -1,5 +1,5 @@
 // Added with: deno task ui add @better-auth-ui/organization
-// Local changes: use Phosphor, accept an onboarding name suggestion, and omit unsupported organization model fields while retaining the official create flow.
+// Local changes: use Phosphor and domain-specific function names, accept an onboarding name suggestion, and omit unsupported organization model fields while retaining the official create flow.
 
 import type { OrganizationAuthClient } from "@better-auth-ui/core/plugins/organization"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
@@ -50,7 +50,7 @@ export function CreateOrganizationDialog({
     },
   })
 
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
+  const submitOrganizationCreation = (e: SyntheticEvent<HTMLFormElement>) => {
     e.preventDefault()
     if (submissionLocked.current) return
 
@@ -77,7 +77,7 @@ export function CreateOrganizationDialog({
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
-        <form onSubmit={handleSubmit} className="flex flex-col gap-6">
+        <form onSubmit={submitOrganizationCreation} className="flex flex-col gap-6">
           <DialogHeader>
             <DialogTitle className="flex items-center gap-2">
               <Briefcase />

--- a/webapp/src/components/auth/organization/edit-member-roles-dialog.tsx
+++ b/webapp/src/components/auth/organization/edit-member-roles-dialog.tsx
@@ -1,5 +1,5 @@
 // Added with: deno task ui add @better-auth-ui/organization
-// Local changes: Use Phosphor icons and Base UI Toast with the app's static owner/admin/member roles.
+// Local changes: Use Phosphor icons, Base UI Toast, and domain-specific function names with the app's static owner/admin/member roles.
 
 "use client"
 
@@ -62,7 +62,7 @@ export function EditMemberRolesDialog({
     if (open) setSelectedRoles(parseMemberRoles(member.role))
   }, [member.role, open])
 
-  const toggleRole = (role: string, checked: boolean) => {
+  const toggleMemberRole = (role: string, checked: boolean) => {
     setSelectedRoles((current) =>
       checked
         ? current.includes(role) ? current : [...current, role]
@@ -116,7 +116,7 @@ export function EditMemberRolesDialog({
                       checked={checked}
                       disabled={disabled}
                       id={id}
-                      onCheckedChange={(next) => toggleRole(role, next === true)}
+                      onCheckedChange={(next) => toggleMemberRole(role, next === true)}
                     />
                   </Field>
                 </FieldLabel>

--- a/webapp/src/components/auth/organization/invite-member-dialog.tsx
+++ b/webapp/src/components/auth/organization/invite-member-dialog.tsx
@@ -1,5 +1,5 @@
 // Added with: deno task ui add @better-auth-ui/organization
-// Local changes: use Phosphor/Base Toast and actor-assignable static roles; omit disabled teams, dynamic roles, and invitation model fields.
+// Local changes: use Phosphor/Base Toast, domain-specific function names, and actor-assignable static roles; omit disabled teams, dynamic roles, and invitation model fields.
 
 "use client"
 
@@ -121,13 +121,13 @@ export function InviteMemberDialog({
     .map((entry) => assignableRoles[entry] ?? entry)
     .join(", ")
 
-  const toggleRole = (role: string) => {
+  const toggleInvitationRole = (role: string) => {
     setSelectedRoles((current) =>
       current.includes(role) ? current.filter((entry) => entry !== role) : [...current, role]
     )
   }
 
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
+  const submitMemberInvitation = (e: SyntheticEvent<HTMLFormElement>) => {
     e.preventDefault()
 
     if (
@@ -161,7 +161,7 @@ export function InviteMemberDialog({
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
-        <form onSubmit={handleSubmit} className="flex flex-col gap-6">
+        <form onSubmit={submitMemberInvitation} className="flex flex-col gap-6">
           <DialogHeader>
             <DialogTitle className="flex items-center gap-2">
               <UserPlus />
@@ -231,7 +231,7 @@ export function InviteMemberDialog({
                         key={item.value}
                         checked={checked}
                         disabled={checked && selectedRoles.length === 1}
-                        onCheckedChange={() => toggleRole(item.value)}
+                        onCheckedChange={() => toggleInvitationRole(item.value)}
                       >
                         {item.label}
                       </DropdownMenuCheckboxItem>

--- a/webapp/src/components/auth/organization/organization-invitations.tsx
+++ b/webapp/src/components/auth/organization/organization-invitations.tsx
@@ -1,5 +1,5 @@
 // Added with: deno task ui add @better-auth-ui/organization
-// Local changes: use Phosphor and hover titles for icon-only filter actions, make filters/table responsive, and repair strict optional props.
+// Local changes: use Phosphor, domain-specific function names, and hover titles for icon-only filter actions; make filters/table responsive and repair strict optional props.
 
 import {
   hasMemberRole,
@@ -114,7 +114,7 @@ export function OrganizationInvitations({
 
   const [inviteOpen, setInviteOpen] = useState(false)
 
-  function toggleSort(column: string) {
+  function toggleInvitationSort(column: string) {
     setSortDescriptor((current) => {
       if (current?.column !== column) {
         return { column, direction: "ascending" }
@@ -263,41 +263,41 @@ export function OrganizationInvitations({
           <Table aria-label={organizationLocalization.invitations}>
             <TableHeader>
               <TableRow>
-                <SortableTableHead
+                <InvitationSortableTableHead
                   sortDirection={sortDescriptor?.column === "email"
                     ? sortDescriptor.direction
                     : undefined}
-                  onClick={() => toggleSort("email")}
+                  onClick={() => toggleInvitationSort("email")}
                 >
                   {localization.auth.email}
-                </SortableTableHead>
+                </InvitationSortableTableHead>
 
-                <SortableTableHead
+                <InvitationSortableTableHead
                   sortDirection={sortDescriptor?.column === "createdAt"
                     ? sortDescriptor.direction
                     : undefined}
-                  onClick={() => toggleSort("createdAt")}
+                  onClick={() => toggleInvitationSort("createdAt")}
                 >
                   {organizationLocalization.invitedAt}
-                </SortableTableHead>
+                </InvitationSortableTableHead>
 
-                <SortableTableHead
+                <InvitationSortableTableHead
                   sortDirection={sortDescriptor?.column === "role"
                     ? sortDescriptor.direction
                     : undefined}
-                  onClick={() => toggleSort("role")}
+                  onClick={() => toggleInvitationSort("role")}
                 >
                   {organizationLocalization.role}
-                </SortableTableHead>
+                </InvitationSortableTableHead>
 
-                <SortableTableHead
+                <InvitationSortableTableHead
                   sortDirection={sortDescriptor?.column === "status"
                     ? sortDescriptor.direction
                     : undefined}
-                  onClick={() => toggleSort("status")}
+                  onClick={() => toggleInvitationSort("status")}
                 >
                   {organizationLocalization.status}
-                </SortableTableHead>
+                </InvitationSortableTableHead>
 
                 <TableHead className="text-end">
                   {organizationLocalization.actions}
@@ -341,7 +341,7 @@ export function OrganizationInvitations({
   )
 }
 
-function SortableTableHead({
+function InvitationSortableTableHead({
   children,
   sortDirection,
   onClick,

--- a/webapp/src/components/auth/organization/organization-members.tsx
+++ b/webapp/src/components/auth/organization/organization-members.tsx
@@ -1,5 +1,5 @@
 // Added with: deno task ui add @better-auth-ui/organization
-// Local changes: Use Phosphor and a hover title for the icon-only filter action; omit disabled teams and support responsive controls/table and strict optional props.
+// Local changes: Use Phosphor, domain-specific function names, and a hover title for the icon-only filter action; omit disabled teams and support responsive controls/table and strict optional props.
 
 "use client"
 
@@ -198,7 +198,7 @@ export function OrganizationMembers({
   const pageEnd = pageStart + (sortedMembers?.length ?? 0)
   const hasNextPage = pageEnd < total
 
-  function toggleSort(column: string) {
+  function toggleMemberSort(column: string) {
     setSortDescriptor((current) => {
       if (current?.column !== column) {
         return { column, direction: "ascending" }
@@ -315,24 +315,24 @@ export function OrganizationMembers({
                 {paged
                   ? <TableHead>{organizationLocalization.member}</TableHead>
                   : (
-                    <SortableTableHead
+                    <MemberSortableTableHead
                       sortDirection={sortDescriptor?.column === "user"
                         ? sortDescriptor.direction
                         : undefined}
-                      onClick={() => toggleSort("user")}
+                      onClick={() => toggleMemberSort("user")}
                     >
                       {organizationLocalization.member}
-                    </SortableTableHead>
+                    </MemberSortableTableHead>
                   )}
 
-                <SortableTableHead
+                <MemberSortableTableHead
                   sortDirection={sortDescriptor?.column === "role"
                     ? sortDescriptor.direction
                     : undefined}
-                  onClick={() => toggleSort("role")}
+                  onClick={() => toggleMemberSort("role")}
                 >
                   {organizationLocalization.role}
-                </SortableTableHead>
+                </MemberSortableTableHead>
 
                 <TableHead className="text-end">
                   {organizationLocalization.actions}
@@ -398,7 +398,7 @@ export function OrganizationMembers({
   )
 }
 
-function SortableTableHead({
+function MemberSortableTableHead({
   children,
   sortDirection,
   onClick,

--- a/webapp/src/components/auth/reset-password.tsx
+++ b/webapp/src/components/auth/reset-password.tsx
@@ -1,5 +1,5 @@
 // Added with: deno task ui add @better-auth-ui/auth
-// Local changes: Use Phosphor icons, the contextual Base UI Toast manager, and Deno-compatible browser globals; preserve strict error-state typing; render a semantic page heading.
+// Local changes: Use Phosphor icons, the contextual Base UI Toast manager, Deno-compatible browser globals, and domain-specific function names; preserve strict error-state typing; render a semantic page heading.
 
 "use client"
 
@@ -86,7 +86,7 @@ export function ResetPassword({ className }: ResetPasswordProps) {
     }
   }, [addToast, localization.auth.invalidResetPasswordToken, navigate, signInURL])
 
-  function handleSubmit(e: SyntheticEvent<HTMLFormElement>) {
+  function submitPasswordReset(e: SyntheticEvent<HTMLFormElement>) {
     e.preventDefault()
 
     const searchParams = new URLSearchParams(globalThis.location.search)
@@ -119,7 +119,7 @@ export function ResetPassword({ className }: ResetPasswordProps) {
       </CardHeader>
 
       <CardContent>
-        <form onSubmit={handleSubmit}>
+        <form onSubmit={submitPasswordReset}>
           <FieldGroup>
             <Field data-invalid={!!fieldErrors.password}>
               <FieldLabel htmlFor="password">

--- a/webapp/src/components/auth/settings/account/user-profile.tsx
+++ b/webapp/src/components/auth/settings/account/user-profile.tsx
@@ -1,5 +1,5 @@
 // Added with: deno task ui add @better-auth-ui/settings
-// Local changes: remove username and generic additional fields; use Base UI Toast and strict typing.
+// Local changes: remove username and generic additional fields; use Base UI Toast, domain-specific function names, and strict typing.
 
 "use client"
 
@@ -39,7 +39,7 @@ export function UserProfile({ className }: UserProfileProps) {
     name?: string | undefined
   }>({})
 
-  function handleSubmit(e: SyntheticEvent<HTMLFormElement>) {
+  function submitUserProfile(e: SyntheticEvent<HTMLFormElement>) {
     e.preventDefault()
 
     const formData = new FormData(e.currentTarget)
@@ -53,7 +53,7 @@ export function UserProfile({ className }: UserProfileProps) {
         {localization.settings.userProfile}
       </h2>
 
-      <form onSubmit={handleSubmit}>
+      <form onSubmit={submitUserProfile}>
         <Card className={cn(className)}>
           <CardContent className="flex flex-col gap-6">
             <ChangeAvatar />

--- a/webapp/src/components/auth/settings/security/change-password.tsx
+++ b/webapp/src/components/auth/settings/security/change-password.tsx
@@ -1,5 +1,5 @@
 // Added with: deno task ui add @better-auth-ui/settings
-// Local changes: use Phosphor icons, Base UI Toast, and hover titles for password visibility controls; omit unconfigured captcha UI and apply strict optional typing.
+// Local changes: use Phosphor icons, Base UI Toast, domain-specific function names, and hover titles for password visibility controls; omit unconfigured captcha UI and apply strict optional typing.
 
 import { getViewURL, isPasswordCompromisedError } from "@better-auth-ui/core"
 import {
@@ -198,7 +198,7 @@ function ChangePasswordForm({
     confirmPassword?: string | undefined
   }>({})
 
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
+  const submitPasswordChange = (e: SyntheticEvent<HTMLFormElement>) => {
     e.preventDefault()
 
     if (emailAndPassword.confirmPassword && newPassword !== confirmPassword) {
@@ -222,7 +222,7 @@ function ChangePasswordForm({
         {localization.settings.changePassword}
       </h2>
 
-      <form onSubmit={handleSubmit}>
+      <form onSubmit={submitPasswordChange}>
         <Card className={cn(className)}>
           <CardContent className="flex flex-col gap-6">
             <Field data-invalid={!!fieldErrors.currentPassword}>

--- a/webapp/src/components/auth/sign-in.tsx
+++ b/webapp/src/components/auth/sign-in.tsx
@@ -1,5 +1,5 @@
 // Added with: deno task ui add @better-auth-ui/auth
-// Local changes: Use Phosphor icons/browser-safe globals; remove unconfigured passkey, last-login, two-factor, CAPTCHA, and plugin buttons; preserve return paths when browser storage is unavailable, strict typing, and a semantic heading.
+// Local changes: Use Phosphor icons, browser-safe globals, and domain-specific function names; remove unconfigured passkey, last-login, two-factor, CAPTCHA, and plugin buttons; preserve return paths when browser storage is unavailable, strict typing, and a semantic heading.
 
 "use client"
 
@@ -112,7 +112,7 @@ export function SignIn({
 
   const providerButtonsProps = socialLayout === undefined ? {} : { socialLayout }
 
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
+  const submitSignIn = (e: SyntheticEvent<HTMLFormElement>) => {
     e.preventDefault()
 
     const formData = new FormData(e.currentTarget)
@@ -155,7 +155,7 @@ export function SignIn({
           )}
 
           {emailAndPassword?.enabled && (
-            <form onSubmit={handleSubmit}>
+            <form onSubmit={submitSignIn}>
               <FieldGroup>
                 <Field data-invalid={!!fieldErrors.email}>
                   <FieldLabel htmlFor="email">

--- a/webapp/src/components/auth/sign-up.tsx
+++ b/webapp/src/components/auth/sign-up.tsx
@@ -1,5 +1,5 @@
 // Added with: deno task ui add @better-auth-ui/auth
-// Local changes: Add the legal gate for email/OAuth signup, preserve the verification return path when browser storage is unavailable, remove generic additional fields and unconfigured CAPTCHA/plugin buttons, send only a boolean assertion, use Phosphor/Base UI Toast, repair strict typing, and read legal URLs from the runtime public config instead of build-time constants.
+// Local changes: Add the legal gate for email/OAuth signup, preserve the verification return path when browser storage is unavailable, remove generic additional fields and unconfigured CAPTCHA/plugin buttons, send only a boolean assertion, use Phosphor/Base UI Toast and domain-specific function names, repair strict typing, and read legal URLs from the runtime public config instead of build-time constants.
 
 "use client"
 
@@ -142,7 +142,7 @@ export function SignUp({
     confirmPassword?: string | undefined
   }>({})
 
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
+  const submitSignUp = (e: SyntheticEvent<HTMLFormElement>) => {
     e.preventDefault()
 
     if (!termsAccepted) {
@@ -209,7 +209,7 @@ export function SignUp({
           )}
 
           {emailAndPassword?.enabled && (
-            <form onSubmit={handleSubmit}>
+            <form onSubmit={submitSignUp}>
               <FieldGroup>
                 {emailAndPassword.name !== false && (
                   <Field data-invalid={!!fieldErrors.name}>

--- a/webapp/src/db/schema/config.server.ts
+++ b/webapp/src/db/schema/config.server.ts
@@ -4,7 +4,7 @@ import { timestamps, timestampWithTimeZone, uuidV7PrimaryKey } from "../postgres
 
 // Global control-plane tables without an organizationId: runtime configuration and operator
 // sessions exist before any organization does and are managed by the deployment operator.
-export const config = snakeCase.table(
+export const configTable = snakeCase.table(
   "config",
   {
     id: uuidV7PrimaryKey(),

--- a/webapp/src/db/schema/tables.server.ts
+++ b/webapp/src/db/schema/tables.server.ts
@@ -1,4 +1,4 @@
 export { account, session, user, verification } from "./authentication.server.ts"
-export { config, configSession } from "./config.server.ts"
+export { configSession, configTable } from "./config.server.ts"
 export { invitation, member, organization } from "./organizations.server.ts"
 export { rateLimit } from "./rate-limit.server.ts"

--- a/webapp/src/emails/index.ts
+++ b/webapp/src/emails/index.ts
@@ -66,7 +66,7 @@ export async function sendEmail(options: SendEmailOptions): Promise<SendEmailRes
   const { emailProvider, emailFromAddress } = await getConfig()
   const provider = resolveProvider(options.provider, emailProvider)
   const input = await buildProviderEmailInput(options, emailFromAddress)
-  const { sendProviderEmail } = await providerLoaders[provider]()
+  const sendProviderEmail = await providerLoaders[provider]()
   const result = await sendProviderEmail(input)
   return { ...result, provider }
 }

--- a/webapp/src/emails/providers/resend.ts
+++ b/webapp/src/emails/providers/resend.ts
@@ -3,7 +3,7 @@ import { Resend } from "resend"
 import { requireResendConfig } from "../../lib/config.server.ts"
 import type { SendProviderEmail } from "../types.ts"
 
-export const sendProviderEmail: SendProviderEmail = async (input) => {
+export const sendResendEmail: SendProviderEmail = async (input) => {
   // The constructor only stores the key and sends over global fetch, so there is nothing to reuse.
   const { apiKey } = await requireResendConfig()
   const { data, error } = await new Resend(apiKey).emails.send({

--- a/webapp/src/emails/providers/ses.ts
+++ b/webapp/src/emails/providers/ses.ts
@@ -25,7 +25,7 @@ async function getClient(): Promise<SESv2Client> {
   return cachedClient.client
 }
 
-export const sendProviderEmail: SendProviderEmail = async (input) => {
+export const sendSesEmail: SendProviderEmail = async (input) => {
   const response = await (await getClient()).send(
     new SendEmailCommand({
       FromEmailAddress: input.from,

--- a/webapp/src/emails/types.ts
+++ b/webapp/src/emails/types.ts
@@ -35,7 +35,7 @@ export interface ResolvedEmailAttachment {
   content: Uint8Array
 }
 
-/** The normalized, fully rendered payload every `sendProviderEmail` receives. */
+/** The normalized, fully rendered payload every provider sender receives. */
 export interface ProviderEmailInput {
   to: string[]
   from: string

--- a/webapp/src/emails/utils.server.ts
+++ b/webapp/src/emails/utils.server.ts
@@ -16,10 +16,10 @@ import type {
  */
 export const providerLoaders: Record<
   EmailProvider,
-  () => Promise<{ sendProviderEmail: SendProviderEmail }>
+  () => Promise<SendProviderEmail>
 > = {
-  resend: () => import("./providers/resend.ts"),
-  ses: () => import("./providers/ses.ts"),
+  resend: async () => (await import("./providers/resend.ts")).sendResendEmail,
+  ses: async () => (await import("./providers/ses.ts")).sendSesEmail,
 }
 
 const CONTENT_TYPES_BY_EXTENSION: Record<string, string> = {

--- a/webapp/src/lib/config.server.test.ts
+++ b/webapp/src/lib/config.server.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, test, vi } from "vitest"
 
-const state = vi.hoisted(() => ({
+const configTestState = vi.hoisted(() => ({
   rows: null as { key: string; value: unknown; updatedAt: Date }[] | null,
 }))
 
@@ -8,10 +8,10 @@ vi.mock("@/db/index.server", () => ({
   db: {
     select: () => ({
       from: () => {
-        if (state.rows === null) {
+        if (configTestState.rows === null) {
           return Promise.reject(Object.assign(new Error("missing table"), { code: "42P01" }))
         }
-        return Promise.resolve(state.rows)
+        return Promise.resolve(configTestState.rows)
       },
     }),
   },
@@ -119,14 +119,14 @@ describe("setup gate boundary", () => {
   })
 
   test("returns 503 with retry-after while the config table is missing", async () => {
-    state.rows = null
+    configTestState.rows = null
     const response = await setupGateResponse()
     expect(response?.status).toBe(503)
     expect(response?.headers.get("retry-after")).toBe("10")
   })
 
   test("returns null once setup is complete", async () => {
-    state.rows = completeRows
+    configTestState.rows = completeRows
     await expect(setupGateResponse()).resolves.toBeNull()
   })
 })

--- a/webapp/src/lib/config.server.ts
+++ b/webapp/src/lib/config.server.ts
@@ -392,11 +392,15 @@ async function readConfigRows(): Promise<ConfigValueRow[] | null> {
   // Dynamic import: db/index.server.ts imports DATABASE_URL from this module, so a static
   // back-import would be a module cycle.
   const { db } = await import("@/db/index.server")
-  const { config } = await import("@/db/schema.server")
+  const { configTable } = await import("@/db/schema.server")
   try {
     return await db
-      .select({ key: config.key, value: config.value, updatedAt: config.updatedAt })
-      .from(config)
+      .select({
+        key: configTable.key,
+        value: configTable.value,
+        updatedAt: configTable.updatedAt,
+      })
+      .from(configTable)
   } catch (error) {
     if (isMissingTableError(error)) return null
     throw error

--- a/webapp/src/lib/constants.ts
+++ b/webapp/src/lib/constants.ts
@@ -8,7 +8,7 @@ export const APP_LOGO_DARK_PNG_URL = "/astralbeam-logo-dark.png"
 export const APP_LOGO_LIGHT_SVG_URL = "/astralbeam-logo-light.svg"
 export const APP_LOGO_DARK_SVG_URL = "/astralbeam-logo-dark.svg"
 export const INERT_REDIRECT_ORIGIN = `https://${APP_HANDLE}.invalid`
-export const AUTH_RETURN_PATHS = ["/auth/accept-invitation"] as const
+export const AUTH_ALLOWED_RETURN_PATHS = ["/auth/accept-invitation"] as const
 
 // Fallbacks when the corresponding config values are unset; the operator can override both at /configure.
 export const DEFAULT_PRIVACY_POLICY_URL = `${APP_WEBSITE}/privacy`

--- a/webapp/src/lib/constants.ts
+++ b/webapp/src/lib/constants.ts
@@ -8,6 +8,7 @@ export const APP_LOGO_DARK_PNG_URL = "/astralbeam-logo-dark.png"
 export const APP_LOGO_LIGHT_SVG_URL = "/astralbeam-logo-light.svg"
 export const APP_LOGO_DARK_SVG_URL = "/astralbeam-logo-dark.svg"
 export const INERT_REDIRECT_ORIGIN = `https://${APP_HANDLE}.invalid`
+export const AUTH_RETURN_PATHS = ["/auth/accept-invitation"] as const
 
 // Fallbacks when the corresponding config values are unset; the operator can override both at /configure.
 export const DEFAULT_PRIVACY_POLICY_URL = `${APP_WEBSITE}/privacy`

--- a/webapp/src/routes/(authentication)/auth/$path.tsx
+++ b/webapp/src/routes/(authentication)/auth/$path.tsx
@@ -4,9 +4,8 @@ import { createFileRoute, notFound, redirect } from "@tanstack/react-router"
 import { Auth } from "@/components/auth/auth"
 import { getRouteSessionAccessDecision } from "@/lib/auth/session"
 import { normalizeReturnPath, normalizeReturnPathFromSearch } from "@/lib/auth/redirect"
-import { INERT_REDIRECT_ORIGIN } from "@/lib/constants"
+import { AUTH_RETURN_PATHS, INERT_REDIRECT_ORIGIN } from "@/lib/constants"
 
-const ALLOWED_AUTH_RETURN_PATHS = ["/auth/accept-invitation"] as const
 const AUTH_PATHS = new Set([
   ...Object.values(viewPaths.auth),
   "accept-invitation",
@@ -29,7 +28,7 @@ export const Route = createFileRoute("/(authentication)/auth/$path")({
       const redirectTo = normalizeReturnPathFromSearch(
         location.searchStr,
         INERT_REDIRECT_ORIGIN,
-        ALLOWED_AUTH_RETURN_PATHS,
+        AUTH_RETURN_PATHS,
       )
       const search = new URLSearchParams({ redirectTo })
       throw redirect({
@@ -45,7 +44,7 @@ export const Route = createFileRoute("/(authentication)/auth/$path")({
         const redirectTo = normalizeReturnPath(
           `${location.pathname}${invitationSearch ? `?${invitationSearch}` : ""}`,
           INERT_REDIRECT_ORIGIN,
-          ALLOWED_AUTH_RETURN_PATHS,
+          AUTH_RETURN_PATHS,
         )
         throw redirect({
           href: `/auth/sign-in?${new URLSearchParams({ redirectTo })}`,

--- a/webapp/src/routes/(authentication)/auth/$path.tsx
+++ b/webapp/src/routes/(authentication)/auth/$path.tsx
@@ -4,7 +4,7 @@ import { createFileRoute, notFound, redirect } from "@tanstack/react-router"
 import { Auth } from "@/components/auth/auth"
 import { getRouteSessionAccessDecision } from "@/lib/auth/session"
 import { normalizeReturnPath, normalizeReturnPathFromSearch } from "@/lib/auth/redirect"
-import { AUTH_RETURN_PATHS, INERT_REDIRECT_ORIGIN } from "@/lib/constants"
+import { AUTH_ALLOWED_RETURN_PATHS, INERT_REDIRECT_ORIGIN } from "@/lib/constants"
 
 const AUTH_PATHS = new Set([
   ...Object.values(viewPaths.auth),
@@ -28,7 +28,7 @@ export const Route = createFileRoute("/(authentication)/auth/$path")({
       const redirectTo = normalizeReturnPathFromSearch(
         location.searchStr,
         INERT_REDIRECT_ORIGIN,
-        AUTH_RETURN_PATHS,
+        AUTH_ALLOWED_RETURN_PATHS,
       )
       const search = new URLSearchParams({ redirectTo })
       throw redirect({
@@ -44,7 +44,7 @@ export const Route = createFileRoute("/(authentication)/auth/$path")({
         const redirectTo = normalizeReturnPath(
           `${location.pathname}${invitationSearch ? `?${invitationSearch}` : ""}`,
           INERT_REDIRECT_ORIGIN,
-          AUTH_RETURN_PATHS,
+          AUTH_ALLOWED_RETURN_PATHS,
         )
         throw redirect({
           href: `/auth/sign-in?${new URLSearchParams({ redirectTo })}`,

--- a/webapp/src/routes/__root.tsx
+++ b/webapp/src/routes/__root.tsx
@@ -26,7 +26,7 @@ import {
   APP_LOGO_LIGHT_PNG_URL,
   APP_LOGO_LIGHT_SVG_URL,
   APP_NAME,
-  AUTH_RETURN_PATHS,
+  AUTH_ALLOWED_RETURN_PATHS,
   DEFAULT_PUBLIC_CONFIG,
   INERT_REDIRECT_ORIGIN,
 } from "@/lib/constants"
@@ -88,7 +88,7 @@ export const Route = createRootRouteWithContext<{
     const redirectTo = normalizeReturnPath(
       rawRedirectTo,
       await getRedirectOrigin(),
-      AUTH_RETURN_PATHS,
+      AUTH_ALLOWED_RETURN_PATHS,
     )
 
     if (
@@ -176,7 +176,7 @@ function AppProviders({ children }: { children: ReactNode }) {
   const redirectTo = normalizeReturnPath(
     new URLSearchParams(searchStr).get("redirectTo"),
     origin,
-    AUTH_RETURN_PATHS,
+    AUTH_ALLOWED_RETURN_PATHS,
   )
 
   return (

--- a/webapp/src/routes/__root.tsx
+++ b/webapp/src/routes/__root.tsx
@@ -26,6 +26,7 @@ import {
   APP_LOGO_LIGHT_PNG_URL,
   APP_LOGO_LIGHT_SVG_URL,
   APP_NAME,
+  AUTH_RETURN_PATHS,
   DEFAULT_PUBLIC_CONFIG,
   INERT_REDIRECT_ORIGIN,
 } from "@/lib/constants"
@@ -33,7 +34,6 @@ import appCss from "@/styles.css?url"
 
 import { getPublicConfig } from "./-functions/get-public-config"
 
-const ALLOWED_AUTH_RETURN_PATHS = ["/auth/accept-invitation"] as const
 const APP_THEMES = ["system", "light", "dark"] as const
 type AppTheme = (typeof APP_THEMES)[number]
 const devtoolsConfig = { position: "bottom-right" } as const
@@ -88,7 +88,7 @@ export const Route = createRootRouteWithContext<{
     const redirectTo = normalizeReturnPath(
       rawRedirectTo,
       await getRedirectOrigin(),
-      ALLOWED_AUTH_RETURN_PATHS,
+      AUTH_RETURN_PATHS,
     )
 
     if (
@@ -176,7 +176,7 @@ function AppProviders({ children }: { children: ReactNode }) {
   const redirectTo = normalizeReturnPath(
     new URLSearchParams(searchStr).get("redirectTo"),
     origin,
-    ALLOWED_AUTH_RETURN_PATHS,
+    AUTH_RETURN_PATHS,
   )
 
   return (

--- a/webapp/src/routes/api/chat/-lib/constants.server.ts
+++ b/webapp/src/routes/api/chat/-lib/constants.server.ts
@@ -1,14 +1,14 @@
 import { APP_HANDLE, APP_NAME } from "@/lib/constants"
 
-export const BASE_SYSTEM_PROMPT =
+export const CHAT_SYSTEM_PROMPT =
   `You are the ${APP_NAME} assistant, embedded as a chat widget inside a host application. ` +
   "Be concise and act through the declared tools. Widgets and questionnaires already render " +
   "their results in the conversation, so do not repeat their content in your replies."
 
 // Interim per-instance abuse guard while the endpoint is unauthenticated: a fixed one-minute
 // request window per client address, held in memory.
-export const RATE_LIMIT_WINDOW_MS = 60_000
-export const RATE_LIMIT_MAX_REQUESTS = 20
+export const CHAT_RATE_LIMIT_WINDOW_MS = 60_000
+export const CHAT_RATE_LIMIT_MAX_REQUESTS = 20
 
 export const CHAT_TOKEN_AUDIENCE = `${APP_HANDLE}-chat`
 export const CHAT_TOKEN_ISSUER = `${APP_HANDLE}-global`
@@ -17,10 +17,10 @@ export const CHAT_TOKEN_KEY_ID = "global-v1"
 export const CHAT_TOKEN_MAX_LIFETIME_SECONDS = 600
 export const CHAT_TOKEN_MAX_LENGTH = 16_384
 
-export const ANSI_RESET = "\x1b[0m"
-export const ANSI_BADGE = "\x1b[45;97m" // magenta background, white text
-export const ANSI_DIM = "\x1b[2m"
-export const CATEGORY_ANSI: Record<string, string> = {
+export const DEBUG_ANSI_RESET = "\x1b[0m"
+export const DEBUG_ANSI_BADGE = "\x1b[45;97m" // magenta background, white text
+export const DEBUG_ANSI_DIM = "\x1b[2m"
+export const DEBUG_ANSI_BY_CATEGORY: Record<string, string> = {
   request: "\x1b[36m",
   run: "\x1b[34m",
   stream: "\x1b[35m",

--- a/webapp/src/routes/api/chat/-lib/debug.server.ts
+++ b/webapp/src/routes/api/chat/-lib/debug.server.ts
@@ -1,18 +1,23 @@
 import type { StreamChunk } from "@tanstack/ai"
 
 import { APP_HANDLE } from "@/lib/constants"
-import { ANSI_BADGE, ANSI_DIM, ANSI_RESET, CATEGORY_ANSI } from "./constants.server"
+import {
+  DEBUG_ANSI_BADGE,
+  DEBUG_ANSI_BY_CATEGORY,
+  DEBUG_ANSI_DIM,
+  DEBUG_ANSI_RESET,
+} from "./constants.server"
 import type { DebugLog } from "./types"
 
 // Mirrors the SDK's browser-console debug logger so a `debug: true` conversation can be
 // followed from both sides: UTC timestamp, colored category, then the full data object.
 export function createDebugLog(runId: string): DebugLog {
   return (category, summary, data) => {
-    const color = CATEGORY_ANSI[category] ?? ""
+    const color = DEBUG_ANSI_BY_CATEGORY[category] ?? ""
     console.log(
-      `${ANSI_BADGE} ${APP_HANDLE} ${ANSI_RESET} ${ANSI_DIM}${
+      `${DEBUG_ANSI_BADGE} ${APP_HANDLE} ${DEBUG_ANSI_RESET} ${DEBUG_ANSI_DIM}${
         new Date().toISOString()
-      } run=${runId}${ANSI_RESET} ${color}${category}${ANSI_RESET} ${summary}`,
+      } run=${runId}${DEBUG_ANSI_RESET} ${color}${category}${DEBUG_ANSI_RESET} ${summary}`,
     )
     if (data !== undefined) console.dir(data, { depth: null, colors: true })
   }

--- a/webapp/src/routes/api/chat/-lib/utils.server.ts
+++ b/webapp/src/routes/api/chat/-lib/utils.server.ts
@@ -1,4 +1,4 @@
-import { RATE_LIMIT_MAX_REQUESTS, RATE_LIMIT_WINDOW_MS } from "./constants.server"
+import { CHAT_RATE_LIMIT_MAX_REQUESTS, CHAT_RATE_LIMIT_WINDOW_MS } from "./constants.server"
 import type { ChatMessages } from "./types"
 
 // The SDK chat widget embeds on host origins the webapp does not serve, so the endpoint must
@@ -25,15 +25,15 @@ export function isRateLimited(request: Request): boolean {
   const client = request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() || "local"
   const now = Date.now()
   const window = requestWindows.get(client)
-  if (!window || now - window.windowStart >= RATE_LIMIT_WINDOW_MS) {
+  if (!window || now - window.windowStart >= CHAT_RATE_LIMIT_WINDOW_MS) {
     for (const [key, value] of requestWindows) {
-      if (now - value.windowStart >= RATE_LIMIT_WINDOW_MS) requestWindows.delete(key)
+      if (now - value.windowStart >= CHAT_RATE_LIMIT_WINDOW_MS) requestWindows.delete(key)
     }
     requestWindows.set(client, { windowStart: now, count: 1 })
     return false
   }
   window.count += 1
-  return window.count > RATE_LIMIT_MAX_REQUESTS
+  return window.count > CHAT_RATE_LIMIT_MAX_REQUESTS
 }
 
 // The OpenAI adapter replays a completed tool call's Responses item id (metadata.itemId)

--- a/webapp/src/routes/api/chat/index.ts
+++ b/webapp/src/routes/api/chat/index.ts
@@ -13,7 +13,7 @@ import {
   isChatAuthenticationConfigurationError,
   isChatAuthenticationError,
 } from "./-lib/auth.server"
-import { BASE_SYSTEM_PROMPT, CHAT_TOKEN_AUDIENCE } from "./-lib/constants.server"
+import { CHAT_SYSTEM_PROMPT, CHAT_TOKEN_AUDIENCE } from "./-lib/constants.server"
 import { createDebugLog, withDebugLog } from "./-lib/debug.server"
 import type { ChatParams } from "./-lib/types"
 import {
@@ -88,7 +88,7 @@ export const Route = createFileRoute("/api/chat/")({
             adapter: createOpenaiChat("gpt-5.6-terra", openaiApiKey),
             messages: stripToolCallMetadata(params.messages),
             systemPrompts: [
-              BASE_SYSTEM_PROMPT,
+              CHAT_SYSTEM_PROMPT,
               ...(typeof systemPrompt === "string" && systemPrompt.length > 0
                 ? [systemPrompt]
                 : []),

--- a/webapp/src/routes/configure/-components/config-field-groups.tsx
+++ b/webapp/src/routes/configure/-components/config-field-groups.tsx
@@ -4,7 +4,11 @@ import { GlobeIcon } from "@phosphor-icons/react"
 
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { CURRENT_ORIGIN_KEY, FIELD_GROUPS, ROTATABLE_KEYS } from "../-lib/constants"
+import {
+  APP_BASE_URL_CONFIG_KEY,
+  CONFIG_FIELD_GROUPS,
+  ROTATABLE_CONFIG_KEYS,
+} from "../-lib/constants"
 import type { ConfigureField, FieldDraft } from "../-lib/types"
 import { ConfigFieldInput } from "./config-field-input"
 
@@ -25,7 +29,7 @@ export function ConfigFieldGroups({
 }) {
   const fieldsByKey = new Map(fields.map((field) => [field.key, field]))
 
-  return FIELD_GROUPS.map((group) => {
+  return CONFIG_FIELD_GROUPS.map((group) => {
     const groupFields = group.keys
       .map((key) => fieldsByKey.get(key))
       .filter((field): field is ConfigureField => field !== undefined)
@@ -45,8 +49,10 @@ export function ConfigFieldGroups({
               error={fieldErrors[field.key]}
               disabled={disabled}
               onDraftChange={(draft) => onDraftChange(field.key, draft)}
-              onRotate={ROTATABLE_KEYS.has(field.key) ? () => onRotate(field.key) : undefined}
-              footer={field.key === CURRENT_ORIGIN_KEY
+              onRotate={ROTATABLE_CONFIG_KEYS.has(field.key)
+                ? () => onRotate(field.key)
+                : undefined}
+              footer={field.key === APP_BASE_URL_CONFIG_KEY
                 ? (
                   <Button
                     type="button"

--- a/webapp/src/routes/configure/-components/operator-login-form.tsx
+++ b/webapp/src/routes/configure/-components/operator-login-form.tsx
@@ -17,7 +17,7 @@ export function OperatorLoginForm({ onLoggedIn }: { onLoggedIn: () => void }) {
   const [error, setError] = useState<string | null>(null)
   const [pending, setPending] = useState(false)
 
-  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+  const submitOperatorLogin = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
     setPending(true)
     setError(null)
@@ -44,7 +44,7 @@ export function OperatorLoginForm({ onLoggedIn }: { onLoggedIn: () => void }) {
         </CardTitle>
       </CardHeader>
       <CardContent>
-        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+        <form onSubmit={submitOperatorLogin} className="flex flex-col gap-4">
           <p className="text-sm text-muted-foreground">
             Enter your database credentials for this deployment to manage the configuration.
           </p>

--- a/webapp/src/routes/configure/-lib/constants.server.ts
+++ b/webapp/src/routes/configure/-lib/constants.server.ts
@@ -2,4 +2,4 @@ export const OPERATOR_SESSION_COOKIE = "operator_session"
 // Operator sessions are deliberately short: they hold database-credential-level access to every
 // runtime setting, so they expire outright rather than sliding on activity.
 export const OPERATOR_SESSION_TTL_SECONDS = 20 * 60
-export const MIGRATION_ADVISORY_LOCK_KEY = "config_migrations"
+export const CONFIG_MIGRATION_LOCK_KEY = "config_migrations"

--- a/webapp/src/routes/configure/-lib/constants.ts
+++ b/webapp/src/routes/configure/-lib/constants.ts
@@ -1,5 +1,5 @@
 /** Registry keys laid out in the order the editor shows them, grouped into one card each. */
-export const FIELD_GROUPS: { title: string; keys: string[] }[] = [
+export const CONFIG_FIELD_GROUPS: { title: string; keys: string[] }[] = [
   {
     title: "General",
     keys: ["app_base_url", "privacy_policy_url", "terms_of_service_url", "chat_auth_secret"],
@@ -28,7 +28,7 @@ export const FIELD_GROUPS: { title: string; keys: string[] }[] = [
   { title: "LLM Providers", keys: ["openai_api_key"] },
 ]
 
-export const ROTATABLE_KEYS = new Set(["better_auth_secret", "chat_auth_secret"])
+export const ROTATABLE_CONFIG_KEYS = new Set(["better_auth_secret", "chat_auth_secret"])
 
 // The base URL is the origin the operator is already browsing, so the editor offers to fill it in.
-export const CURRENT_ORIGIN_KEY = "app_base_url"
+export const APP_BASE_URL_CONFIG_KEY = "app_base_url"

--- a/webapp/src/routes/configure/-lib/db.server.ts
+++ b/webapp/src/routes/configure/-lib/db.server.ts
@@ -1,7 +1,7 @@
 import { eq, sql } from "drizzle-orm"
 
 import { db } from "@/db/index.server"
-import { config } from "@/db/schema.server"
+import { configTable } from "@/db/schema.server"
 import { isMissingTableError } from "@/lib/config.server"
 
 interface ConfigRow {
@@ -16,12 +16,12 @@ export async function listConfigRows(): Promise<ConfigRow[] | null> {
   try {
     return await db
       .select({
-        key: config.key,
-        value: config.value,
-        updatedAt: config.updatedAt,
-        updatedBy: config.updatedBy,
+        key: configTable.key,
+        value: configTable.value,
+        updatedAt: configTable.updatedAt,
+        updatedBy: configTable.updatedBy,
       })
-      .from(config)
+      .from(configTable)
   } catch (error) {
     if (isMissingTableError(error)) return null
     throw error
@@ -32,15 +32,15 @@ export async function upsertConfigValue(
   { key, value, updatedBy }: { key: string; value: unknown; updatedBy: string | null },
 ): Promise<void> {
   await db
-    .insert(config)
+    .insert(configTable)
     .values({ key, value, updatedBy })
     .onConflictDoUpdate({
-      target: config.key,
+      target: configTable.key,
       // Upserts bypass Drizzle's $onUpdateFn hook, so updated_at is set explicitly.
       set: { value, updatedBy, updatedAt: sql`now()` },
     })
 }
 
 export async function deleteConfigValue(key: string): Promise<void> {
-  await db.delete(config).where(eq(config.key, key))
+  await db.delete(configTable).where(eq(configTable.key, key))
 }

--- a/webapp/src/routes/configure/-lib/migrations.server.ts
+++ b/webapp/src/routes/configure/-lib/migrations.server.ts
@@ -5,7 +5,7 @@ import postgres from "postgres"
 
 import { db } from "@/db/index.server"
 import { DATABASE_URL, hasPostgresErrorCode, invalidateConfigCache } from "@/lib/config.server"
-import { MIGRATION_ADVISORY_LOCK_KEY } from "./constants.server"
+import { CONFIG_MIGRATION_LOCK_KEY } from "./constants.server"
 import { promoteMemorySessions } from "./operator-session.server"
 
 export interface BundledMigration {
@@ -124,7 +124,7 @@ export async function applyPendingMigrations(
   const client = postgres(DATABASE_URL, { max: 1 })
   try {
     const [lock] = await client`
-      select pg_try_advisory_lock(hashtext(${MIGRATION_ADVISORY_LOCK_KEY})) as locked
+      select pg_try_advisory_lock(hashtext(${CONFIG_MIGRATION_LOCK_KEY})) as locked
     `
     if (!lock?.locked) return { ok: false, error: "A migration run is already in progress" }
     try {
@@ -178,7 +178,7 @@ export async function applyPendingMigrations(
       }
       return { ok: true, applied }
     } finally {
-      await client`select pg_advisory_unlock(hashtext(${MIGRATION_ADVISORY_LOCK_KEY}))`
+      await client`select pg_advisory_unlock(hashtext(${CONFIG_MIGRATION_LOCK_KEY}))`
     }
   } finally {
     await client.end()

--- a/webapp/src/routes/configure/-lib/operator-session.server.test.ts
+++ b/webapp/src/routes/configure/-lib/operator-session.server.test.ts
@@ -2,7 +2,7 @@ import { createHash } from "node:crypto"
 
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest"
 
-const state = vi.hoisted(() => ({
+const operatorSessionTestState = vi.hoisted(() => ({
   tableExists: false,
   inserted: [] as Record<string, unknown>[],
   selectRows: [] as { dbUsername: string; expiresAt: Date }[],
@@ -21,8 +21,8 @@ vi.mock("@/db/index.server", () => ({
     insert: () => ({
       values: (row: Record<string, unknown>) => {
         const execute = () => {
-          if (!state.tableExists) return Promise.reject(missingTableError())
-          state.inserted.push(row)
+          if (!operatorSessionTestState.tableExists) return Promise.reject(missingTableError())
+          operatorSessionTestState.inserted.push(row)
           return Promise.resolve()
         }
         return {
@@ -37,13 +37,16 @@ vi.mock("@/db/index.server", () => ({
     select: () => ({
       from: () => ({
         where: () =>
-          state.tableExists
-            ? Promise.resolve(state.selectRows)
+          operatorSessionTestState.tableExists
+            ? Promise.resolve(operatorSessionTestState.selectRows)
             : Promise.reject(missingTableError()),
       }),
     }),
     delete: () => ({
-      where: () => (state.tableExists ? Promise.resolve() : Promise.reject(missingTableError())),
+      where: () =>
+        operatorSessionTestState.tableExists
+          ? Promise.resolve()
+          : Promise.reject(missingTableError()),
     }),
   },
 }))
@@ -54,9 +57,9 @@ import { OPERATOR_SESSION_TTL_SECONDS } from "./constants.server"
 describe("operator session boundary", () => {
   beforeEach(() => {
     vi.useFakeTimers()
-    state.tableExists = false
-    state.inserted = []
-    state.selectRows = []
+    operatorSessionTestState.tableExists = false
+    operatorSessionTestState.inserted = []
+    operatorSessionTestState.selectRows = []
   })
 
   afterEach(() => {
@@ -80,10 +83,10 @@ describe("operator session boundary", () => {
   })
 
   test("database sessions store only a token hash", async () => {
-    state.tableExists = true
+    operatorSessionTestState.tableExists = true
     const token = await createOperatorSession("astralbeam")
-    expect(state.inserted).toHaveLength(1)
-    const stored = state.inserted[0]
+    expect(operatorSessionTestState.inserted).toHaveLength(1)
+    const stored = operatorSessionTestState.inserted[0]
     expect(stored?.tokenHash).toBe(createHash("sha256").update(token).digest("hex"))
     expect(JSON.stringify(stored)).not.toContain(token)
   })
@@ -91,19 +94,22 @@ describe("operator session boundary", () => {
   test("bootstrap sessions move into the database once the table exists", async () => {
     const token = await createOperatorSession("astralbeam")
     const tokenHash = createHash("sha256").update(token).digest("hex")
-    expect(state.inserted).toHaveLength(0)
+    expect(operatorSessionTestState.inserted).toHaveLength(0)
 
-    state.tableExists = true
+    operatorSessionTestState.tableExists = true
     await expect(verifyOperatorSession(token)).resolves.toEqual({
       dbUsername: "astralbeam",
       expiresAt: currentExpiry(),
     })
-    expect(state.inserted.some((row) => row.tokenHash === tokenHash)).toBe(true)
+    expect(operatorSessionTestState.inserted.some((row) => row.tokenHash === tokenHash)).toBe(true)
 
     // The memory copy is gone: verification now depends on the database row alone.
-    state.selectRows = []
+    operatorSessionTestState.selectRows = []
     await expect(verifyOperatorSession(token)).resolves.toBeNull()
-    state.selectRows = [{ dbUsername: "astralbeam", expiresAt: currentExpiry() }]
+    operatorSessionTestState.selectRows = [{
+      dbUsername: "astralbeam",
+      expiresAt: currentExpiry(),
+    }]
     await expect(verifyOperatorSession(token)).resolves.toEqual({
       dbUsername: "astralbeam",
       expiresAt: currentExpiry(),

--- a/webapp/vite.config.ts
+++ b/webapp/vite.config.ts
@@ -29,7 +29,7 @@ const legalAssets = [
     })),
 ]
 
-const config = defineConfig(({ mode }) => {
+const viteConfig = defineConfig(({ mode }) => {
   // Expand mode files through Vite before server modules read process.env; existing shell and
   // deployment variables still win. https://vite.dev/config/#using-environment-variables-in-config
   const runtimeEnvironment = loadEnv(mode, fileURLToPath(new URL(".", import.meta.url)), "")
@@ -67,4 +67,4 @@ const config = defineConfig(({ mode }) => {
   }
 })
 
-export default config
+export default viteConfig


### PR DESCRIPTION
- Rename repeated and generic webapp functions and constants with concise auth, organization, chat, email-provider, configuration, debug, and test qualifiers.
- Share the authentication return-path constant and keep TanStack Router's required `Route` export as the documented framework exception.
- Record the globally unique naming convention in `webapp/AGENTS.md`.
