### PR TITLE
Surface authentication email delivery failures

### DIFF
--- a/webapp/src/emails/index.ts
+++ b/webapp/src/emails/index.ts
@@ -154,11 +154,16 @@ async function deliverAuthEmail(
 
   try {
     await sendEmail(options)
-  } catch {
-    // Record the failure category without retaining provider responses, recipients, or token URLs.
-    console.error("Authentication email provider delivery failed")
+  } catch (error) {
+    // Log the provider's own reason, which an operator needs to fix a rejected sender or key, but
+    // never the options: they carry the recipient, the rendered email, and the token URL.
+    console.error("Authentication email provider delivery failed:", providerFailureReason(error))
     throw new Error(AUTH_EMAIL_DELIVERY_ERROR)
   }
+}
+
+function providerFailureReason(error: unknown): string {
+  return error instanceof Error && error.message ? error.message : "unknown provider failure"
 }
 
 function formatTimestamp(date: Date): string {

--- a/webapp/src/lib/auth.server.ts
+++ b/webapp/src/lib/auth.server.ts
@@ -20,6 +20,10 @@ import { getRequiredConfig } from "@/lib/config.server"
 import type { ConfigSnapshot } from "@/lib/types"
 import { APP_NAME } from "@/lib/constants"
 import {
+  assertAuthEmailDelivered,
+  deliverBlockingAuthEmail,
+} from "@/lib/auth/email-delivery.server"
+import {
   acceptedAtForUserCreation,
   assertLegalAcceptance,
   recordValue,
@@ -47,6 +51,8 @@ async function runAfterResponse(promise: Promise<unknown>): Promise<void> {
   await promise
 }
 
+// A password-change notice is informational and its recipient is not waiting on it, so it stays
+// deferred past the response instead of blocking like the emails deliverBlockingAuthEmail guards.
 async function notifyPasswordChanged(user: { email: string }): Promise<void> {
   await runAfterResponse(
     sendPasswordChangedEmail({ user }).catch(() => {
@@ -99,8 +105,8 @@ function buildAuth(snapshot: ConfigSnapshot) {
       resetPasswordTokenExpiresIn: AUTH_EMAIL_EXPIRY_SECONDS,
       revokeSessionsOnPasswordReset: true,
       customSyntheticUser: ({ coreFields }) => createSyntheticUser(coreFields),
-      // Better Auth schedules the returned promise through advanced.backgroundTasks. https://better-auth.com/docs/concepts/email
-      sendResetPassword: ({ user, url }) => sendResetPasswordEmail({ user, url }),
+      sendResetPassword: ({ user, url }) =>
+        deliverBlockingAuthEmail(() => sendResetPasswordEmail({ user, url })),
       onPasswordReset: async ({ user }) => {
         await notifyPasswordChanged(user)
       },
@@ -110,9 +116,8 @@ function buildAuth(snapshot: ConfigSnapshot) {
       sendOnSignUp: true,
       sendOnSignIn: false,
       autoSignInAfterVerification: true,
-      sendVerificationEmail: async ({ user, url }) => {
-        await runAfterResponse(sendVerificationEmail({ user, url }))
-      },
+      sendVerificationEmail: ({ user, url }) =>
+        deliverBlockingAuthEmail(() => sendVerificationEmail({ user, url })),
     },
     socialProviders: {
       ...(snapshot.google && {
@@ -186,18 +191,12 @@ function buildAuth(snapshot: ConfigSnapshot) {
       },
     },
     advanced: {
+      // advanced.backgroundTasks stays unset so Better Auth awaits each email send inside the
+      // request; a handler would defer it and swallow the rejection. https://better-auth.com/docs/concepts/email
       database: {
         // Let PostgreSQL apply the schema's UUIDv7 defaults. https://better-auth.com/docs/concepts/database#id-generation
         generateId: false,
         joins: true,
-      },
-      backgroundTasks: {
-        // Nitro exposes request.waitUntil in its Deno adapter. https://better-auth.com/docs/concepts/email
-        handler: (promise) => {
-          void runAfterResponse(promise).catch(() => {
-            console.error("Authentication background task failed")
-          })
-        },
       },
     },
     hooks: {
@@ -213,6 +212,7 @@ function buildAuth(snapshot: ConfigSnapshot) {
         await addOAuthServerContext({ termsAccepted: true })
       }),
       after: createAuthMiddleware(async (context) => {
+        assertAuthEmailDelivered()
         if (context.path !== "/change-password" || isAPIError(context.context.returned)) return
         const user = context.context.session?.user
         if (user) await notifyPasswordChanged(user)
@@ -246,9 +246,8 @@ function buildAuth(snapshot: ConfigSnapshot) {
         invitationExpiresIn: ORGANIZATION_INVITATION_EXPIRY_SECONDS,
         requireEmailVerificationOnInvitation: true,
         disableOrganizationDeletion: true,
-        sendInvitationEmail: async (data) => {
-          await sendOrganizationInvitationEmail(data)
-        },
+        sendInvitationEmail: (data) =>
+          deliverBlockingAuthEmail(() => sendOrganizationInvitationEmail(data)),
       }),
       tanstackStartCookies(),
     ],

--- a/webapp/src/lib/auth/email-delivery.server.test.ts
+++ b/webapp/src/lib/auth/email-delivery.server.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, test, vi } from "vitest"
+
+const emailDeliveryTestState = vi.hoisted(() => ({
+  request: null as Request | null,
+}))
+
+vi.mock("@tanstack/react-start/server", () => ({
+  getRequest: () => {
+    if (!emailDeliveryTestState.request) throw new Error("no request context")
+    return emailDeliveryTestState.request
+  },
+}))
+
+import {
+  assertAuthEmailDelivered,
+  deliverBlockingAuthEmail,
+} from "@/lib/auth/email-delivery.server"
+
+function useRequestContext(): Request {
+  emailDeliveryTestState.request = new Request("https://example.com/api/auth/sign-up/email")
+  return emailDeliveryTestState.request
+}
+
+afterEach(() => {
+  emailDeliveryTestState.request = null
+})
+
+describe("authentication email delivery boundary", () => {
+  test("a failed send fails the response instead of passing silently", async () => {
+    useRequestContext()
+    await expect(deliverBlockingAuthEmail(() => Promise.reject(new Error("provider down"))))
+      .rejects.toThrow("provider down")
+
+    expect(() => assertAuthEmailDelivered()).toThrow()
+  })
+
+  test("a delivered send leaves the response untouched", async () => {
+    useRequestContext()
+    await deliverBlockingAuthEmail(() => Promise.resolve())
+
+    expect(() => assertAuthEmailDelivered()).not.toThrow()
+  })
+
+  test("a failure is scoped to the request that saw it", async () => {
+    useRequestContext()
+    await expect(deliverBlockingAuthEmail(() => Promise.reject(new Error("provider down"))))
+      .rejects.toThrow("provider down")
+
+    useRequestContext()
+    expect(() => assertAuthEmailDelivered()).not.toThrow()
+  })
+
+  test("the surfaced error never repeats the provider's reason", async () => {
+    useRequestContext()
+    await expect(deliverBlockingAuthEmail(() => Promise.reject(new Error("smtp-secret-detail"))))
+      .rejects.toThrow("smtp-secret-detail")
+
+    expect(() => assertAuthEmailDelivered()).toThrow(/could not send the email/i)
+    expect(() => assertAuthEmailDelivered()).not.toThrow()
+  })
+})

--- a/webapp/src/lib/auth/email-delivery.server.ts
+++ b/webapp/src/lib/auth/email-delivery.server.ts
@@ -1,0 +1,46 @@
+import { getRequest } from "@tanstack/react-start/server"
+import { APIError } from "better-auth/api"
+
+/**
+ * Better Auth routes every send through `runInBackgroundOrAwait`, which logs a rejection and
+ * swallows it, so a throw inside `sendVerificationEmail` never reaches the client. Blocking sends
+ * record their failure against the current request here, and `assertAuthEmailDelivered` turns it
+ * into an error response from the `after` hook.
+ */
+const failedAuthEmailRequests = new WeakSet<Request>()
+
+const AUTH_EMAIL_FAILURE_MESSAGE =
+  "We could not send the email. Please try again in a few minutes, or contact support if it keeps failing."
+
+function currentAuthEmailRequest(): Request | null {
+  try {
+    return getRequest()
+  } catch {
+    // Auth CLI calls and direct server API calls can run outside TanStack's request context.
+    return null
+  }
+}
+
+/**
+ * Awaits an authentication email the caller is waiting on, so the response reports the outcome
+ * instead of completing while delivery fails out of band.
+ */
+export async function deliverBlockingAuthEmail(send: () => Promise<void>): Promise<void> {
+  try {
+    await send()
+  } catch (error) {
+    const request = currentAuthEmailRequest()
+    if (request) failedAuthEmailRequests.add(request)
+    throw error
+  }
+}
+
+/** Fails the response when a blocking authentication email could not be delivered. */
+export function assertAuthEmailDelivered(): void {
+  const request = currentAuthEmailRequest()
+  if (!request || !failedAuthEmailRequests.has(request)) return
+  failedAuthEmailRequests.delete(request)
+  // No `code`: Better Auth UI prefers a localized string for a known code and would otherwise
+  // show the raw identifier, while `message` is rendered as written.
+  throw new APIError("INTERNAL_SERVER_ERROR", { message: AUTH_EMAIL_FAILURE_MESSAGE })
+}

--- a/webapp/src/lib/config.server.test.ts
+++ b/webapp/src/lib/config.server.test.ts
@@ -96,6 +96,20 @@ describe("config snapshot boundary", () => {
     })
   })
 
+  test("a malformed from address is rejected instead of reaching the provider", () => {
+    const malformed = buildConfigSnapshot([
+      ...completeRows,
+      row("email_from_address", "onboarding.resend.dev"),
+    ])
+    expect(malformed.emailFromAddress).toBeNull()
+
+    const named = buildConfigSnapshot([
+      ...completeRows,
+      row("email_from_address", "App <onboarding@resend.dev>"),
+    ])
+    expect(named.emailFromAddress).toBe("App <onboarding@resend.dev>")
+  })
+
   test("a selected email provider requires its credential", () => {
     const issues = validateConfigCompleteness({
       app_base_url: "http://localhost:3000",

--- a/webapp/src/lib/config.server.ts
+++ b/webapp/src/lib/config.server.ts
@@ -52,6 +52,22 @@ const decodeSecretValue = Schema.decodeUnknownSync(
   Schema.String.pipe(Schema.check(Schema.isMinLength(32))),
 )
 const decodeNonEmptyText = Schema.decodeUnknownSync(Schema.NonEmptyString)
+
+// Resend rejects a From value that is not `email@example.com` or `Name <email@example.com>`, and
+// SES has the same requirement, so the shape is validated here instead of failing at send time.
+// https://resend.com/docs/api-reference/emails/send-email
+const EMAIL_ADDRESS_PATTERN = /^[^\s@<>,]+@[^\s@<>,.]+(?:\.[^\s@<>,.]+)+$/
+const NAMED_EMAIL_ADDRESS_PATTERN = /^(?:[^<>@,]*\S\s*)?<([^\s<>,]+)>$/
+
+const decodeEmailFromAddress = Schema.decodeUnknownSync(
+  Schema.String.pipe(
+    Schema.check(
+      Schema.makeFilter((value) =>
+        EMAIL_ADDRESS_PATTERN.test(NAMED_EMAIL_ADDRESS_PATTERN.exec(value)?.[1] ?? value)
+      ),
+    ),
+  ),
+)
 const decodeEmailProvider = Schema.decodeUnknownSync(Schema.Literals(["resend", "ses"]))
 const decodePublicHttpUrl = Schema.decodeUnknownSync(
   Schema.URLFromString.pipe(
@@ -196,11 +212,15 @@ export const CONFIG_DEFINITIONS: readonly ConfigDefinition[] = [
   {
     key: "email_from_address",
     label: "Email From Address",
-    description: "Default From address for outgoing email.",
+    description:
+      "Default From address for outgoing email, as 'email@example.com' or 'Name <email@example.com>'.",
     kind: "text",
     required: false,
     secret: false,
-    decode: nonEmptyDecoder("Email from address"),
+    decode: sanitizedDecoder(
+      decodeEmailFromAddress,
+      "Email from address must be 'email@example.com' or 'Name <email@example.com>'",
+    ),
   },
   {
     key: "resend_api_key",
@@ -316,6 +336,12 @@ export function validateConfigCompleteness(values: ConfigValues): ConfigIssue[] 
         message: `${configDefinition(missing)?.label} is required to enable this sign-in provider`,
       })
     }
+  }
+  if (values.email_provider && !values.email_from_address) {
+    issues.push({
+      key: "email_from_address",
+      message: "An email provider is selected but no valid From address is configured",
+    })
   }
   if (values.email_provider === "resend" && !values.resend_api_key) {
     issues.push({


### PR DESCRIPTION
- Block on authentication email delivery so a failed send fails the request the user is waiting on, instead of completing behind a "check your inbox" screen:
  - `advanced.backgroundTasks` is now left unset, so Better Auth awaits `sendVerificationEmail`, `sendResetPassword`, and `sendInvitationEmail` inside the request rather than deferring them to `request.waitUntil`.
  - Better Auth routes every send through `runInBackgroundOrAwait`, which logs a rejection and swallows it, so a throw inside the callback can never reach the client on its own. `deliverBlockingAuthEmail` records the failure against the current request and `assertAuthEmailDelivered` converts it into an `APIError` from the `after` hook, which Better Auth returns as the response.
  - The surfaced message is deliberately generic and carries no `code`, so Better Auth UI renders the sentence rather than a raw identifier, and the provider's reason never reaches the client.
  - The password-change notice stays deferred past the response: it is informational and its recipient is not waiting on it, so an email outage should not fail a completed password change.
- Validate the From address shape in the config registry, since Resend and SES accept only `email@example.com` or `Name <email@example.com>`. A typo such as `onboarding.resend.dev` previously saved cleanly at `/configure` and only failed at send time with a provider [422](https://resend.com/docs/api-reference/emails/send-email).
  - `/configure` now also reports a missing or invalid From address whenever an email provider is selected.
  - The validation error stays value-free, matching the existing config error rules.
- Log the provider's own reason for a failed send, which an operator needs to fix a rejected sender or key, while keeping the recipient, rendered email, and token URL out of the log.
- Add tests covering the delivery boundary (failure fails the response, per-request scoping, no provider detail in the surfaced error) and the rejected From address.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
