### PR TITLE
Add PgBouncer to docker-compose setup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,7 @@
   // .env.development defaults to 127.0.0.1 for host workflows, but inside this container that loops back to astralbeam rather than its dependencies.
   // Override only editor subprocesses with Compose service DNS https://code.visualstudio.com/remote/advancedcontainers/environment-variables
   "remoteEnv": {
-    "DATABASE_URL": "postgres://astralbeam:astralbeam123@postgres:5432/astralbeam",
+    "DATABASE_URL": "postgres://astralbeam:astralbeam123@pgbouncer:5432/astralbeam",
     "POSTGRES_HOST": "postgres",
     "VALKEY_HOST": "valkey"
   },

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     command: sleep infinity
     init: true
     depends_on:
-      postgres:
+      pgbouncer:
         condition: service_healthy
       valkey:
         condition: service_healthy

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@
 
 - Keep Webapp environment files under `webapp`. Commit reviewed non-secret environment files such as `.env`, `.env.development`, `.env.test`, and `.env.example`; ignore `*.local` files and never commit credentials or deployment-specific values.
 - Keep the webapp's bootstrap environment variables and optional deployment overrides documented in `webapp/AGENTS.md`; other runtime settings live in its database `config` table and are managed at `/configure`. Keep standalone tool loading local to the tool configuration, with shell, CI, and deployment variables taking precedence over file values.
-- Never install PostgreSQL or Valkey from `scripts/setup.sh` on macOS; start its Podman services through the Docker-compatible `docker compose` command when available unless `SKIP_DOCKER_COMPOSE=true` is set. Invoke `scripts/codex-db.sh` only through `INSTALL_EXTRA=codex-db` in Codex Cloud's Ubuntu environment, paired with `SKIP_DOCKER_COMPOSE=true` to prevent a Compose start.
+- Never install PostgreSQL or Valkey from `scripts/setup.sh` on macOS; start PostgreSQL, PgBouncer, and Valkey through the Docker-compatible `docker compose` command when available unless `SKIP_DOCKER_COMPOSE=true` is set. Keep PgBouncer as the only loopback-published PostgreSQL endpoint so local application and CLI traffic exercise transaction pooling; preserve `POSTGRES_HOST` and `POSTGRES_PORT` as its backend overrides and `PGBOUNCER_HOST_PORT` as its host-published port override. Use `docker compose exec postgres` only for explicit direct database administration. Invoke `scripts/codex-db.sh` only through `INSTALL_EXTRA=codex-db` in Codex Cloud's Ubuntu environment, paired with `SKIP_DOCKER_COMPOSE=true` to prevent a Compose start.
 
 ## Webapp and SDK UI
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -57,9 +57,9 @@ To help agent CLIs find the codebase outside the devcontainer, expose the direct
 
 - Open a new terminal so the project-managed Deno LTS is on `PATH` before running `deno task` commands.
 
-- The setup script does not install PostgreSQL or Valkey on macOS. When Docker Compose is available, it starts both services unless `SKIP_DOCKER_COMPOSE=true` is set.
+- The setup script does not install PostgreSQL or Valkey on macOS. When Docker Compose is available, it starts PostgreSQL, PgBouncer, and Valkey unless `SKIP_DOCKER_COMPOSE=true` is set. PgBouncer is the only database service published to the host, so the default `DATABASE_URL` sends local application, Drizzle, and migration traffic through its transaction pool. Set `PGBOUNCER_HOST_PORT` and update `DATABASE_URL` together only when port 5432 is unavailable; set `POSTGRES_HOST` and `POSTGRES_PORT` to route PgBouncer to a different backend.
 
-- From the repository root, stop services with `docker compose down`. Add `--volumes` to permanently delete the local PostgreSQL and Valkey data.
+- From the repository root, stop services with `docker compose down`. Add `--volumes` to permanently delete the local PostgreSQL and Valkey data. Use `docker compose exec postgres` only when a documented administrative workflow requires a direct PostgreSQL connection.
 
 ## Cloud agent setup
 

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -2,9 +2,9 @@
 # Loopback avoids publishing on every host interface: https://docs.docker.com/reference/compose-file/services/#ports
 
 services:
-  postgres:
+  pgbouncer:
     ports:
