### PR TITLE
Replay tool calls without their Responses item id

### DIFF
--- a/webapp/src/routes/api/chat/-lib/adapter.server.test.ts
+++ b/webapp/src/routes/api/chat/-lib/adapter.server.test.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "vitest"
+
+import { createChatAdapter } from "./adapter.server"
+
+import type { ModelMessage } from "@tanstack/ai"
+
+/** Responses input item, structurally: `openai` is not a direct dependency of this project. */
+interface InputItem extends Record<string, unknown> {
+  type?: string
+}
+
+/** `convertMessagesToInput` is protected, and its output is the whole point of the override. */
+function convert(messages: Array<ModelMessage>): Array<InputItem> {
+  const adapter = createChatAdapter("sk-test") as unknown as {
+    convertMessagesToInput: (messages: Array<ModelMessage>) => Array<InputItem>
+  }
+  return adapter.convertMessagesToInput(messages)
+}
+
+// A reasoning model 400s on a replayed `function_call` whose `reasoning` item is absent, which
+// broke every host tool result until the item id stopped being sent.
+test("replays a tool call without the Responses item id that requires a reasoning item", () => {
+  const input = convert([
+    { role: "user", content: "tell me about chemical hygiene" },
+    {
+      role: "assistant",
+      content: "",
+      toolCalls: [
+        {
+          id: "call_1",
+          type: "function",
+          function: { name: "searchDocuments", arguments: '{"query":"chemical hygiene"}' },
+          metadata: { itemId: "fc_0d130cb4c88ab49e" },
+        },
+      ],
+    },
+    { role: "tool", toolCallId: "call_1", content: '{"results":[]}' },
+  ])
+
+  const functionCall = input.find((item) => item.type === "function_call")
+  expect(functionCall).toMatchObject({ type: "function_call", call_id: "call_1" })
+  expect(functionCall).not.toHaveProperty("id")
+
+  // The result still has to reach the model, or the run resumes with no tool output.
+  expect(input.at(-1)).toMatchObject({ type: "function_call_output", call_id: "call_1" })
+})

--- a/webapp/src/routes/api/chat/-lib/adapter.server.ts
+++ b/webapp/src/routes/api/chat/-lib/adapter.server.ts
@@ -1,0 +1,34 @@
+import { OpenAITextAdapter } from "@tanstack/ai-openai"
+
+import type { ModelMessage } from "@tanstack/ai"
+
+/** Model every chat run streams from. */
+const CHAT_MODEL = "gpt-5.6-terra"
+
+/**
+ * Chat adapter that replays a completed tool call by `call_id` alone.
+ *
+ * The base adapter captures each `function_call`'s Responses item id from the stream and replays it
+ * as `id` on the following request, but never replays the `reasoning` item the call was paired with.
+ * A reasoning model rejects that pairing with "Item 'fc_...' of type 'function_call' was provided
+ * without its required 'reasoning' item", which fails the run the moment a host tool result comes
+ * back and leaves the widget with no reply. Dropping the item id makes the call match on `call_id`,
+ * which carries no reasoning requirement.
+ *
+ * https://platform.openai.com/docs/guides/reasoning#keeping-reasoning-items-in-context
+ */
+class ChatAdapter extends OpenAITextAdapter<typeof CHAT_MODEL> {
+  // The return type is inherited: `openai` is not a direct dependency, so its `ResponseInput`
+  // cannot be named here, and dropping an optional property keeps each item's own type.
+  protected override convertMessagesToInput(messages: Array<ModelMessage>) {
+    return super.convertMessagesToInput(messages).map((item) => {
+      if (!("type" in item) || item.type !== "function_call" || !("id" in item)) return item
+      const { id: _itemId, ...withoutItemId } = item
+      return withoutItemId as typeof item
+    })
+  }
+}
+
+export function createChatAdapter(apiKey: string) {
+  return new ChatAdapter({ apiKey }, CHAT_MODEL)
+}

--- a/webapp/src/routes/api/chat/-lib/utils.server.ts
+++ b/webapp/src/routes/api/chat/-lib/utils.server.ts
@@ -4,7 +4,6 @@ import {
   CHAT_RATE_LIMIT_WINDOW_MS,
   CHAT_TOKEN_AUDIENCE,
 } from "./constants.server"
-import type { ChatMessages } from "./types"
 
 // The SDK chat widget embeds on host origins the webapp does not serve, so the endpoint must
 // answer cross-origin requests. Bearer auth uses no cookies, so "*" remains valid; the allowed
@@ -53,27 +52,4 @@ export function isRateLimited(request: Request): boolean {
   }
   window.count += 1
   return window.count > CHAT_RATE_LIMIT_MAX_REQUESTS
