### PR TITLE
Grant the webapp runtime the system information it needs

### DIFF
--- a/webapp/deno.jsonc
+++ b/webapp/deno.jsonc
@@ -15,10 +15,14 @@
       "sys": true,
       "write": true
     },
+    // The AWS SDK reads uid/gid and the home directory to locate shared config files, and its
+    // user-agent middleware reads the OS release; nodemailer's SMTP client falls back to the
+    // hostname for EHLO. https://docs.deno.com/runtime/fundamentals/security/#system-information
     "runtime": {
       "env": true,
       "net": true,
-      "read": true
+      "read": true,
+      "sys": ["gid", "homedir", "hostname", "osRelease", "uid"]
     }
   },
   "fmt": {


### PR DESCRIPTION
- Grant the webapp's `runtime` permission set narrow `sys` access (`gid`, `homedir`, `hostname`, `osRelease`, `uid`) in `webapp/deno.jsonc`, fixing production email sends that died with `NotCapable: Requires sys access to "uid"` inside the AWS SDK's shared-config lookup.
  - The AWS SDK reads uid/gid and the home directory while locating `~/.aws` shared config files, and its user-agent middleware reads the OS release.
  - Nodemailer's SMTP client falls back to `os.hostname()` for EHLO, so the SMTP provider would have hit the same wall next.
  - Kinds come from Deno's [system information permission](https://docs.deno.com/runtime/fundamentals/security/#system-information) list; `sys` stays fully granted only for `tooling`.
- Verified locally under `-P=runtime` with a throwaway SESv2 client pointed at a dead endpoint: both the explicit-credential path and the shared-config-file credential path now reach the network instead of failing on permissions.