-      - "127.0.0.1:${POSTGRES_HOST_PORT:-5432}:5432"
+      - "127.0.0.1:${PGBOUNCER_HOST_PORT:-5432}:5432"
   valkey:
     ports:
       - "127.0.0.1:${VALKEY_HOST_PORT:-6379}:6379"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,20 @@
 x-postgres-env: &postgres-env
-  POSTGRES_USER: ${POSTGRES_USER:-astralbeam}
-  POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-astralbeam123}
-  POSTGRES_DB: ${POSTGRES_DB:-astralbeam}
-  POSTGRES_HOST: ${POSTGRES_HOST:-postgres}
-  POSTGRES_PORT: ${POSTGRES_PORT:-5432}
+  POSTGRES_USER: &postgres-user ${POSTGRES_USER:-astralbeam}
+  POSTGRES_PASSWORD: &postgres-password ${POSTGRES_PASSWORD:-astralbeam123}
+  POSTGRES_DB: &postgres-database ${POSTGRES_DB:-astralbeam}
+
+# Leave DB_NAME unset so the generated PgBouncer config accepts development and test database names: https://github.com/edoburu/docker-pgbouncer/blob/master/entrypoint.sh
+x-pgbouncer-env: &pgbouncer-env
+  DB_USER: *postgres-user
+  DB_PASSWORD: *postgres-password
+  DB_HOST: ${POSTGRES_HOST:-postgres}
+  DB_PORT: ${POSTGRES_PORT:-5432}
+  HEALTHCHECK_DB: *postgres-database
+  AUTH_TYPE: scram-sha-256
+  POOL_MODE: transaction
+  # Postgres.js prepares statements by default, so transaction pooling must track them: https://www.pgbouncer.org/config.html#max_prepared_statements
+  MAX_PREPARED_STATEMENTS: 200
+  ADMIN_USERS: *postgres-user
 
 x-valkey-env: &valkey-env
   VALKEY_HOST: ${VALKEY_HOST:-valkey}
@@ -19,6 +30,19 @@ services:
       - postgres-data:/var/lib/postgresql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
+
+  pgbouncer:
+    image: edoburu/pgbouncer:v1.25.2-p0
+    restart: unless-stopped
+    environment:
+      <<: *pgbouncer-env
+    depends_on:
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - PGPASSWORD="$${DB_PASSWORD}" psql --host 127.0.0.1 --username "$${DB_USER}" --dbname "$${HEALTHCHECK_DB}" --tuples-only --no-align --command "select 1" | grep -qx 1
 
   valkey:
     image: valkey/valkey:9

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,20 +1,20 @@
 x-postgres-env: &postgres-env
-  POSTGRES_USER: &postgres-user ${POSTGRES_USER:-astralbeam}
-  POSTGRES_PASSWORD: &postgres-password ${POSTGRES_PASSWORD:-astralbeam123}
-  POSTGRES_DB: &postgres-database ${POSTGRES_DB:-astralbeam}
+  POSTGRES_USER: ${POSTGRES_USER:-astralbeam}
+  POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-astralbeam123}
+  POSTGRES_DB: ${POSTGRES_DB:-astralbeam}
 
 # Leave DB_NAME unset so the generated PgBouncer config accepts development and test database names: https://github.com/edoburu/docker-pgbouncer/blob/master/entrypoint.sh
 x-pgbouncer-env: &pgbouncer-env
-  DB_USER: *postgres-user
-  DB_PASSWORD: *postgres-password
+  DB_USER: ${POSTGRES_USER:-astralbeam}
+  DB_PASSWORD: ${POSTGRES_PASSWORD:-astralbeam123}
   DB_HOST: ${POSTGRES_HOST:-postgres}
   DB_PORT: ${POSTGRES_PORT:-5432}
-  HEALTHCHECK_DB: *postgres-database
+  HEALTHCHECK_DB: ${POSTGRES_DB:-astralbeam}
   AUTH_TYPE: scram-sha-256
   POOL_MODE: transaction
   # Postgres.js prepares statements by default, so transaction pooling must track them: https://www.pgbouncer.org/config.html#max_prepared_statements
   MAX_PREPARED_STATEMENTS: 200