-}
-
-// The OpenAI adapter replays a completed tool call's Responses item id (metadata.itemId)
-// on follow-up requests but not the reasoning item it was paired with, which reasoning
-// models reject with a 400. Dropping the metadata replays the call by call_id alone.
-export function stripToolCallMetadata(messages: ChatMessages): ChatMessages {
-  return messages.map((message) => {
-    if ("parts" in message && Array.isArray(message.parts)) {
-      return {
-        ...message,
-        parts: message.parts.map((part) =>
-          part.type === "tool-call" ? { ...part, metadata: undefined } : part
-        ),
-      }
-    }
-    if ("toolCalls" in message && Array.isArray(message.toolCalls)) {
-      return {
-        ...message,
-        toolCalls: message.toolCalls.map((toolCall) => ({ ...toolCall, metadata: undefined })),
-      }
-    }
-    return message
-  })
 }

--- a/webapp/src/routes/api/chat/index.ts
+++ b/webapp/src/routes/api/chat/index.ts
@@ -4,10 +4,10 @@ import {
   mergeAgentTools,
   toServerSentEventsResponse,
 } from "@tanstack/ai"
-import { createOpenaiChat } from "@tanstack/ai-openai"
 import { createFileRoute } from "@tanstack/react-router"
 
 import { getConfig, setupGateResponse } from "@/lib/config.server"
+import { createChatAdapter } from "./-lib/adapter.server"
 import { normalizeChatAttachments, redactChatAttachmentData } from "./-lib/attachments.server"
 import {
   authenticateChatRequest,
@@ -22,7 +22,6 @@ import {
   errorResponse,
   isChatRequestTooLarge,
   isRateLimited,
-  stripToolCallMetadata,
   unauthorizedChatResponse,
 } from "./-lib/utils.server"
 
@@ -94,15 +93,13 @@ export const Route = createFileRoute("/api/chat/")({
           // Attachments are rewritten into what the model reads before the run starts: the
           // provider adapter throws on a content part it cannot map, which would fail the whole
           // run over one unsupported file.
-          const { messages, attachments } = normalizeChatAttachments(
-            stripToolCallMetadata(params.messages),
-          )
+          const { messages, attachments } = normalizeChatAttachments(params.messages)
           if (log && attachments.length > 0) {
             log("attachment", `${attachments.length} attachment(s) normalized`, attachments)
           }
           const abortController = new AbortController()
           const stream = chat({
-            adapter: createOpenaiChat("gpt-5.6-terra", openaiApiKey),
+            adapter: createChatAdapter(openaiApiKey),
             messages,
             systemPrompts: [
               CHAT_SYSTEM_PROMPT,


### PR DESCRIPTION
A chat run died with no reply as soon as a host tool returned its result:

```
400 Item 'fc_0d130cb4c88ab49e...' of type 'function_call' was provided without
its required 'reasoning' item: 'rs_0d130cb4c88ab49e...'
```

Plain chat worked, the tool executed fine, and then the stream ended silently — so the widget showed the tool call and nothing after it.

## Cause

Three layers cooperate to reintroduce the item id:

1. `openai-base` `responses-text.ts` captures each `function_call`'s Responses item id off the stream as `metadata.itemId`.
2. `@tanstack/ai` `processor.ts` keeps it on purpose — *"Capture provider metadata that arrived on TOOL_CALL_START so it round-trips back through the assistant message on the next turn"* — and `messages.ts` puts it on the assistant message.
3. `responses-text.ts` `convertMessagesToInput` re-emits it as `...(itemId && { id: itemId })`.

Replaying `fc_…` obliges you to replay the `rs_…` reasoning item with it, which nothing here models, so a reasoning model rejects the request. We run `gpt-5.6-terra` with `reasoning: { effort: "high" }`, so every client-tool round trip hit this.

## Why the existing mitigation missed it

`stripToolCallMetadata` was written for exactly this 400, and it worked — but it only sanitized inbound `params.messages`. The failing request isn't built from those: when a run resumes after a client tool, the loop rebuilds the provider request from its own accumulated state, carrying the item ids it captured live from the stream. The strip never saw them.

So the fix moves down a layer, to `convertMessagesToInput`, which every request funnels through regardless of where its messages came from. That makes `stripToolCallMetadata` redundant, and it's removed.

## Change

New `-lib/adapter.server.ts` subclasses `OpenAITextAdapter` and drops `id` from `function_call` input items, so calls match on `call_id`, which carries no reasoning requirement.

Trade-off worth noting: the alternative is replaying the `rs_…` items alongside their `fc_…` items, which would preserve the model's reasoning context across the tool boundary and is likely better for answer quality on multi-step tool use. Neither the adapter nor `@tanstack/ai` models reasoning items today, so that's an upstream change. This PR restores correctness; that would be the improvement.

No version bump: the fix is entirely in `webapp`, which has no `version` field, and `sdk` is untouched at 0.0.3 — integrators need no upgrade, the fix lands when the endpoint deploys.

## Testing

`deno task ready` passes (format, lint, typecheck, knip, 132 tests, build).

Added a regression test asserting the replayed `function_call` carries `call_id` and no `id`, and that the `function_call_output` still reaches the model. I checked the test is meaningful by running the unpatched adapter over the same messages, which produces:

```json
{"type":"function_call","call_id":"call_1","id":"fc_0d130cb4c88ab49e","name":"searchDocuments","arguments":"{}"}
```

Found while wiring a host-side search tool into a consumer app; that integration was blocked on this and is still unverified end-to-end past the tool result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)