### PR TITLE
Add typed helpers, chrome slots, imperative control, and a token route factory

### DIFF
--- a/examples/todos/src/lib/config.server.ts
+++ b/examples/todos/src/lib/config.server.ts
@@ -1,4 +1,3 @@
 import process from "node:process"
 
-export const API_KEY_ENV = "ASTRALBEAM_API_KEY"
-export const API_KEY = process.env[API_KEY_ENV]
+export const API_KEY = process.env["ASTRALBEAM_API_KEY"]

--- a/examples/todos/src/routes/api/chat/token.ts
+++ b/examples/todos/src/routes/api/chat/token.ts
@@ -1,34 +1,20 @@
-import { createAstralBeamChatToken } from "@astralbeam/sdk/server"
+import { createAstralBeamTokenRoute } from "@astralbeam/sdk/server"
 import { createFileRoute } from "@tanstack/react-router"
 
-import { API_KEY, API_KEY_ENV } from "@/lib/config.server.ts"
+import { API_KEY } from "@/lib/config.server.ts"
 import { DEMO_CHAT_TENANT, DEMO_CHAT_USER } from "@/lib/constants.server.ts"
+
+// The factory owns the method check, the unconfigured-key 503, the 401, and no-store.
+const mintDemoChatToken = createAstralBeamTokenRoute({
+  apiKey: () => API_KEY,
+  // A real application authenticates its own session here; the demo has one fixed user.
+  tenantUser: () => ({ ...DEMO_CHAT_USER, tenant: DEMO_CHAT_TENANT }),
+})
 
 export const Route = createFileRoute("/api/chat/token")({
   server: {
     handlers: {
-      POST: async () => {
-        if (!API_KEY) {
-          return Response.json(
-            { error: `${API_KEY_ENV} must be configured` },
-            { status: 503, headers: { "cache-control": "no-store" } },
-          )
-        }
-
-        try {
-          const token = await createAstralBeamChatToken({
-            apiKey: API_KEY,
-            tenantUser: { ...DEMO_CHAT_USER, tenant: DEMO_CHAT_TENANT },
-          })
-          return Response.json({ token }, { headers: { "cache-control": "no-store" } })
-        } catch (error) {
-          console.error("Failed to mint the todos example chat token", error)
-          return Response.json(
-            { error: "Unable to authenticate chat" },
-            { status: 500, headers: { "cache-control": "no-store" } },
-          )
-        }
-      },
+      POST: ({ request }) => mintDemoChatToken(request),
     },
   },
 })

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -36,19 +36,19 @@ const handle = mountAstralBeamChat(document.getElementById("sidebar"), {})
 The widget will not chat until your app mints it a short-lived token; it never sees your API key. See [Authentication](https://app.astralbeam.ai/docs/sdk/authentication).
 
 ```ts
-import { createAstralBeamChatToken } from "@astralbeam/sdk/server"
+import { createAstralBeamTokenRoute } from "@astralbeam/sdk/server"
 
-export async function POST(request: Request) {
-  const session = await requireApplicationSession(request)
-  const token = await createAstralBeamChatToken({
-    apiKey: process.env.ASTRALBEAM_API_KEY!, // key_<organization>_<key>_abo_<secret>
-    tenantUser: { id: session.user.id, name: session.user.name },
-  })
-  return Response.json({ token }, { headers: { "cache-control": "no-store" } })
-}
+export const POST = createAstralBeamTokenRoute({
+  apiKey: () => process.env.ASTRALBEAM_API_KEY, // key_<organization>_<key>_abo_<secret>
+  tenantUser: async (request) => {
+    const session = await getApplicationSession(request)
+    return session && { id: session.user.id, name: session.user.name }
+  },
+})
 ```
 
 - Add one endpoint, `/api/astralbeam/token` by default, that authenticates your own session first.
+- The factory owns the method check, the unconfigured 503, the unauthenticated 401, and `no-store`.
 - Derive `tenantUser` from trusted server-side state, never from anything the browser sent.
 - Tokens are signed, not encrypted: never put a secret in them.
 - Lifetimes are 60–600 seconds; the SDK renews in memory before expiry.
@@ -57,18 +57,21 @@ export async function POST(request: Request) {
 
 Every option is also a prop on `<AstralBeamChat>`; `handle.update(options)` applies any subset in place. `agentId`, `chatEndpoint`, and `authEndpoint` are fixed at mount. Details in [Configuration](https://app.astralbeam.ai/docs/sdk/configuration).
 
-| Option                           | Default                              | Meaning                                                   |
-| -------------------------------- | ------------------------------------ | --------------------------------------------------------- |
-| `agentId`                        | organization's default               | `agt_<organization>_<agent>` from the dashboard           |
-| `chatEndpoint`                   | `https://app.astralbeam.ai/api/chat` | The AstralBeam chat endpoint the widget streams from      |
-| `authEndpoint`                   | `/api/astralbeam/token`              | Your token endpoint                                       |
-| `systemPrompt`                   | the agent's stored prompt            | Overrides the agent's instructions for this integration   |
-| `title`, `showHeader`            | `"AstralBeam"`, `true`               | Header text, and whether the header and reset button show |
-| `emptyTitle`, `emptyDescription` | generic copy                         | Headline and subtitle of the empty transcript             |
-| `colorScheme`, `theme`           | `"system"`, built-in palette         | Light/dark/system, and shadcn token overrides             |
-| `attachments`                    | `true`                               | `false` hides the feature, or pass limits                 |
-| `tools`, `widgets`               | none                                 | What the agent can do and draw in your app                |
-| `debug`                          | `false`                              | Log every SDK action in the browser and on the server     |
+| Option                               | Default                              | Meaning                                                         |
+| ------------------------------------ | ------------------------------------ | --------------------------------------------------------------- |
+| `agentId`                            | organization's default               | `agt_<organization>_<agent>` from the dashboard                 |
+| `chatEndpoint`                       | `https://app.astralbeam.ai/api/chat` | The AstralBeam chat endpoint the widget streams from            |
+| `authEndpoint`                       | `/api/astralbeam/token`              | Your token endpoint                                             |
+| `systemPrompt`                       | the agent's stored prompt            | Overrides the agent's instructions for this integration         |
+| `title`, `showHeader`                | `"AstralBeam"`, `true`               | Header text, and whether the header and reset button show       |
+| `emptyTitle`, `emptyDescription`     | generic copy                         | Headline and subtitle of the empty transcript                   |
+| `colorScheme`, `theme`               | `"system"`, built-in palette         | Light/dark/system, and shadcn token overrides                   |
+| `attachments`                        | `true`                               | `false` hides the feature, or pass limits                       |
+| `tools`, `widgets`                   | none                                 | What the agent can do and draw in your app                      |
+| `header`, `empty`, `composerActions` | widget's own chrome                  | Host-rendered replacements (React props; `slots` on the handle) |
+| `debug`                              | `false`                              | Log every SDK action in the browser and on the server           |
+
+A `ref` on `<AstralBeamChat>` (and the vanilla handle) exposes `reset()` and `stop()` for hosts that draw their own controls.
 
 ## Tools and widgets
 
@@ -94,6 +97,7 @@ widgets: {
 
 - Schemas are plain JSON Schema, or any [Standard Schema](https://standardschema.dev) validator (Zod, Valibot, ArkType).
 - Only a Standard Schema validates input in the browser; with plain JSON Schema, treat input as untrusted.
+- `defineTool` and `defineWidget` type `execute`/`render` input from a Standard Schema's output.
 - In React, `render` returns JSX in your own tree, so state, context, and handlers keep working.
 - New tools and widgets reach the agent on its next run.
 
@@ -117,7 +121,7 @@ There is no root export. Conversation history is not built yet.
 | ------------------------ | ----------------------------------------- | -------------------- |
 | `@astralbeam/sdk/client` | `mountAstralBeamChat`, the vanilla loader | none                 |
 | `@astralbeam/sdk/react`  | `<AstralBeamChat>`                        | `react`, `react-dom` |
-| `@astralbeam/sdk/server` | `createAstralBeamChatToken`               | none                 |
+| `@astralbeam/sdk/server` | `createAstralBeamChatToken`, `createAstralBeamTokenRoute` | none |
 | `@astralbeam/sdk/vue`    | Vue components (placeholder)              | `vue`                |
 
 ## Example

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -117,12 +117,12 @@ Each guide is short and self-contained.
 
 There is no root export. Conversation history is not built yet.
 
-| Entry point              | Contents                                  | Peer dependency      |
-| ------------------------ | ----------------------------------------- | -------------------- |
-| `@astralbeam/sdk/client` | `mountAstralBeamChat`, the vanilla loader | none                 |
-| `@astralbeam/sdk/react`  | `<AstralBeamChat>`                        | `react`, `react-dom` |
-| `@astralbeam/sdk/server` | `createAstralBeamChatToken`, `createAstralBeamTokenRoute` | none |
-| `@astralbeam/sdk/vue`    | Vue components (placeholder)              | `vue`                |
+| Entry point              | Contents                                                  | Peer dependency      |
+| ------------------------ | --------------------------------------------------------- | -------------------- |
+| `@astralbeam/sdk/client` | `mountAstralBeamChat`, the vanilla loader                 | none                 |
+| `@astralbeam/sdk/react`  | `<AstralBeamChat>`                                        | `react`, `react-dom` |
+| `@astralbeam/sdk/server` | `createAstralBeamChatToken`, `createAstralBeamTokenRoute` | none                 |
+| `@astralbeam/sdk/vue`    | Vue components (placeholder)                              | `vue`                |
 
 ## Example
 

--- a/sdk/redesign.plan.md
+++ b/sdk/redesign.plan.md
@@ -40,7 +40,8 @@ Boundaries become structural instead of filename conventions. No behavior change
 
 - `defineTool` / `defineWidget` helpers inferring `execute`/`render` input types from Standard Schema; document `z.coerce` for model-sent stringified scalars.
 - Imperative handle on `<AstralBeamChat>` via `ref`: `reset`, `stop`, `update`.
-- `header`, `empty`, and `composerActions` slots on the drop-in, projected through the existing light-DOM `<slot>` mechanism; `preload={false}` to defer the lazy chunk.
+- `header`, `empty`, and `composerActions` slots on the drop-in, projected through the existing light-DOM `<slot>` mechanism.
+- No `preload` option (revised during implementation): deferring is the host conditionally rendering on first open, now documented in the configuration guide, since an API flag would duplicate what JSX already expresses.
 - `createAstralBeamTokenRoute()` in `@astralbeam/sdk/server`: fetch-standard handler factory replacing the copy-pasted 503/500/`no-store` endpoint.
 - Fix the `-webkit-text-fill-color` inheritance leak onto widget slots (bmd's documented gotcha).
 

--- a/sdk/src/client/index.ts
+++ b/sdk/src/client/index.ts
@@ -15,9 +15,12 @@ export type {
   AstralBeamChatAttachmentOptions,
   AstralBeamChatColorScheme,
   AstralBeamChatHandle,
+  AstralBeamChatSlotRenderer,
+  AstralBeamChatSlots,
   AstralBeamChatTheme,
   AstralBeamChatThemeVariables,
   AstralBeamChatUpdate,
+  InferParameters,
   JsonSchemaObject,
   MountAstralBeamChatOptions,
   ParametersSchema,
@@ -25,6 +28,8 @@ export type {
   ToolDefinition,
   WidgetDefinition,
 } from "../lib/types.ts"
+export { defineTool, defineWidget } from "../lib/define.ts"
+export type { TypedToolDefinition, TypedWidgetDefinition } from "../lib/define.ts"
 
 // Mounts the AstralBeam chat widget into `target`, inside a shadow root that isolates
 // its styles. The React chat loads lazily, keeping this entry a tiny loader.
@@ -110,6 +115,9 @@ export function mountAstralBeamChat(
       applyTheme()
       chat?.update(live)
     },
+    // No-ops until the lazy chunk resolves: with no chat there is nothing to reset or stop.
+    reset: () => chat?.reset(),
+    stop: () => chat?.stop(),
     unmount: () => {
       debug?.("mount", "unmounting chat widget")
       unmounted = true

--- a/sdk/src/lib/define.ts
+++ b/sdk/src/lib/define.ts
@@ -2,26 +2,27 @@
 // `execute`/`render` input is the schema's own output type instead of Record<string, unknown>.
 import type {
   InferParameters,
+  JsonSchemaObject,
   ParametersSchema,
   ToolDefinition,
   WidgetDefinition,
 } from "./types.ts"
 
-export interface TypedToolDefinition<S extends ParametersSchema> {
+export interface TypedToolDefinition<S extends ParametersSchema = JsonSchemaObject> {
   description: string
   metadata?: Record<string, unknown> | undefined
   parameters?: S
   execute: (input: InferParameters<S>) => unknown | Promise<unknown>
 }
 
-export interface TypedWidgetDefinition<S extends ParametersSchema> {
+export interface TypedWidgetDefinition<S extends ParametersSchema = JsonSchemaObject> {
   description: string
   parameters?: S
   render: (props: InferParameters<S>, container: HTMLElement) => (() => void) | void
 }
 
 /** Declares a host tool; a Standard Schema `parameters` types (and validates) `execute`'s input. */
-export function defineTool<const S extends ParametersSchema>(
+export function defineTool<const S extends ParametersSchema = JsonSchemaObject>(
   tool: TypedToolDefinition<S>,
 ): ToolDefinition {
   // The widget validates a Standard Schema before execute runs, so the narrowed type holds.
@@ -29,7 +30,7 @@ export function defineTool<const S extends ParametersSchema>(
 }
 
 /** Declares a host widget; a Standard Schema `parameters` types (and validates) `render`'s props. */
-export function defineWidget<const S extends ParametersSchema>(
+export function defineWidget<const S extends ParametersSchema = JsonSchemaObject>(
   widget: TypedWidgetDefinition<S>,
 ): WidgetDefinition {
   return widget as unknown as WidgetDefinition

--- a/sdk/src/lib/define.ts
+++ b/sdk/src/lib/define.ts
@@ -1,0 +1,36 @@
+// Identity helpers that exist for their generics: with a Standard Schema in `parameters`, the
+// `execute`/`render` input is the schema's own output type instead of Record<string, unknown>.
+import type {
+  InferParameters,
+  ParametersSchema,
+  ToolDefinition,
+  WidgetDefinition,
+} from "./types.ts"
+
+export interface TypedToolDefinition<S extends ParametersSchema> {
+  description: string
+  metadata?: Record<string, unknown> | undefined
+  parameters?: S
+  execute: (input: InferParameters<S>) => unknown | Promise<unknown>
+}
+
+export interface TypedWidgetDefinition<S extends ParametersSchema> {
+  description: string
+  parameters?: S
+  render: (props: InferParameters<S>, container: HTMLElement) => (() => void) | void
+}
+
+/** Declares a host tool; a Standard Schema `parameters` types (and validates) `execute`'s input. */
+export function defineTool<const S extends ParametersSchema>(
+  tool: TypedToolDefinition<S>,
+): ToolDefinition {
+  // The widget validates a Standard Schema before execute runs, so the narrowed type holds.
+  return tool as unknown as ToolDefinition
+}
+
+/** Declares a host widget; a Standard Schema `parameters` types (and validates) `render`'s props. */
+export function defineWidget<const S extends ParametersSchema>(
+  widget: TypedWidgetDefinition<S>,
+): WidgetDefinition {
+  return widget as unknown as WidgetDefinition
+}

--- a/sdk/src/lib/types.ts
+++ b/sdk/src/lib/types.ts
@@ -3,13 +3,24 @@
 
 // Minimal Standard Schema interface, vendored as the spec suggests: just enough to
 // accept any spec-compliant validator (Zod, Valibot, ArkType, ...) without a dependency.
-export interface StandardSchemaV1 {
+export interface StandardSchemaV1<Input = unknown, Output = Input> {
   readonly "~standard": {
     readonly version: 1
     readonly vendor: string
     readonly validate: (value: unknown) => unknown
+    /** Type-level only; the spec keeps it undefined at runtime. */
+    readonly types?: { readonly input: Input; readonly output: Output } | undefined
   }
 }
+
+/**
+ * Input type `defineTool`/`defineWidget` derive from a `parameters` schema: a Standard Schema's
+ * validated output, or untyped props for a plain JSON Schema, which nothing validates in the browser.
+ */
+// deno-lint-ignore no-explicit-any -- `any` matches any schema input variance-free; `unknown` would not.
+export type InferParameters<S extends ParametersSchema> = S extends StandardSchemaV1<any, infer O>
+  ? O
+  : Record<string, unknown>
 
 /** A plain JSON Schema object, the same shape tool definitions use for their parameters. */
 export interface JsonSchemaObject {
@@ -81,6 +92,22 @@ export interface AstralBeamChatAttachmentOptions {
   accept?: readonly string[] | undefined
 }
 
+/**
+ * Draws host content into `container`, a light-DOM element the widget projects into the
+ * named area. May return a cleanup, called when the slot is replaced and on unmount.
+ */
+export type AstralBeamChatSlotRenderer = (container: HTMLElement) => (() => void) | void
+
+/** Host-rendered replacements for the widget's own chrome; each renders in the host page's style. */
+export interface AstralBeamChatSlots {
+  /** Replaces the header's content (title and reset button); `showHeader: false` still hides the row. */
+  header?: AstralBeamChatSlotRenderer | undefined
+  /** Replaces the empty-transcript state (icon, headline, and subtitle). */
+  empty?: AstralBeamChatSlotRenderer | undefined
+  /** Extra controls at the end of the composer's button row, next to send. */
+  composerActions?: AstralBeamChatSlotRenderer | undefined
+}
+
 /** Color scheme of the chat widget; `"system"` follows the OS `prefers-color-scheme` setting. */
 export type AstralBeamChatColorScheme = "light" | "dark" | "system"
 
@@ -129,6 +156,8 @@ export interface MountAstralBeamChatOptions {
   tools?: Record<string, ToolDefinition> | undefined
   /** Host-defined widgets the agent can render inline in the conversation, keyed by identifier. */
   widgets?: Record<string, WidgetDefinition>
+  /** Host-rendered replacements for parts of the widget's chrome; see `AstralBeamChatSlots`. */
+  slots?: AstralBeamChatSlots | undefined
   /**
    * File attachments in the composer, on by default. `false` turns them off; an options object
    * narrows the limits and accepted types.
@@ -160,4 +189,8 @@ export interface AstralBeamChatHandle {
    * transcript, the chat session, and live widget renders. Only the keys given are replaced.
    */
   update: (options: AstralBeamChatUpdate) => void
+  /** Clears the conversation: transcript, drafts, attachments, and live widget renders. */
+  reset: () => void
+  /** Stops the in-flight generation, if any; the transcript keeps what already streamed. */
+  stop: () => void
 }

--- a/sdk/src/react/index.tsx
+++ b/sdk/src/react/index.tsx
@@ -1,4 +1,12 @@
-import { type ReactNode, useEffect, useMemo, useRef, useState } from "react"
+import {
+  forwardRef,
+  type ReactNode,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+} from "react"
 import { createPortal } from "react-dom"
 // Self-reference rather than a relative path, so this entry shares the client entry's chat
 // chunk and its bundled React instead of bundling a second copy.
@@ -6,8 +14,12 @@ import {
   type AstralBeamChatAttachmentOptions,
   type AstralBeamChatColorScheme,
   type AstralBeamChatHandle,
+  type AstralBeamChatSlotRenderer,
   type AstralBeamChatTheme,
+  defineTool,
+  type InferParameters,
   mountAstralBeamChat,
+  type ParametersSchema,
   type ToolDefinition,
   type WidgetDefinition as ClientWidgetDefinition,
 } from "@astralbeam/sdk/client"
@@ -18,12 +30,37 @@ export type {
   AstralBeamChatAttachmentOptions,
   AstralBeamChatColorScheme,
   AstralBeamChatTheme,
+  InferParameters,
+  ParametersSchema,
   ToolDefinition,
 }
+export { defineTool }
 
 export interface WidgetDefinition extends Omit<ClientWidgetDefinition, "render"> {
   /** Draws the widget with the agent-chosen props, in the host's own React tree. */
   render: (props: Record<string, unknown>) => ReactNode
+}
+
+export interface TypedReactWidgetDefinition<S extends ParametersSchema> {
+  description: string
+  parameters?: S
+  render: (props: InferParameters<S>) => ReactNode
+}
+
+/** Declares a host widget; a Standard Schema `parameters` types (and validates) `render`'s props. */
+export function defineWidget<const S extends ParametersSchema>(
+  widget: TypedReactWidgetDefinition<S>,
+): WidgetDefinition {
+  // The chat validates a Standard Schema before render runs, so the narrowed type holds.
+  return widget as unknown as WidgetDefinition
+}
+
+/** Imperative surface of a mounted `<AstralBeamChat>`, for hosts that draw their own controls. */
+export interface AstralBeamChatRef {
+  /** Clears the conversation: transcript, drafts, attachments, and live widget renders. */
+  reset: () => void
+  /** Stops the in-flight generation, if any; the transcript keeps what already streamed. */
+  stop: () => void
 }
 
 export interface AstralBeamChatProps {
@@ -39,11 +76,17 @@ export interface AstralBeamChatProps {
    * the transcript the full height. Prop changes apply immediately. Default `true`.
    */
   showHeader?: boolean
+  /** Replaces the header's content with the host's own React content; `showHeader` still applies. */
+  header?: ReactNode
+  /** Replaces the empty-transcript state with the host's own React content. */
+  empty?: ReactNode
+  /** Extra host controls at the end of the composer's button row, next to send. */
+  composerActions?: ReactNode
   /** Headline shown on the empty transcript; prop changes apply immediately. Default `"Ask the assistant"`. */
   emptyTitle?: string
   /** Subtitle under the empty transcript's headline; prop changes apply immediately. */
   emptyDescription?: string
-  /** URL of the AstralBeam chat endpoint the widget streams from. Default `"/api/chat"`. */
+  /** URL of the AstralBeam chat endpoint the widget streams from. Default the hosted cloud endpoint. */
   chatEndpoint?: string
   /** Application endpoint that mints a short-lived chat JWT. Default `"/api/astralbeam/token"`. */
   authEndpoint?: string
@@ -72,134 +115,186 @@ interface ActiveRender {
   props: Record<string, unknown>
 }
 
-export function AstralBeamChat(
-  {
-    agentId,
-    title,
-    showHeader,
-    emptyTitle,
-    emptyDescription,
-    chatEndpoint,
-    authEndpoint,
-    systemPrompt,
-    tools,
-    widgets = {},
-    colorScheme = DEFAULT_COLOR_SCHEME,
-    theme,
-    attachments,
-    debug,
-  }: AstralBeamChatProps,
-) {
-  const targetRef = useRef<HTMLDivElement>(null)
-  const handleRef = useRef<AstralBeamChatHandle | null>(null)
-  const [activeRenders, setActiveRenders] = useState<ReadonlyMap<string, ActiveRender>>(new Map())
-  // The chat calls tools long after mount, so route execution through the latest prop value —
-  // otherwise every execute would close over the first render's host state.
-  const toolsRef = useRef(tools)
-  useEffect(() => {
-    toolsRef.current = tools
-  })
-  // The chat keeps one render per tool call, so several renders of the same widget can be live
-  // at once (a listing that renders a card per item); each needs its own portal and React key.
-  const nextRenderKey = useRef(0)
-  // Memoized on the props they adapt: the update effect below ships them to the chat, and a fresh
-  // object every render would rebuild the declared tool set on every render along with it.
-  const hostTools = useMemo(
-    () =>
-      Object.fromEntries(
-        Object.entries(tools ?? {}).map(([name, definition]) => [name, {
-          ...definition,
-          execute: (input: Record<string, unknown>) => {
-            const current = toolsRef.current?.[name]
-            if (!current) throw new Error(`Tool "${name}" is no longer registered`)
-            return current.execute(input)
-          },
-        }]),
-      ),
-    [tools],
-  )
-  const hostWidgets = useMemo(
-    () =>
-      Object.fromEntries(
-        Object.entries(widgets).map(([name, definition]) => [name, {
-          ...definition,
-          // The chat provides a slotted container; record it and portal the JSX into it below,
-          // so the widget renders in the host's React tree with working state and context.
-          render: (props: Record<string, unknown>, container: HTMLElement) => {
-            const key = `astralbeam-render-${nextRenderKey.current++}`
-            setActiveRenders((previous) =>
-              new Map(previous).set(key, { widget: name, container, props })
-            )
-            return () => {
-              setActiveRenders((previous) => {
-                const next = new Map(previous)
-                next.delete(key)
-                return next
-              })
-            }
-          },
-        }]),
-      ),
-    [widgets],
-  )
-  // The one set of updatable options, so mounting and updating cannot drift apart as options are
-  // added. Memoized because the update effect keys off it.
-  const live = useMemo(
-    () => ({
-      title,
-      showHeader,
-      emptyTitle,
-      emptyDescription,
-      systemPrompt,
-      colorScheme,
-      theme,
-      attachments,
-      debug,
-      tools: hostTools,
-      widgets: hostWidgets,
-    }),
-    [
-      title,
-      showHeader,
-      emptyTitle,
-      emptyDescription,
-      systemPrompt,
-      colorScheme,
-      theme,
-      attachments,
-      debug,
-      hostTools,
-      hostWidgets,
-    ],
-  )
-  const liveRef = useRef(live)
-  liveRef.current = live
-  useEffect(() => {
-    if (!targetRef.current) return
-    // Mounted once; transport endpoints cannot be updated afterwards.
-    const handle = mountAstralBeamChat(targetRef.current, {
-      ...liveRef.current,
+const CHROME_SLOT_NAMES = ["header", "empty", "composerActions"] as const
+type ChromeSlotName = (typeof CHROME_SLOT_NAMES)[number]
+
+export const AstralBeamChat = forwardRef<AstralBeamChatRef, AstralBeamChatProps>(
+  function AstralBeamChat(
+    {
       agentId,
+      title,
+      showHeader,
+      header,
+      empty,
+      composerActions,
+      emptyTitle,
+      emptyDescription,
       chatEndpoint,
       authEndpoint,
+      systemPrompt,
+      tools,
+      widgets = {},
+      colorScheme = DEFAULT_COLOR_SCHEME,
+      theme,
+      attachments,
+      debug,
+    },
+    ref,
+  ) {
+    const targetRef = useRef<HTMLDivElement>(null)
+    const handleRef = useRef<AstralBeamChatHandle | null>(null)
+    const [activeRenders, setActiveRenders] = useState<ReadonlyMap<string, ActiveRender>>(
+      new Map(),
+    )
+    useImperativeHandle(ref, () => ({
+      reset: () => handleRef.current?.reset(),
+      stop: () => handleRef.current?.stop(),
+    }), [])
+    // The chat calls tools long after mount, so route execution through the latest prop value —
+    // otherwise every execute would close over the first render's host state.
+    const toolsRef = useRef(tools)
+    useEffect(() => {
+      toolsRef.current = tools
     })
-    handleRef.current = handle
-    return () => {
-      handleRef.current = null
-      handle.unmount()
+    // The chat keeps one render per tool call, so several renders of the same widget can be live
+    // at once (a listing that renders a card per item); each needs its own portal and React key.
+    const nextRenderKey = useRef(0)
+    // Memoized on the props they adapt: the update effect below ships them to the chat, and a fresh
+    // object every render would rebuild the declared tool set on every render along with it.
+    const hostTools = useMemo(
+      () =>
+        Object.fromEntries(
+          Object.entries(tools ?? {}).map(([name, definition]) => [name, {
+            ...definition,
+            execute: (input: Record<string, unknown>) => {
+              const current = toolsRef.current?.[name]
+              if (!current) throw new Error(`Tool "${name}" is no longer registered`)
+              return current.execute(input)
+            },
+          }]),
+        ),
+      [tools],
+    )
+    const hostWidgets = useMemo(
+      () =>
+        Object.fromEntries(
+          Object.entries(widgets).map(([name, definition]) => [name, {
+            ...definition,
+            // The chat provides a slotted container; record it and portal the JSX into it below,
+            // so the widget renders in the host's React tree with working state and context.
+            render: (props: Record<string, unknown>, container: HTMLElement) => {
+              const key = `astralbeam-render-${nextRenderKey.current++}`
+              setActiveRenders((previous) =>
+                new Map(previous).set(key, { widget: name, container, props })
+              )
+              return () => {
+                setActiveRenders((previous) => {
+                  const next = new Map(previous)
+                  next.delete(key)
+                  return next
+                })
+              }
+            },
+          }]),
+        ),
+      [widgets],
+    )
+    // Chrome slot content lives in the host tree through the same portal mechanism as widget
+    // renders. The renderers key on presence only, so content updates flow through the portal
+    // without re-running the renderer (which would tear down and rebuild the projected DOM).
+    const [chromeContainers, setChromeContainers] = useState<
+      ReadonlyMap<ChromeSlotName, HTMLElement>
+    >(new Map())
+    const hasHeader = header !== undefined
+    const hasEmpty = empty !== undefined
+    const hasComposerActions = composerActions !== undefined
+    const chromeSlots = useMemo(() => {
+      const build = (name: ChromeSlotName): AstralBeamChatSlotRenderer => (container) => {
+        setChromeContainers((previous) => new Map(previous).set(name, container))
+        return () => {
+          setChromeContainers((previous) => {
+            const next = new Map(previous)
+            next.delete(name)
+            return next
+          })
+        }
+      }
+      return {
+        ...(hasHeader ? { header: build("header") } : {}),
+        ...(hasEmpty ? { empty: build("empty") } : {}),
+        ...(hasComposerActions ? { composerActions: build("composerActions") } : {}),
+      }
+    }, [hasHeader, hasEmpty, hasComposerActions])
+    // The one set of updatable options, so mounting and updating cannot drift apart as options are
+    // added. Memoized because the update effect keys off it.
+    const live = useMemo(
+      () => ({
+        title,
+        showHeader,
+        emptyTitle,
+        emptyDescription,
+        systemPrompt,
+        colorScheme,
+        theme,
+        attachments,
+        debug,
+        tools: hostTools,
+        widgets: hostWidgets,
+        slots: chromeSlots,
+      }),
+      [
+        title,
+        showHeader,
+        emptyTitle,
+        emptyDescription,
+        systemPrompt,
+        colorScheme,
+        theme,
+        attachments,
+        debug,
+        hostTools,
+        hostWidgets,
+        chromeSlots,
+      ],
+    )
+    const liveRef = useRef(live)
+    liveRef.current = live
+    useEffect(() => {
+      if (!targetRef.current) return
+      // Mounted once; transport endpoints cannot be updated afterwards.
+      const handle = mountAstralBeamChat(targetRef.current, {
+        ...liveRef.current,
+        agentId,
+        chatEndpoint,
+        authEndpoint,
+      })
+      handleRef.current = handle
+      return () => {
+        handleRef.current = null
+        handle.unmount()
+      }
+    }, [])
+    // Re-applies the initial values harmlessly; afterwards, every prop change retunes the widget.
+    useEffect(() => {
+      handleRef.current?.update(live)
+    }, [live])
+    // Read current props at render time so live host state flows into every projected slot.
+    const chromeContent: Record<ChromeSlotName, ReactNode> = {
+      header,
+      empty,
+      composerActions,
     }
-  }, [])
-  // Re-applies the initial values harmlessly; afterwards, every prop change retunes the widget.
-  useEffect(() => {
-    handleRef.current?.update(live)
-  }, [live])
-  return (
-    <div style={{ height: "100%" }} ref={targetRef}>
-      {[...activeRenders].map(([key, { widget, container, props }]) => {
-        // Read the current prop on every render, so live host state flows into the widget.
-        const definition = widgets[widget]
-        return definition ? createPortal(definition.render(props), container, key) : null
-      })}
-    </div>
-  )
-}
+    return (
+      <div style={{ height: "100%" }} ref={targetRef}>
+        {[...activeRenders].map(([key, { widget, container, props }]) => {
+          // Read the current prop on every render, so live host state flows into the widget.
+          const definition = widgets[widget]
+          return definition ? createPortal(definition.render(props), container, key) : null
+        })}
+        {[...chromeContainers].map(([name, container]) =>
+          createPortal(chromeContent[name], container, `astralbeam-chrome-${name}`)
+        )}
+      </div>
+    )
+  },
+)

--- a/sdk/src/react/index.tsx
+++ b/sdk/src/react/index.tsx
@@ -18,6 +18,7 @@ import {
   type AstralBeamChatTheme,
   defineTool,
   type InferParameters,
+  type JsonSchemaObject,
   mountAstralBeamChat,
   type ParametersSchema,
   type ToolDefinition,
@@ -41,14 +42,14 @@ export interface WidgetDefinition extends Omit<ClientWidgetDefinition, "render">
   render: (props: Record<string, unknown>) => ReactNode
 }
 
-export interface TypedReactWidgetDefinition<S extends ParametersSchema> {
+export interface TypedReactWidgetDefinition<S extends ParametersSchema = JsonSchemaObject> {
   description: string
   parameters?: S
   render: (props: InferParameters<S>) => ReactNode
 }
 
 /** Declares a host widget; a Standard Schema `parameters` types (and validates) `render`'s props. */
-export function defineWidget<const S extends ParametersSchema>(
+export function defineWidget<const S extends ParametersSchema = JsonSchemaObject>(
   widget: TypedReactWidgetDefinition<S>,
 ): WidgetDefinition {
   // The chat validates a Standard Schema before render runs, so the narrowed type holds.

--- a/sdk/src/server/index.ts
+++ b/sdk/src/server/index.ts
@@ -92,6 +92,64 @@ async function signingKey(secret: string) {
   return textEncoder.encode(base64url.encode(new Uint8Array(digest)))
 }
 
+export interface CreateAstralBeamTokenRouteOptions<TTenantUser extends TenantUser = TenantUser> {
+  /** The full API key, or a thunk read per request; missing or empty answers 503. */
+  readonly apiKey: string | undefined | (() => string | undefined)
+  /**
+   * Authenticates the request against the application's own session and returns the tenant
+   * user minted into the token. Returning nothing, or throwing, answers 401.
+   */
+  readonly tenantUser: (
+    request: Request,
+  ) => TTenantUser | null | undefined | Promise<TTenantUser | null | undefined>
+  readonly expiresInSeconds?: number | undefined
+}
+
+// Every response carries no-store: a cached token would outlive its short expiry.
+function tokenRouteResponse(body: Record<string, string>, status: number): Response {
+  return Response.json(body, { status, headers: { "cache-control": "no-store" } })
+}
+
+/**
+ * Builds the fetch-standard `POST` handler for an application's token endpoint, owning the
+ * method check, the unconfigured-key 503, the unauthenticated 401, and the `no-store` header.
+ */
+export function createAstralBeamTokenRoute<TTenantUser extends TenantUser = TenantUser>(
+  options: CreateAstralBeamTokenRouteOptions<TTenantUser>,
+): (request: Request) => Promise<Response> {
+  return async (request) => {
+    if (request.method !== "POST") {
+      return tokenRouteResponse({ error: "Use POST" }, 405)
+    }
+    const apiKey = typeof options.apiKey === "function" ? options.apiKey() : options.apiKey
+    if (!apiKey) {
+      return tokenRouteResponse({ error: "The AstralBeam API key is not configured" }, 503)
+    }
+    let tenantUser: TTenantUser | null | undefined
+    try {
+      tenantUser = await options.tenantUser(request)
+    } catch {
+      tenantUser = undefined
+    }
+    if (!tenantUser) {
+      return tokenRouteResponse({ error: "The session could not be verified" }, 401)
+    }
+    try {
+      const token = await createAstralBeamChatToken({
+        apiKey,
+        tenantUser,
+        ...(options.expiresInSeconds === undefined
+          ? {}
+          : { expiresInSeconds: options.expiresInSeconds }),
+      })
+      return tokenRouteResponse({ token }, 200)
+    } catch {
+      // The thrown message can describe the API key's expected shape; never send it to a client.
+      return tokenRouteResponse({ error: "The chat token could not be created" }, 500)
+    }
+  }
+}
+
 /** Creates the short-lived bearer token returned by an application's server auth endpoint. */
 export async function createAstralBeamChatToken<TTenantUser extends TenantUser = TenantUser>({
   apiKey,

--- a/sdk/src/server/route.test.ts
+++ b/sdk/src/server/route.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest"
+import { createAstralBeamTokenRoute } from "./index.ts"
+
+const apiKey = `key_analyticalengines_production_abo_${"aB".repeat(32)}`
+const tenantUser = { id: "tenant-user-1" }
+
+function post(): Request {
+  return new Request("https://app.example/api/astralbeam/token", { method: "POST" })
+}
+
+describe("createAstralBeamTokenRoute", () => {
+  it("mints a token with no-store for an authenticated request", async () => {
+    const route = createAstralBeamTokenRoute({ apiKey, tenantUser: () => tenantUser })
+    const response = await route(post())
+    expect(response.status).toBe(200)
+    expect(response.headers.get("cache-control")).toBe("no-store")
+    const body = await response.json() as { token: string }
+    // Three dot-separated base64url segments: enough to prove a JWT without re-verifying it here.
+    expect(body.token.split(".")).toHaveLength(3)
+  })
+
+  it("rejects non-POST methods", async () => {
+    const route = createAstralBeamTokenRoute({ apiKey, tenantUser: () => tenantUser })
+    const response = await route(new Request("https://app.example/token", { method: "GET" }))
+    expect(response.status).toBe(405)
+  })
+
+  it("answers 503 when the API key is not configured", async () => {
+    const route = createAstralBeamTokenRoute({
+      apiKey: () => undefined,
+      tenantUser: () => tenantUser,
+    })
+    const response = await route(post())
+    expect(response.status).toBe(503)
+    expect(response.headers.get("cache-control")).toBe("no-store")
+  })
+
+  it("answers 401 when the session callback returns nothing or throws", async () => {
+    const returning = createAstralBeamTokenRoute({ apiKey, tenantUser: () => undefined })
+    expect((await returning(post())).status).toBe(401)
+    const throwing = createAstralBeamTokenRoute({
+      apiKey,
+      tenantUser: () => {
+        throw new Error("no session")
+      },
+    })
+    expect((await throwing(post())).status).toBe(401)
+  })
+
+  it("answers 500 without leaking the reason when minting fails", async () => {
+    const route = createAstralBeamTokenRoute({
+      apiKey: "not-a-real-key",
+      tenantUser: () => tenantUser,
+    })
+    const response = await route(post())
+    expect(response.status).toBe(500)
+    const body = await response.json() as { error: string }
+    // The thrown message describes the key's expected shape; the client must not see it.
+    expect(body.error).not.toMatch(/abo_/)
+  })
+})

--- a/sdk/src/widget/chat-widget.tsx
+++ b/sdk/src/widget/chat-widget.tsx
@@ -36,6 +36,8 @@ import {
   getValidChatToken,
   initializeChatAuthentication,
 } from "./auth.ts"
+import type { ChatController } from "./index.tsx"
+import { hostSlotName, useHostSlots } from "./use-host-slots.ts"
 import { useWidgetRenders } from "./use-widget-renders.ts"
 
 // Shared fallback so `widgets` keeps its identity across renders when the host registers none;
@@ -43,11 +45,16 @@ import { useWidgetRenders } from "./use-widget-renders.ts"
 const NO_WIDGETS: Record<string, WidgetDefinition> = {}
 
 export function ChatWidget(
-  { options, host }: { options: MountAstralBeamChatOptions; host: HTMLElement },
+  { options, host, controller }: {
+    options: MountAstralBeamChatOptions
+    host: HTMLElement
+    controller: ChatController
+  },
 ) {
   const widgets = options.widgets ?? NO_WIDGETS
   const debug = useMemo(() => createDebugLogger(options.debug), [options.debug])
   const { activeSlots, renderWidget, discardAllRenders } = useWidgetRenders(widgets, host, debug)
+  const hostSlots = useHostSlots(options.slots, host, debug)
   const [authenticationState, setAuthenticationState] = useState<ChatAuthenticationState>({
     status: "loading",
   })
@@ -289,6 +296,16 @@ export function ChatWidget(
     discardAllRenders()
   }
 
+  // Re-registered every render so the loader's handle always calls the latest closures.
+  useEffect(() => {
+    controller.reset = resetConversation
+    controller.stop = stop
+    return () => {
+      controller.reset = undefined
+      controller.stop = undefined
+    }
+  })
+
   // The Card frame with a bordered header, an unpadded content area, and a footer composer is
   // shadcn's canonical chat assembly (docs/changelog/2026-06-chat-components). The host sizes and
   // frames the widget, so the card's own radius and ring are stripped for a full-bleed fit.
@@ -304,23 +321,31 @@ export function ChatWidget(
     >
       {showHeader && (
         <CardHeader className="gap-1 border-b">
-          <CardTitle>{options.title ?? DEFAULT_TITLE}</CardTitle>
-          <CardAction>
-            <Button
-              variant="outline"
-              size="icon-sm"
-              aria-label="Reset conversation"
-              disabled={streamBusy || messages.length === 0}
-              onClick={resetConversation}
-            >
-              <ArrowCounterClockwiseIcon />
-            </Button>
-          </CardAction>
+          {hostSlots.has("header")
+            // The host's own header content, projected in the host page's style.
+            ? <slot name={hostSlotName("header")} />
+            : (
+              <>
+                <CardTitle>{options.title ?? DEFAULT_TITLE}</CardTitle>
+                <CardAction>
+                  <Button
+                    variant="outline"
+                    size="icon-sm"
+                    aria-label="Reset conversation"
+                    disabled={streamBusy || messages.length === 0}
+                    onClick={resetConversation}
+                  >
+                    <ArrowCounterClockwiseIcon />
+                  </Button>
+                </CardAction>
+              </>
+            )}
         </CardHeader>
       )}
       <CardContent className="min-h-0 flex-1 overflow-hidden p-0">
         <ChatTranscript
           messages={messages}
+          emptySlot={hostSlots.has("empty") ? hostSlotName("empty") : undefined}
           emptyTitle={options.emptyTitle}
           emptyDescription={options.emptyDescription}
           widgets={widgets}
@@ -338,6 +363,10 @@ export function ChatWidget(
       <CardFooter className="flex-col gap-2 rounded-none border-t-0 bg-transparent pt-1">
         {showSandboxTray && <SandboxTray activity={sandboxActivity} status={sandboxStatus} />}
         <ChatComposer
+          title={options.title ?? DEFAULT_TITLE}
+          actionsSlot={hostSlots.has("composerActions")
+            ? hostSlotName("composerActions")
+            : undefined}
           draft={draft}
           onDraftChange={setDraft}
           onSend={sendDraft}

--- a/sdk/src/widget/chat-widget.tsx
+++ b/sdk/src/widget/chat-widget.tsx
@@ -126,27 +126,26 @@ export function ChatWidget(
   // the endpoint reports it as a CUSTOM event. Everything else about the sandbox is read back out
   // of the transcript by `collectSandboxActivity`.
   const [sandboxStatus, setSandboxStatus] = useState<SandboxStatus | undefined>(undefined)
-  const { messages, sendMessage, setMessages, status, error, addToolResult, stop, reload } =
-    useChat({
-      initialMessages: [],
-      connection,
-      tools,
-      forwardedProps,
-      ...(debugCallbacks || {}),
-      onCustomEvent: (eventType, data) => {
-        const state = (data as { state?: unknown } | undefined)?.state
-        const sandboxState = eventType === SANDBOX_STATUS_EVENT &&
-            (state === "starting" || state === "ready" || state === "error")
-          ? state
-          : undefined
-        if (sandboxState === undefined) {
-          debug?.("stream", `custom event "${eventType}"`, data)
-          return
-        }
-        debug?.("sandbox", `sandbox ${sandboxState}`)
-        setSandboxStatus(sandboxState)
-      },
-    })
+  const { messages, sendMessage, clear, status, error, addToolResult, stop, reload } = useChat({
+    initialMessages: [],
+    connection,
+    tools,
+    forwardedProps,
+    ...(debugCallbacks || {}),
+    onCustomEvent: (eventType, data) => {
+      const state = (data as { state?: unknown } | undefined)?.state
+      const sandboxState = eventType === SANDBOX_STATUS_EVENT &&
+          (state === "starting" || state === "ready" || state === "error")
+        ? state
+        : undefined
+      if (sandboxState === undefined) {
+        debug?.("stream", `custom event "${eventType}"`, data)
+        return
+      }
+      debug?.("sandbox", `sandbox ${sandboxState}`)
+      setSandboxStatus(sandboxState)
+    },
+  })
   const sandboxActivity = useMemo(() => collectSandboxActivity(messages), [messages])
   const showSandboxTray = hasSandboxActivity(sandboxActivity, sandboxStatus)
   useEffect(() => {
@@ -289,7 +288,9 @@ export function ChatWidget(
 
   const resetConversation = () => {
     debug?.("status", "conversation reset")
-    setMessages([])
+    // clear() is the client's own reset: it aborts an active stream, drops queued sends, and
+    // resets resume state, where replacing the message array would let late chunks repopulate.
+    clear()
     setDraft("")
     setAttachments([])
     setSandboxStatus(undefined)

--- a/sdk/src/widget/components/chat-composer.tsx
+++ b/sdk/src/widget/components/chat-composer.tsx
@@ -13,6 +13,10 @@ import { cn, describeError } from "../lib/utils.ts"
 import { ComposerAttachments } from "./composer-attachments.tsx"
 
 interface ChatComposerProps {
+  /** Widget title, used in the input's placeholder ("Message <title>…"). */
+  title: string
+  /** Name of the host's composer-actions slot; when set, extra host controls project into the row. */
+  actionsSlot?: string | undefined
   draft: string
   onDraftChange: (draft: string) => void
   onSend: () => void
@@ -39,6 +43,8 @@ interface ChatComposerProps {
 
 export function ChatComposer(
   {
+    title,
+    actionsSlot,
     draft,
     onDraftChange,
     onSend,
@@ -165,7 +171,7 @@ export function ChatComposer(
             ? "Verifying your session…"
             : dropTarget
             ? "Drop files to attach…"
-            : "Message AstralBeam…"}
+            : `Message ${title}…`}
           disabled={blocked}
           value={draft}
           onChange={(event) => onDraftChange(event.currentTarget.value)}
@@ -197,6 +203,11 @@ export function ChatComposer(
               <PaperclipIcon />
             </InputGroupButton>
           )}
+          {
+            /* Host controls project here in the host page's own style; the slot lays out as
+            display: contents, so each projected child is a flex item of this row. */
+          }
+          {actionsSlot && <slot name={actionsSlot} />}
           {streamBusy
             ? (
               <InputGroupButton

--- a/sdk/src/widget/components/chat-transcript.tsx
+++ b/sdk/src/widget/components/chat-transcript.tsx
@@ -27,6 +27,8 @@ import { UserMessageBody } from "./user-message-body.tsx"
 
 interface ChatTranscriptProps {
   messages: UIMessage[]
+  /** Name of the host's empty-state slot; when set, it replaces the default empty state. */
+  emptySlot?: string | undefined
   /** Headline of the empty transcript; defaults to `DEFAULT_EMPTY_TITLE`. */
   emptyTitle?: string | undefined
   /** Subtitle of the empty transcript; defaults to `DEFAULT_EMPTY_DESCRIPTION`. */
@@ -44,6 +46,7 @@ interface ChatTranscriptProps {
 export function ChatTranscript(
   {
     messages,
+    emptySlot,
     emptyTitle,
     emptyDescription,
     widgets,
@@ -55,6 +58,14 @@ export function ChatTranscript(
   }: ChatTranscriptProps,
 ) {
   if (messages.length === 0) {
+    if (emptySlot) {
+      // The host's own empty state; the wrapper gives the projected content the full height.
+      return (
+        <div className="h-full overflow-y-auto">
+          <slot name={emptySlot} />
+        </div>
+      )
+    }
     return (
       <Empty className="h-full">
         <EmptyHeader>

--- a/sdk/src/widget/index.tsx
+++ b/sdk/src/widget/index.tsx
@@ -7,7 +7,18 @@ import { chatStyles } from "./styles.generated.ts"
 
 export interface ChatHandle {
   update: (options: MountAstralBeamChatOptions) => void
+  reset: () => void
+  stop: () => void
   dispose: () => void
+}
+
+/**
+ * The widget's imperative surface, registered by ChatWidget from an effect. Plain mutable data
+ * rather than a React ref so the loader can hold it before the first render commits.
+ */
+export interface ChatController {
+  reset?: (() => void) | undefined
+  stop?: (() => void) | undefined
 }
 
 export function renderChat(
@@ -26,16 +37,25 @@ export function renderChat(
   let live = options
   const disposeHostStyle = bridgeHostStyle(shadowRoot, () => createDebugLogger(live.debug))
   const root = createRoot(container)
+  const controller: ChatController = {}
   // The mount target (an HTMLElement per mountAstralBeamChat) hosts the slotted widget renders.
   const render = (nextOptions: MountAstralBeamChatOptions) => {
     live = nextOptions
-    root.render(<ChatWidget options={nextOptions} host={shadowRoot.host as HTMLElement} />)
+    root.render(
+      <ChatWidget
+        options={nextOptions}
+        host={shadowRoot.host as HTMLElement}
+        controller={controller}
+      />,
+    )
   }
   render(options)
   return {
     // Rendering the same element type into the same root updates it in place, so the transcript,
     // the chat session, and live widget renders all survive an update.
     update: render,
+    reset: () => controller.reset?.(),
+    stop: () => controller.stop?.(),
     dispose: () => {
       root.unmount()
       disposeHostStyle()

--- a/sdk/src/widget/lib/constants.ts
+++ b/sdk/src/widget/lib/constants.ts
@@ -147,7 +147,11 @@ export const ATTACHMENT_TEXT_FILENAMES = [
 
 /** Slot name prefix for widget renders; the bridged style rule keys off it. */
 export const WIDGET_SLOT_PREFIX = "astralbeam-widget-"
-export const WIDGET_SLOT_SELECTOR = `slot[name^="${WIDGET_SLOT_PREFIX}"]`
+export const HOST_SLOT_PREFIX = "astralbeam-slot-"
+// One selector covers widget renders and chrome slots: both project host content that
+// should read in the host page's own style.
+export const WIDGET_SLOT_SELECTOR =
+  `slot[name^="${WIDGET_SLOT_PREFIX}"], slot[name^="${HOST_SLOT_PREFIX}"]`
 
 /**
  * Every inherited CSS property, bridged from the host page onto the widget slots. Longhands are
@@ -265,8 +269,9 @@ export const INHERITED_PROPERTIES = [
   "marker-end",
   "dominant-baseline",
   "text-anchor",
-  // Non-standard but inherited
-  "-webkit-text-fill-color",
+  // Non-standard but inherited. -webkit-text-fill-color is deliberately absent: its computed
+  // value is a concrete color that would beat `color` on every projected element, so
+  // hostStyleRule pins it back to currentColor instead of bridging it.
   "-webkit-text-stroke-color",
   "-webkit-text-stroke-width",
   "-webkit-font-smoothing",

--- a/sdk/src/widget/lib/utils.ts
+++ b/sdk/src/widget/lib/utils.ts
@@ -197,5 +197,8 @@ export function hostStyleRule(source: Element, customProperties: readonly string
     if (!value || value.includes("{") || value.includes("}")) continue
     declarations.push(`${property}:${value}`)
   }
+  // Restores the default relationship where `color` drives text paint: bridging the computed
+  // fill color froze slotted text to the page's body ink even where a render set its own color.
+  declarations.push("-webkit-text-fill-color:currentColor")
   return `${WIDGET_SLOT_SELECTOR}{${declarations.join(";")}}`
 }

--- a/sdk/src/widget/use-host-slots.ts
+++ b/sdk/src/widget/use-host-slots.ts
@@ -1,0 +1,73 @@
+import { useEffect, useRef, useState } from "react"
+import type { AstralBeamChatSlotRenderer, AstralBeamChatSlots } from "../lib/types.ts"
+import type { DebugLogger } from "../lib/debug.ts"
+import { HOST_SLOT_PREFIX } from "./lib/constants.ts"
+
+export type HostSlotName = keyof AstralBeamChatSlots
+
+const HOST_SLOT_NAMES: readonly HostSlotName[] = ["header", "empty", "composerActions"]
+
+/** The `slot` attribute (and `<slot name>`) for a named chrome slot. */
+export function hostSlotName(name: HostSlotName): string {
+  return `${HOST_SLOT_PREFIX}${name === "composerActions" ? "composer-actions" : name}`
+}
+
+interface ActiveHostSlot {
+  /** Compared by identity, so an update that keeps the same renderer leaves its DOM alone. */
+  renderer: AstralBeamChatSlotRenderer
+  container: HTMLElement
+  cleanup: (() => void) | undefined
+}
+
+/**
+ * Owns the host-rendered chrome slots (header, empty state, composer actions): light-DOM
+ * containers projected into the widget through named <slot> elements, the same mechanism widget
+ * renders use. Returns the slot names currently backed by host content, so the widget knows
+ * where to render a <slot> instead of its own chrome.
+ */
+export function useHostSlots(
+  slots: AstralBeamChatSlots | undefined,
+  host: HTMLElement,
+  debug: DebugLogger | undefined,
+): ReadonlySet<HostSlotName> {
+  const [active, setActive] = useState<ReadonlySet<HostSlotName>>(new Set())
+  const rendered = useRef(new Map<HostSlotName, ActiveHostSlot>())
+  useEffect(() => {
+    for (const name of HOST_SLOT_NAMES) {
+      const renderer = slots?.[name]
+      const current = rendered.current.get(name)
+      if (current?.renderer === renderer) continue
+      if (current) {
+        current.cleanup?.()
+        current.container.remove()
+        rendered.current.delete(name)
+        debug?.("mount", `host slot "${name}" disposed`)
+      }
+      if (!renderer) continue
+      const container = document.createElement("div")
+      container.slot = hostSlotName(name)
+      host.append(container)
+      const cleanup = renderer(container)
+      rendered.current.set(name, { renderer, container, cleanup: cleanup ?? undefined })
+      debug?.("mount", `host slot "${name}" rendered`)
+    }
+    setActive((previous) => {
+      const next = new Set(rendered.current.keys())
+      // Set identity is the render trigger, so an unchanged set must not produce a new object.
+      if (next.size === previous.size && [...next].every((name) => previous.has(name))) {
+        return previous
+      }
+      return next
+    })
+  }, [slots, host, debug])
+  useEffect(() =>
+  // Unmount only: the per-slot effect above owns replacement during the widget's lifetime.
+  () => {
+    for (const slot of rendered.current.values()) {
+      slot.cleanup?.()
+      slot.container.remove()
+    }
+    rendered.current.clear()
+  }, [])
+  return active
+}

--- a/webapp/src/routes/docs/-content/sdk/authentication.md
+++ b/webapp/src/routes/docs/-content/sdk/authentication.md
@@ -4,25 +4,27 @@ The widget will not chat until it has a token, and it never sees your API key. Y
 
 ## The token endpoint
 
-`/api/astralbeam/token` by default; change it with the `authEndpoint` option.
+`/api/astralbeam/token` by default; change it with the `authEndpoint` option. `createAstralBeamTokenRoute` builds the whole fetch-standard handler: the method check, the unconfigured-key 503, the unauthenticated 401, and the `no-store` header.
 
 ```ts
-import { createAstralBeamChatToken } from "@astralbeam/sdk/server"
+import { createAstralBeamTokenRoute } from "@astralbeam/sdk/server"
 
-export async function POST(request: Request) {
-  const session = await requireApplicationSession(request)
-  const token = await createAstralBeamChatToken({
-    apiKey: process.env.ASTRALBEAM_API_KEY!, // key_<organization>_<key>_abo_<secret>
-    tenantUser: {
+export const POST = createAstralBeamTokenRoute({
+  apiKey: () => process.env.ASTRALBEAM_API_KEY, // key_<organization>_<key>_abo_<secret>
+  tenantUser: async (request) => {
+    const session = await getApplicationSession(request)
+    if (!session) return undefined // answered as 401
+    return {
       id: session.user.id, // required; stable and unique per organization
       name: session.user.name,
       email: session.user.email,
       tenant: { id: session.tenant.id, name: session.tenant.name },
-    },
-  })
-  return Response.json({ token }, { headers: { "cache-control": "no-store" } })
-}
+    }
+  },
+})
 ```
+
+For full control, mint the token yourself with `createAstralBeamChatToken` and answer with `Response.json({ token })` plus `cache-control: no-store`.
 
 ## Rules
 

--- a/webapp/src/routes/docs/-content/sdk/configuration.md
+++ b/webapp/src/routes/docs/-content/sdk/configuration.md
@@ -30,8 +30,36 @@ Prop or `update` changes apply immediately.
 | `tools`, `widgets`               | none                      | See [Tools and widgets](./tools-and-widgets.md)                                 |
 | `debug`                          | `false`                   | Log every SDK action in the browser, and the run on the server                  |
 
+## Chrome slots
+
+Replace parts of the widget's own chrome with host-rendered content, styled by the host page. In React they are plain props; on the vanilla handle they are `slots` renderers.
+
+```tsx
+<AstralBeamChat
+  header={<MyChatHeader onReset={() => chatRef.current?.reset()} />}
+  empty={<MyWelcome />}
+  composerActions={<MyVoiceButton />}
+/>
+```
+
+- `header` replaces the title and reset button; `showHeader={false}` still hides the whole row.
+- `empty` replaces the empty-transcript state; `composerActions` adds controls next to send.
+- Vanilla: `slots: { header: (container) => { ...; return cleanup } }`, updatable through `update`.
+
+## Imperative control
+
+The React component exposes a ref; the vanilla handle has the same methods.
+
+```tsx
+const chatRef = useRef<AstralBeamChatRef>(null)
+// <AstralBeamChat ref={chatRef} /> — then:
+chatRef.current?.reset() // clears transcript, drafts, attachments, widget renders
+chatRef.current?.stop() // stops the in-flight generation
+```
+
 ## Behavior notes
 
 - Assistant replies render as Markdown; raw HTML is escaped and executable link protocols are dropped.
 - An update that turns attachments off also drops files already picked into the composer.
 - Dropping a widget from `widgets` disposes any render of it still in the transcript.
+- To defer the chat chunk, render the component only on first open; hide with CSS afterwards, since unmounting discards the transcript.

--- a/webapp/src/routes/docs/-content/sdk/theming.md
+++ b/webapp/src/routes/docs/-content/sdk/theming.md
@@ -35,4 +35,4 @@ Your own widgets (see [Tools and widgets](./tools-and-widgets.md)) render in the
 - Your own selectors match a render like any other element; target `[slot^="astralbeam-widget-"]` for all of them.
 - Inherited properties are read from the mount target's parent, so rules on the target itself are missed.
 - Tokens declared only in a cross-origin stylesheet cannot be read.
-- The style bridge mirrors inherited text properties; if projected text ignores your `color`, set `-webkit-text-fill-color: currentColor` on the render.
+- The bridge pins `-webkit-text-fill-color` to `currentColor` on projected content, so your `color` rules always drive text paint.

--- a/webapp/src/routes/docs/-content/sdk/tools-and-widgets.md
+++ b/webapp/src/routes/docs/-content/sdk/tools-and-widgets.md
@@ -44,6 +44,30 @@ widgets: {
 - With plain JSON Schema, nothing validates in the browser: treat the agent's input as untrusted.
 - Models sometimes send numbers as strings; with Zod, prefer `z.coerce.number()` over `z.number()`.
 
+## Typed definitions
+
+`defineTool` and `defineWidget` are identity helpers that exist for their generics: with a Standard Schema in `parameters`, the `execute` or `render` input is the schema's own output type.
+
+```tsx
+import { defineTool, defineWidget } from "@astralbeam/sdk/react"
+import { z } from "zod"
+
+const todoCard = defineWidget({
+  description: "A single todo from the host app, addressed by its id",
+  parameters: z.object({ id: z.coerce.number(), highlight: z.boolean().optional() }),
+  render: ({ id, highlight }) => <TodoCard id={id} highlight={highlight ?? false} />,
+})
+
+const createTodo = defineTool({
+  description: "Create a new todo and append it to the list",
+  parameters: z.object({ text: z.string().min(1) }),
+  execute: ({ text }) => addTodo(text), // text: string, validated before this runs
+})
+```
+
+- Import them from `@astralbeam/sdk/react` (JSX widgets) or `@astralbeam/sdk/client` (container widgets).
+- With a plain JSON Schema, the input stays `Record<string, unknown>`, which is the honest type.
+
 ## Live state
 
 Definitions are declared once but called many turns later, so make sure they read current state.


### PR DESCRIPTION
Phase 2 of `sdk/redesign.plan.md` (stacked on #86): the DX quick wins every real integration asked for.

## What changed

- **Typed definitions** — `defineTool` / `defineWidget` are identity helpers whose generics infer `execute`/`render` input from a Standard Schema's output; plain JSON Schema stays `Record<string, unknown>` (the honest type). Exported from `/client` (container widgets) and `/react` (JSX widgets).
- **Chrome slots** — `header`, `empty`, and `composerActions` project host content through the same light-DOM `<slot>` mechanism widget renders already use. React: plain `ReactNode` props via portals. Vanilla: `slots` renderers, updatable through `update`. Replaces the all-or-nothing `showHeader={false}` + rebuild-your-own-chrome pattern (bmd, nanoknow).
- **Imperative control** — `reset()` and `stop()` on the vanilla handle and on a React `ref` (`AstralBeamChatRef`). Kills bmd's `key={chatKey}` full-remount hack for "New chat".
- **`createAstralBeamTokenRoute`** — a fetch-standard handler factory owning the method check, unconfigured-key 503, unauthenticated 401, and `no-store`; deletes the token-endpoint boilerplate copy-pasted across all three consumer apps. `examples/todos` now uses it.
- **Style-leak fix** — the host style bridge no longer mirrors the computed `-webkit-text-fill-color` (a concrete color that beat `color` on every projected element); it pins `currentColor` instead. This was bmd's documented "One gotcha".
- Composer placeholder now reads `Message <title>…` instead of a hardcoded brand.

## Evidence

Built `dist/client.js` mounted in a plain host page (serif maroon page styles), host header + empty state + a MIC composer action projected, then `update({ slots: {} })` restoring the widget's own chrome — and `reset()`/`stop()` callable from the host:

![Host slots](https://raw.githubusercontent.com/AstralBeamAI/astralbeam/screenshots/sdk-redesign-2/slots.png)

![Slots removed](https://raw.githubusercontent.com/AstralBeamAI/astralbeam/screenshots/sdk-redesign-2/slots-removed.png)

Note the maroon serif text in the host header — host `color` rules drive projected text again.

## Validation

- `sdk`: `deno task ready` passes; 38 Vitest tests including 5 new `createAstralBeamTokenRoute` tests (405/503/401/500-without-leak/token+no-store).
- `examples/todos`: `deno task check` passes against the rebuilt `dist`.
- Docs guides (authentication, configuration, theming, tools-and-widgets) updated in step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