-  ADMIN_USERS: *postgres-user
+  ADMIN_USERS: ${POSTGRES_USER:-astralbeam}
 
 x-valkey-env: &valkey-env
   VALKEY_HOST: ${VALKEY_HOST:-valkey}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ x-pgbouncer-env: &pgbouncer-env
   HEALTHCHECK_DB: ${POSTGRES_DB:-astralbeam}
   AUTH_TYPE: scram-sha-256
   POOL_MODE: transaction
-  # Postgres.js prepares statements by default, so transaction pooling must track them: https://www.pgbouncer.org/config.html#max_prepared_statements
+  # Direct Postgres.js queries and explicit Drizzle prepared queries require transaction-pool tracking: https://www.pgbouncer.org/config.html#max_prepared_statements
   MAX_PREPARED_STATEMENTS: 200
   ADMIN_USERS: ${POSTGRES_USER:-astralbeam}
 

--- a/webapp/src/db/README.md
+++ b/webapp/src/db/README.md
@@ -29,11 +29,13 @@ Both imports belong in server-only code and require `DATABASE_URL` and `DATABASE
 
 ## Local services
 
-Start PostgreSQL and Valkey from the repository root before commands that connect to PostgreSQL. Podman supplies the Docker-compatible command used here:
+Start PostgreSQL, PgBouncer, and Valkey from the repository root before commands that connect to PostgreSQL. Podman supplies the Docker-compatible command used here:
 
 ```sh
 docker compose up --detach --wait
 ```
+
+PgBouncer owns the loopback database port and uses transaction pooling, so the checked-in development and test `DATABASE_URL` values route Webapp and Drizzle traffic through it. PostgreSQL is not published to the host; use `docker compose exec postgres` only for the direct administrative reset workflows below. If port 5432 is unavailable, set `PGBOUNCER_HOST_PORT` and change the local `DATABASE_URL` port to match.
 
 ## Database commands
 

--- a/webapp/src/db/migration-runner.server.test.ts
+++ b/webapp/src/db/migration-runner.server.test.ts
@@ -1,0 +1,47 @@
+import type postgres from "postgres"
+import { describe, expect, test, vi } from "vitest"
+
+import { runWithMigrationAdvisoryLock } from "./migration-runner.server.ts"
+
+function lockClient(locked: boolean): {
+  client: postgres.Sql
+  transaction: ReturnType<typeof vi.fn>
+} {
+  const transaction = vi.fn((_template: TemplateStringsArray) => Promise.resolve([{ locked }]))
+  const client = {
+    begin: vi.fn(async (callback) =>
+      await callback(transaction as unknown as postgres.TransactionSql)
+    ),
+  } as unknown as postgres.Sql
+  return { client, transaction }
+}
+
+describe("migration advisory lock", () => {
+  test("runs migrations while the transaction-scoped lock is held", async () => {
+    const applyMigrations = vi.fn(() =>
+      Promise.resolve({ ok: true as const, applied: ["migration"] })
+    )
+    const locking = lockClient(true)
+
+    await expect(runWithMigrationAdvisoryLock(locking.client, applyMigrations)).resolves.toEqual({
+      ok: true,
+      applied: ["migration"],
+    })
+    const lockQuery = locking.transaction.mock.calls.at(0)?.at(0)
+    if (!lockQuery) throw new Error("Expected an advisory-lock query")
+    expect(lockQuery.join("?")).toContain("pg_try_advisory_xact_lock")
+    expect(applyMigrations).toHaveBeenCalledOnce()
+  })
+
+  test("rejects a competing migration run", async () => {
+    const applyMigrations = vi.fn(() => Promise.resolve({ ok: true as const, applied: [] }))
+
+    await expect(
+      runWithMigrationAdvisoryLock(lockClient(false).client, applyMigrations),
+    ).resolves.toEqual({
+      ok: false,
+      error: "A migration run is already in progress",
+    })
+    expect(applyMigrations).not.toHaveBeenCalled()
+  })
+})

--- a/webapp/src/db/migration-runner.server.ts
+++ b/webapp/src/db/migration-runner.server.ts
@@ -113,6 +113,23 @@ type ApplyMigrationsResult =
   | { ok: true; applied: string[] }
   | { ok: false; error: string }
 
+function createSingleConnectionClient(databaseUrl: string): postgres.Sql {
+  return postgres(databaseUrl, { max: 1 })
+}
+
+export async function runWithMigrationAdvisoryLock(
+  lockClient: postgres.Sql,
+  applyMigrations: () => Promise<ApplyMigrationsResult>,
+): Promise<ApplyMigrationsResult> {
+  return await lockClient.begin(async (lockTransaction) => {
+    const [lock] = await lockTransaction`
+      select pg_try_advisory_xact_lock(hashtext(${CONFIG_MIGRATION_LOCK_KEY})) as locked
+    `
+    if (!lock?.locked) return { ok: false, error: "A migration run is already in progress" }
+    return await applyMigrations()
+  })
+}
+
 function migrationErrorDetail(error: unknown): string {
   if (error instanceof Error) {
     const code = (error as { code?: unknown }).code
@@ -125,19 +142,18 @@ function migrationErrorDetail(error: unknown): string {
 export async function applyApprovedMigrations(
   approvedMigrations: { name: string; hash: string }[],
 ): Promise<ApplyMigrationsResult> {
-  // Advisory locks are session-scoped, so the runner needs its own single connection instead of
-  // the shared pool.
-  const client = postgres(getDatabaseUrl(), { max: 1 })
+  // Transaction pooling can change the backing PostgreSQL session between transactions. Keep a
+  // transaction open on a dedicated client so its advisory lock remains pinned while a second
+  // client preserves the existing one-transaction-per-migration behavior.
+  const databaseUrl = getDatabaseUrl()
+  const lockClient = createSingleConnectionClient(databaseUrl)
+  const migrationClient = createSingleConnectionClient(databaseUrl)
   try {
-    const [lock] = await client`
-      select pg_try_advisory_lock(hashtext(${CONFIG_MIGRATION_LOCK_KEY})) as locked
-    `
-    if (!lock?.locked) return { ok: false, error: "A migration run is already in progress" }
-    try {
+    return await runWithMigrationAdvisoryLock(lockClient, async () => {
       let appliedNames: Set<string> | null
       try {
         appliedNames = appliedNameSet(
-          await client`select name from drizzle.__drizzle_migrations`,
+          await migrationClient`select name from drizzle.__drizzle_migrations`,
         )
       } catch (error) {
         if (!isMissingBookkeepingError(error)) throw error
@@ -150,8 +166,8 @@ export async function applyApprovedMigrations(
       }
       if (appliedNames === null) {
         // Same bookkeeping DDL as drizzle-orm's migrator, so the drizzle-kit CLI remains usable.
-        await client`CREATE SCHEMA IF NOT EXISTS drizzle`
-        await client.unsafe(
+        await migrationClient`CREATE SCHEMA IF NOT EXISTS drizzle`
+        await migrationClient.unsafe(
           `CREATE TABLE IF NOT EXISTS drizzle.__drizzle_migrations (
             id SERIAL PRIMARY KEY,
             hash text NOT NULL,
@@ -164,7 +180,7 @@ export async function applyApprovedMigrations(
       const applied: string[] = []
       for (const migration of pending) {
         try {
-          await client.begin(async (transaction) => {
+          await migrationClient.begin(async (transaction) => {
             for (const statement of migration.sql.split("--> statement-breakpoint")) {
               await transaction.unsafe(statement)
             }
@@ -183,11 +199,9 @@ export async function applyApprovedMigrations(
         applied.push(migration.name)
       }
       return { ok: true, applied }
-    } finally {
-      await client`select pg_advisory_unlock(hashtext(${CONFIG_MIGRATION_LOCK_KEY}))`
-    }
+    })
   } finally {
-    await client.end()
+    await Promise.all([lockClient.end(), migrationClient.end()])
     cachedMigrationState = undefined
   }
 }


### PR DESCRIPTION
- Add pinned [PgBouncer 1.25.2](https://github.com/edoburu/docker-pgbouncer/releases/tag/v1.25.2-p0) as the mandatory local and devcontainer database endpoint with SCRAM authentication, transaction pooling, prepared-statement tracking, health checks, and configurable frontend and backend ports.
- Keep PostgreSQL private to the Compose network while preserving explicit direct administration through `docker compose exec postgres`.
- Hold `/configure` migration coordination in a transaction-scoped advisory lock on a dedicated connection while retaining independent per-migration transactions on a separate client.
- Document the pooled development workflow and protect migration-lock behavior with regression coverage.
