### PR TITLE
Migrate the SDK to a single apiUrl base option

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ deno task build
 
 ### 4. Run the todos example
 
-A barebones TanStack Start app that embeds the widget from `sdk/dist`, mints demo chat tokens on the server, and points the widget at the webapp's `/api/chat`, on http://localhost:4700. See [`examples/todos/README.md`](examples/todos/README.md) for what to try.
+A barebones TanStack Start app that embeds the widget from `sdk/dist`, mints demo chat tokens on the server, and points the widget at the webapp's `/api`, on http://localhost:4700. See [`examples/todos/README.md`](examples/todos/README.md) for what to try.
 
 ```sh
 cd examples/todos

--- a/examples/todos/README.md
+++ b/examples/todos/README.md
@@ -4,7 +4,7 @@ A deliberately barebones TanStack Start todos app that embeds the AstralBeam cha
 
 The app uses plain CSS with no Tailwind or shadcn/ui. That is the point: the chat widget's Tailwind-based UI lives entirely inside its shadow root, and the only host UI in the conversation is the app's own `TodoCard`, registered as the `todoCard` widget so the agent can render it inline with props it chooses, while live app state and handlers keep working.
 
-The chat talks to a real organization-owned agent: the app points `chatEndpoint` at the webapp's `/api/chat`, serves the SDK's default `/api/astralbeam/token` token route (built with `createAstralBeamTokenRoute`), mints a short-lived JWT from an organization API key for a fixed demo tenant user, and registers `get_todos`, `create_todo`, `update_todo`, and `delete_todo` tools that execute against the app's own React state.
+The chat talks to a real organization-owned agent: the app points `apiUrl` at the webapp's `/api`, serves the SDK's default `/api/astralbeam/token` token route (built with `createAstralBeamTokenRoute`), mints a short-lived JWT from an organization API key for a fixed demo tenant user, and registers `get_todos`, `create_todo`, `update_todo`, and `delete_todo` tools that execute against the app's own React state.
 
 The agent's instructions are owned by the dashboard: the SDK cannot send a system prompt, so paste the prompt below into the demo agent on the agents page.
 

--- a/examples/todos/src/components/todos-assistant.tsx
+++ b/examples/todos/src/components/todos-assistant.tsx
@@ -5,7 +5,7 @@ import {
 } from "@astralbeam/sdk/react"
 
 import { TodoCard } from "@/components/todo-card.tsx"
-import { CHAT_AGENT_ID, CHAT_ENDPOINT, CHAT_TITLE } from "@/lib/config.ts"
+import { ASTRALBEAM_API_URL, CHAT_AGENT_ID, CHAT_TITLE } from "@/lib/config.ts"
 import { WIDGET_THEME } from "@/lib/constants.ts"
 import type { Todo } from "@/lib/types.ts"
 
@@ -31,7 +31,7 @@ export function TodosAssistant({
       <AstralBeamChat
         agentId={CHAT_AGENT_ID}
         title={CHAT_TITLE}
-        chatEndpoint={CHAT_ENDPOINT}
+        apiUrl={ASTRALBEAM_API_URL}
         tools={tools}
         colorScheme={colorScheme}
         theme={customTheme ? WIDGET_THEME : undefined}

--- a/examples/todos/src/lib/config.ts
+++ b/examples/todos/src/lib/config.ts
@@ -1,6 +1,6 @@
 export const APP_NAME = "AstralBeam Todos"
 export const CHAT_TITLE = "Todos assistant"
-export const CHAT_ENDPOINT = "http://localhost:4500/api/chat"
+export const ASTRALBEAM_API_URL = "http://localhost:4500/api"
 // Left undefined when unset so the widget falls back to the organization's default agent.
 export const CHAT_AGENT_ID: string | undefined = import.meta.env.VITE_ASTRALBEAM_AGENT_ID ||
   undefined

--- a/sdk/AGENTS.md
+++ b/sdk/AGENTS.md
@@ -45,6 +45,7 @@ Generate shadcn components with `deno task ui add <component>` and allow only mi
 - Keep comments to at most two lines and explain only non-obvious reasoning.
 - Use plain data and helper functions with explicit options objects; no classes or closure-based state factories, except framework-required classes such as React error boundaries.
 - Record structural and build reasoning as comments beside the code that depends on it.
+- Address AstralBeam through the single `apiUrl` base option and derive every route from it with `chatApiUrls`; a new AstralBeam API becomes another path under the base, never another endpoint option. The host's own token endpoint is the separate `authTokenUrl`.
 - Treat a copied API key as its public ID plus the exact Better Auth raw key; hash the complete `abo_<secret>` value, never only its random suffix.
 
 ## Testing

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -26,7 +26,7 @@ const handle = mountAstralBeamChat(document.getElementById("sidebar"), {})
 ```
 
 - The widget fills its container, so give it a parent with a definite height (`min-h-0` in a flex column).
-- Two origins by design: chat streams to the hosted cloud by default, while the token comes from your own app's endpoint. Self-hosted deployments set `chatEndpoint` to their own origin.
+- Two origins by design: chat streams to the hosted cloud by default, while the token comes from your own app's endpoint. Self-hosted deployments set `apiUrl` to their own origin.
 - `@astralbeam/sdk/client` ships no React; the chat loads as a lazy chunk with its own bundled copy.
 - `react` and `react-dom` are optional peer dependencies used only by `@astralbeam/sdk/react`.
 - Mount it above your router if the transcript should survive page navigation.
@@ -55,21 +55,21 @@ export const POST = createAstralBeamTokenRoute({
 
 ## Options
 
-Every option is also a prop on `<AstralBeamChat>`; `handle.update(options)` applies any subset in place. `agentId`, `chatEndpoint`, and `authEndpoint` are fixed at mount. Details in [Configuration](https://app.astralbeam.ai/docs/sdk/configuration).
+Every option is also a prop on `<AstralBeamChat>`; `handle.update(options)` applies any subset in place. `agentId`, `apiUrl`, and `authTokenUrl` are fixed at mount. Details in [Configuration](https://app.astralbeam.ai/docs/sdk/configuration).
 
-| Option                               | Default                              | Meaning                                                         |
-| ------------------------------------ | ------------------------------------ | --------------------------------------------------------------- |
-| `agentId`                            | organization's default               | `agt_<organization>_<agent>` from the dashboard                 |
-| `chatEndpoint`                       | `https://app.astralbeam.ai/api/chat` | The AstralBeam chat endpoint the widget streams from            |
-| `authEndpoint`                       | `/api/astralbeam/token`              | Your token endpoint                                             |
-| `title`, `showHeader`                | `"AstralBeam"`, `true`               | Header text, and whether the header and reset button show       |
-| `emptyTitle`, `emptyDescription`     | generic copy                         | Headline and subtitle of the empty transcript                   |
-| `colorScheme`, `theme`               | `"system"`, built-in palette         | Light/dark/system, and shadcn token overrides                   |
-| `attachments`                        | `true`                               | `false` hides the feature, or pass limits                       |
-| `tools`, `widgets`                   | none                                 | What the agent can do and draw in your app                      |
-| `sandboxPanel`                       | `false`                              | Collected sandbox panel: files with downloads, command log      |
-| `header`, `empty`, `composerActions` | widget's own chrome                  | Host-rendered replacements (React props; `slots` on the handle) |
-| `debug`                              | `false`                              | Log every SDK action in the browser and on the server           |
+| Option                               | Default                         | Meaning                                                         |
+| ------------------------------------ | ------------------------------- | --------------------------------------------------------------- |
+| `agentId`                            | organization's default          | `agt_<organization>_<agent>` from the dashboard                 |
+| `apiUrl`                             | `https://app.astralbeam.ai/api` | Base URL of the AstralBeam API; the widget calls `/chat` there  |
+| `authTokenUrl`                       | `/api/astralbeam/token`         | Your token endpoint                                             |
+| `title`, `showHeader`                | `"AstralBeam"`, `true`          | Header text, and whether the header and reset button show       |
+| `emptyTitle`, `emptyDescription`     | generic copy                    | Headline and subtitle of the empty transcript                   |
+| `colorScheme`, `theme`               | `"system"`, built-in palette    | Light/dark/system, and shadcn token overrides                   |
+| `attachments`                        | `true`                          | `false` hides the feature, or pass limits                       |
+| `tools`, `widgets`                   | none                            | What the agent can do and draw in your app                      |
+| `sandboxPanel`                       | `false`                         | Collected sandbox panel: files with downloads, command log      |
+| `header`, `empty`, `composerActions` | widget's own chrome             | Host-rendered replacements (React props; `slots` on the handle) |
+| `debug`                              | `false`                         | Log every SDK action in the browser and on the server           |
 
 A `ref` on `<AstralBeamChat>` (and the vanilla handle) exposes `reset()` and `stop()` for hosts that draw their own controls.
 

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@astralbeam/sdk",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Frontend SDK for AstralBeam: drop-in agent UI, chat streaming, and server helpers",
   "license": "MIT",
   "type": "module",

--- a/sdk/src/client/index.ts
+++ b/sdk/src/client/index.ts
@@ -1,8 +1,8 @@
 import {
+  DEFAULT_API_URL,
   DEFAULT_COLOR_SCHEME,
   DEFAULT_EMPTY_DESCRIPTION,
   DEFAULT_EMPTY_TITLE,
-  DEFAULT_ENDPOINT,
   DEFAULT_TITLE,
   WIDGET_CONTAINER_CLASS,
 } from "../lib/constants.ts"
@@ -47,7 +47,7 @@ export function mountAstralBeamChat(
     showHeader: live.showHeader ?? true,
     emptyTitle: live.emptyTitle ?? DEFAULT_EMPTY_TITLE,
     emptyDescription: live.emptyDescription ?? DEFAULT_EMPTY_DESCRIPTION,
-    chatEndpoint: live.chatEndpoint ?? DEFAULT_ENDPOINT,
+    apiUrl: live.apiUrl ?? DEFAULT_API_URL,
     authentication: "configured",
     colorScheme: live.colorScheme ?? DEFAULT_COLOR_SCHEME,
     theme: live.theme,
@@ -101,10 +101,10 @@ export function mountAstralBeamChat(
   return {
     update: (next) => {
       if (
-        Object.hasOwn(next, "agentId") || Object.hasOwn(next, "chatEndpoint") ||
-        Object.hasOwn(next, "authEndpoint")
+        Object.hasOwn(next, "agentId") || Object.hasOwn(next, "apiUrl") ||
+        Object.hasOwn(next, "authTokenUrl")
       ) {
-        throw new Error("agentId, chatEndpoint, and authEndpoint are fixed at mount")
+        throw new Error("agentId, apiUrl, and authTokenUrl are fixed at mount")
       }
       // A fresh object rather than a mutation, so the widget's memoized derivations compare the
       // new option values by identity instead of seeing the same object twice.

--- a/sdk/src/core/auth.test.ts
+++ b/sdk/src/core/auth.test.ts
@@ -25,7 +25,7 @@ test("chat authentication loads once and caches a token away from expiry", async
     return Promise.resolve(Response.json({ token }))
   }) as typeof fetch
   const authentication = {
-    authEndpoint: "/auth",
+    authTokenUrl: "/auth",
     session: {
       cached: undefined,
       refreshPromise: undefined,
@@ -54,7 +54,7 @@ test("chat authentication deduplicates concurrent refreshes", async () => {
     return await new Promise<Response>((resolve) => finish = resolve)
   }) as typeof fetch
   const authentication = {
-    authEndpoint: "/auth",
+    authTokenUrl: "/auth",
     session: {
       cached: undefined,
       refreshPromise: undefined,
@@ -78,7 +78,7 @@ test("chat authentication refreshes tokens near expiry", async () => {
   const fetchClient =
     (() => Promise.resolve(Response.json({ token: tokens[requestCount++] }))) as typeof fetch
   const authentication = {
-    authEndpoint: "/auth",
+    authTokenUrl: "/auth",
     session: {
       cached: undefined,
       refreshPromise: undefined,
@@ -115,7 +115,7 @@ test("chat authentication refreshes and retries a rejected chat request once", a
     return Promise.resolve(new Response("ok"))
   }) as typeof fetch
   const authentication = {
-    authEndpoint: "/auth",
+    authTokenUrl: "/auth",
     session: {
       cached: undefined,
       refreshPromise: undefined,
@@ -154,7 +154,7 @@ test("a stale rejected request reuses a token another request already refreshed"
     return Promise.resolve(new Response("ok"))
   }) as typeof fetch
   const authentication = {
-    authEndpoint: "/auth",
+    authTokenUrl: "/auth",
     session: {
       cached: undefined,
       refreshPromise: undefined,
@@ -180,7 +180,7 @@ test("chat authentication fails closed for malformed endpoint responses", async 
   let lastState: ChatAuthenticationState | undefined
   const fetchClient = (() => Promise.resolve(Response.json({ token: "not-a-jwt" }))) as typeof fetch
   const authentication = {
-    authEndpoint: "/auth",
+    authTokenUrl: "/auth",
     session: {
       cached: undefined,
       refreshPromise: undefined,

--- a/sdk/src/core/auth.ts
+++ b/sdk/src/core/auth.ts
@@ -20,7 +20,7 @@ interface ChatAuthenticationSession {
 }
 
 export interface ChatAuthenticationOptions {
-  authEndpoint: string
+  authTokenUrl: string
   session: ChatAuthenticationSession
   onStateChange: (state: ChatAuthenticationState) => void
   fetchClient: typeof globalThis.fetch
@@ -61,10 +61,10 @@ function bearerToken(headers: Headers): string | undefined {
 }
 
 async function fetchChatToken(options: ChatAuthenticationOptions): Promise<string> {
-  const { authEndpoint, session, onStateChange, fetchClient, debug } = options
+  const { authTokenUrl, session, onStateChange, fetchClient, debug } = options
   const { signal } = session.abortController
   try {
-    const response = await fetchClient(authEndpoint, {
+    const response = await fetchClient(authTokenUrl, {
       method: "POST",
       headers: { accept: "application/json" },
       credentials: "include",

--- a/sdk/src/core/session.ts
+++ b/sdk/src/core/session.ts
@@ -5,7 +5,7 @@ import {
   type MultimodalContent,
   type UIMessage,
 } from "@tanstack/ai-client"
-import { DEFAULT_AUTH_ENDPOINT, DEFAULT_ENDPOINT } from "../lib/constants.ts"
+import { chatApiUrls, DEFAULT_AUTH_TOKEN_URL } from "../lib/constants.ts"
 import { createDebugLogger } from "../lib/debug.ts"
 import type { ToolDefinition } from "../lib/types.ts"
 import { buildAgentTools, type WidgetDeclaration } from "./agent-tools.ts"
@@ -34,10 +34,10 @@ export interface WidgetRenderRequest {
 export interface AstralBeamChatCoreOptions {
   /** Public ID of the organization-owned agent; omitted, the organization's default answers. */
   agentId?: string | undefined
-  /** The AstralBeam chat endpoint. Default the hosted cloud endpoint. */
-  chatEndpoint?: string | undefined
+  /** Base URL of the AstralBeam API; `/chat` hangs off it. Default the hosted cloud. */
+  apiUrl?: string | undefined
   /** The application endpoint that mints short-lived chat JWTs. Default `/api/astralbeam/token`. */
-  authEndpoint?: string | undefined
+  authTokenUrl?: string | undefined
   /** Host tools the agent can call; `execute` runs wherever this session lives. */
   tools?: Record<string, ToolDefinition> | undefined
   /** Widgets declared to the agent; `onRenderWidget` is asked to draw them. */
@@ -85,7 +85,7 @@ export interface AstralBeamChatCore {
  */
 export function createAstralBeamChat(options: AstralBeamChatCoreOptions): AstralBeamChatCore {
   const debug = createDebugLogger(options.debug)
-  const endpoint = (options.chatEndpoint ?? DEFAULT_ENDPOINT).replace(/\/+$/, "")
+  const urls = chatApiUrls(options.apiUrl)
   const widgets = options.widgets ?? {}
   const listeners = new Set<() => void>()
   let state: AstralBeamChatState = {
@@ -103,7 +103,7 @@ export function createAstralBeamChat(options: AstralBeamChatCoreOptions): Astral
   }
 
   const authentication: ChatAuthenticationOptions = {
-    authEndpoint: options.authEndpoint ?? DEFAULT_AUTH_ENDPOINT,
+    authTokenUrl: options.authTokenUrl ?? DEFAULT_AUTH_TOKEN_URL,
     session: {
       cached: undefined,
       refreshPromise: undefined,
@@ -118,7 +118,7 @@ export function createAstralBeamChat(options: AstralBeamChatCoreOptions): Astral
   // Agent capability handshake; fails open for state (the endpoint still enforces its policy).
   void (async () => {
     try {
-      const url = new URL(`${endpoint}/config`, globalThis.location?.href)
+      const url = new URL(urls.config, globalThis.location?.href)
       if (options.agentId) url.searchParams.set("agentId", options.agentId)
       const token = await getValidChatToken(authentication)
       const response = await fetch(url, { headers: { authorization: `Bearer ${token}` } })
@@ -154,7 +154,7 @@ export function createAstralBeamChat(options: AstralBeamChatCoreOptions): Astral
   }
 
   const client = new ChatClient({
-    connection: fetchServerSentEvents(endpoint, async () => ({
+    connection: fetchServerSentEvents(urls.chat, async () => ({
       headers: { authorization: `Bearer ${await getValidChatToken(authentication)}` },
       fetchClient: (input, init) => fetchAuthenticatedChat({ ...authentication, input, init }),
     })),

--- a/sdk/src/lib/constants.test.ts
+++ b/sdk/src/lib/constants.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest"
+
+import { chatApiUrls } from "./constants.ts"
+
+describe("chatApiUrls", () => {
+  it("derives the chat routes from the hosted default", () => {
+    expect(chatApiUrls(undefined)).toEqual({
+      chat: "https://app.astralbeam.ai/api/chat",
+      config: "https://app.astralbeam.ai/api/chat/config",
+      files: "https://app.astralbeam.ai/api/chat/files",
+    })
+  })
+
+  it("derives them from a self-hosted base, trailing slashes and all", () => {
+    expect(chatApiUrls("https://acme.example/api//")).toEqual({
+      chat: "https://acme.example/api/chat",
+      config: "https://acme.example/api/chat/config",
+      files: "https://acme.example/api/chat/files",
+    })
+  })
+
+  it("keeps a relative base relative, for a same-origin deployment", () => {
+    expect(chatApiUrls("/api").chat).toBe("/api/chat")
+  })
+})

--- a/sdk/src/lib/constants.ts
+++ b/sdk/src/lib/constants.ts
@@ -11,11 +11,24 @@ export const DEFAULT_EMPTY_TITLE = "Ask the assistant"
 export const DEFAULT_EMPTY_DESCRIPTION =
   "It can answer questions and act through this app's own tools and widgets."
 
-/** Endpoint the chat widget streams from when the mount options give none. */
-export const DEFAULT_ENDPOINT = "https://app.astralbeam.ai/api/chat"
+/** Base URL of the AstralBeam API when the mount options give none; `/chat` and its subroutes hang off it. */
+export const DEFAULT_API_URL = "https://app.astralbeam.ai/api"
 
 /** Host endpoint that mints chat JWTs when the mount options give none. */
-export const DEFAULT_AUTH_ENDPOINT = "/api/astralbeam/token"
+export const DEFAULT_AUTH_TOKEN_URL = "/api/astralbeam/token"
+
+/**
+ * The chat API's URLs under an API base: the stream itself, the agent capability handshake,
+ * and artifact downloads. Chat is one API under the base; others will sit beside it.
+ */
+export function chatApiUrls(apiUrl: string | undefined): {
+  chat: string
+  config: string
+  files: string
+} {
+  const chat = `${(apiUrl ?? DEFAULT_API_URL).replace(/\/+$/, "")}/chat`
+  return { chat, config: `${chat}/config`, files: `${chat}/files` }
+}
 
 /** Color scheme used when the mount options and the React prop give none. */
 export const DEFAULT_COLOR_SCHEME = "system"

--- a/sdk/src/lib/types.ts
+++ b/sdk/src/lib/types.ts
@@ -143,13 +143,13 @@ export interface MountAstralBeamChatOptions {
   /** Subtitle shown under the empty transcript's headline. Default describes the app's tools and widgets. */
   emptyDescription?: string | undefined
   /**
-   * URL of the AstralBeam chat endpoint the widget streams from. Fixed at mount. Default
-   * `"https://app.astralbeam.ai/api/chat"`, the hosted cloud; self-hosted deployments must set
-   * their own origin.
+   * Base URL of the AstralBeam API; the widget calls `/chat` and its subroutes under it. Fixed at
+   * mount. Default `"https://app.astralbeam.ai/api"`, the hosted cloud; self-hosted deployments
+   * must set their own origin.
    */
-  chatEndpoint?: string | undefined
+  apiUrl?: string | undefined
   /** Application endpoint that mints a short-lived chat JWT. Fixed at mount. Default `"/api/astralbeam/token"`. */
-  authEndpoint?: string | undefined
+  authTokenUrl?: string | undefined
   /** Host-defined tools the agent can call, executed in the host page, keyed by tool name. */
   tools?: Record<string, ToolDefinition> | undefined
   /** Host-defined widgets the agent can render inline in the conversation, keyed by identifier. */
@@ -179,11 +179,11 @@ export interface MountAstralBeamChatOptions {
 }
 
 /**
- * Mount options the handle can change afterwards. The agent and transport endpoints are fixed:
+ * Mount options the handle can change afterwards. The agent and the transport URLs are fixed:
  * changing any of them would mean a new client and a discarded transcript.
  */
 export type AstralBeamChatUpdate = Partial<
-  Omit<MountAstralBeamChatOptions, "agentId" | "chatEndpoint" | "authEndpoint">
+  Omit<MountAstralBeamChatOptions, "agentId" | "apiUrl" | "authTokenUrl">
 >
 
 export interface AstralBeamChatHandle {

--- a/sdk/src/react/index.tsx
+++ b/sdk/src/react/index.tsx
@@ -152,10 +152,10 @@ export interface AstralBeamChatProps {
   emptyTitle?: string
   /** Subtitle under the empty transcript's headline; prop changes apply immediately. */
   emptyDescription?: string
-  /** URL of the AstralBeam chat endpoint the widget streams from. Default the hosted cloud endpoint. */
-  chatEndpoint?: string
+  /** Base URL of the AstralBeam API; the widget calls `/chat` under it. Default the hosted cloud. */
+  apiUrl?: string
   /** Application endpoint that mints a short-lived chat JWT. Default `"/api/astralbeam/token"`. */
-  authEndpoint?: string
+  authTokenUrl?: string
   /** Host-defined tools the agent can call, executed in the host's React app, keyed by name. */
   tools?: Record<string, ToolDefinition>
   /** Host-defined widgets the agent can render inline in the conversation, keyed by identifier. */
@@ -195,8 +195,8 @@ export const AstralBeamChat = forwardRef<AstralBeamChatRef, AstralBeamChatProps>
       composerActions,
       emptyTitle,
       emptyDescription,
-      chatEndpoint,
-      authEndpoint,
+      apiUrl,
+      authTokenUrl,
       tools,
       widgets = {},
       colorScheme = DEFAULT_COLOR_SCHEME,
@@ -331,8 +331,8 @@ export const AstralBeamChat = forwardRef<AstralBeamChatRef, AstralBeamChatProps>
       const handle = mountAstralBeamChat(targetRef.current, {
         ...liveRef.current,
         agentId,
-        chatEndpoint,
-        authEndpoint,
+        apiUrl,
+        authTokenUrl,
       })
       handleRef.current = handle
       return () => {

--- a/sdk/src/widget/chat-widget.tsx
+++ b/sdk/src/widget/chat-widget.tsx
@@ -20,7 +20,7 @@ import {
   readAttachmentData,
   resolveAttachmentOptions,
 } from "./lib/attachments.ts"
-import { DEFAULT_AUTH_ENDPOINT, DEFAULT_ENDPOINT, DEFAULT_TITLE } from "../lib/constants.ts"
+import { chatApiUrls, DEFAULT_AUTH_TOKEN_URL, DEFAULT_TITLE } from "../lib/constants.ts"
 import type { MountAstralBeamChatOptions, WidgetDefinition } from "../lib/types.ts"
 import { createDebugLogger } from "../lib/debug.ts"
 import { ASK_QUESTIONNAIRE_TOOL, SANDBOX_STATUS_EVENT } from "../core/protocol.ts"
@@ -61,7 +61,7 @@ export function ChatWidget(
     status: "loading",
   })
   const [authentication] = useState<ChatAuthenticationOptions>(() => ({
-    authEndpoint: options.authEndpoint ?? DEFAULT_AUTH_ENDPOINT,
+    authTokenUrl: options.authTokenUrl ?? DEFAULT_AUTH_TOKEN_URL,
     session: {
       cached: undefined,
       refreshPromise: undefined,
@@ -102,11 +102,11 @@ export function ChatWidget(
     })
   }, [debug, toolNames, widgets])
 
-  // Fixed for the mount, which is why `chatEndpoint` is not part of an update: useChat reads the
+  // Fixed for the mount, which is why `apiUrl` is not part of an update: useChat reads the
   // connection only when it constructs its client, so a new one would cost the transcript.
   const [connection] = useState(() =>
     fetchServerSentEvents(
-      options.chatEndpoint ?? DEFAULT_ENDPOINT,
+      chatApiUrls(options.apiUrl).chat,
       async () => ({
         headers: { authorization: `Bearer ${await getValidChatToken(authentication)}` },
         fetchClient: (input, init) => fetchAuthenticatedChat({ ...authentication, input, init }),
@@ -153,8 +153,7 @@ export function ChatWidget(
   const [grantedAttachments, setGrantedAttachments] = useState(true)
   useEffect(() => {
     let cancelled = false
-    const endpoint = (options.chatEndpoint ?? DEFAULT_ENDPOINT).replace(/\/+$/, "")
-    const url = new URL(`${endpoint}/config`, globalThis.location.href)
+    const url = new URL(chatApiUrls(options.apiUrl).config, globalThis.location.href)
     if (options.agentId) url.searchParams.set("agentId", options.agentId)
     void (async () => {
       try {
@@ -173,13 +172,10 @@ export function ChatWidget(
     return () => {
       cancelled = true
     }
-    // The endpoint and agent are fixed at mount, so this runs once per mounted chat.
-  }, [authentication, debug, options.agentId, options.chatEndpoint])
+    // The API base and agent are fixed at mount, so this runs once per mounted chat.
+  }, [authentication, debug, options.agentId, options.apiUrl])
   // Artifact downloads live beside the chat endpoint; tickets in tool outputs authorize them.
-  const filesEndpoint = useMemo(
-    () => `${(options.chatEndpoint ?? DEFAULT_ENDPOINT).replace(/\/+$/, "")}/files`,
-    [options.chatEndpoint],
-  )
+  const filesEndpoint = useMemo(() => chatApiUrls(options.apiUrl).files, [options.apiUrl])
   const sandboxActivity = useMemo(() => collectSandboxActivity(messages), [messages])
   const sandboxHasWork = sandboxActivity.files.length > 0 || sandboxActivity.commands.length > 0
   useEffect(() => {

--- a/webapp/src/routes/docs/-content/sdk/authentication.md
+++ b/webapp/src/routes/docs/-content/sdk/authentication.md
@@ -4,7 +4,7 @@ The widget will not chat until it has a token, and it never sees your API key. Y
 
 ## The token endpoint
 
-`/api/astralbeam/token` by default; change it with the `authEndpoint` option. `createAstralBeamTokenRoute` builds the whole fetch-standard handler: the method check, the unconfigured-key 503, the unauthenticated 401, and the `no-store` header.
+`/api/astralbeam/token` by default; change it with the `authTokenUrl` option. `createAstralBeamTokenRoute` builds the whole fetch-standard handler: the method check, the unconfigured-key 503, the unauthenticated 401, and the `no-store` header.
 
 ```ts
 import { createAstralBeamTokenRoute } from "@astralbeam/sdk/server"

--- a/webapp/src/routes/docs/-content/sdk/configuration.md
+++ b/webapp/src/routes/docs/-content/sdk/configuration.md
@@ -6,13 +6,14 @@ Every option below is also a prop on `<AstralBeamChat>`. On the vanilla handle, 
 
 These select the agent and build the transport, so changing them requires a fresh mount.
 
-| Option         | Default                              | Meaning                                              |
-| -------------- | ------------------------------------ | ---------------------------------------------------- |
-| `agentId`      | organization's default agent         | `agt_<organization>_<agent>` from the dashboard      |
-| `chatEndpoint` | `https://app.astralbeam.ai/api/chat` | The AstralBeam chat endpoint the widget streams from |
-| `authEndpoint` | `/api/astralbeam/token`              | Your app's token endpoint                            |
+| Option         | Default                         | Meaning                                                         |
+| -------------- | ------------------------------- | --------------------------------------------------------------- |
+| `agentId`      | organization's default agent    | `agt_<organization>_<agent>` from the dashboard                 |
+| `apiUrl`       | `https://app.astralbeam.ai/api` | Base URL of the AstralBeam API; the widget streams from `/chat` |
+| `authTokenUrl` | `/api/astralbeam/token`         | Your app's token endpoint                                       |
 
-- Self-hosted deployments must set `chatEndpoint` to their own origin; the default points at the hosted cloud, and chat tokens are bearer credentials that should only reach the deployment that issued the API key.
+- Self-hosted deployments must set `apiUrl` to their own origin; the default points at the hosted cloud, and chat tokens are bearer credentials that should only reach the deployment that issued the API key.
+- `apiUrl` is a base, not a route: the widget appends `/chat` for the stream and its subroutes for the agent handshake and artifact downloads.
 
 ## Updatable
 

--- a/webapp/src/routes/docs/-content/sdk/getting-started.md
+++ b/webapp/src/routes/docs/-content/sdk/getting-started.md
@@ -24,7 +24,7 @@ export function Sidebar() {
 
 - `react` and `react-dom` are optional peer dependencies; other entry points never load them.
 - Prop changes apply in place; the transcript and session survive them.
-- `agentId`, `chatEndpoint`, and `authEndpoint` are fixed at mount.
+- `agentId`, `apiUrl`, and `authTokenUrl` are fixed at mount.
 
 ## Mount anywhere else
 

--- a/webapp/src/routes/docs/-content/sdk/security.md
+++ b/webapp/src/routes/docs/-content/sdk/security.md
@@ -13,7 +13,7 @@ One principle everywhere: the dashboard grants, the chat endpoint enforces, and 
 
 - Your server mints short-lived chat tokens (60–600 s) from the API key; the browser never sees the key.
 - Tokens are bearer credentials: they stay in memory, ride in an `Authorization` header (no cookies, no CSRF surface), and must only ever reach the deployment that issued the API key.
-- Self-hosted deployments must set `chatEndpoint` explicitly; the default points at the hosted cloud.
+- Self-hosted deployments must set `apiUrl` explicitly; the default points at the hosted cloud.
 
 ## Sandbox artifacts
 


### PR DESCRIPTION
- Replace the SDK's `chatEndpoint` option with `apiUrl`, the base URL of the AstralBeam API, defaulting to `https://app.astralbeam.ai/api`; the widget and headless core derive `/chat`, `/chat/config`, and `/chat/files` from it through the new `chatApiUrls` helper in `sdk/src/lib/constants.ts`.
  - Future AstralBeam APIs become paths under one base instead of new endpoint options; recorded as a convention in `sdk/AGENTS.md`.
  - Server routes are unchanged: the derived URLs are byte-identical to what the SDK requested before.
- Rename the host application's token option `authEndpoint` to `authTokenUrl` (and the internal `ChatAuthenticationOptions` field with it), so the AstralBeam base and the host's own endpoint read as a matched pair.
- Both remain fixed at mount: `handle.update` rejects `agentId`, `apiUrl`, and `authTokenUrl`, and `AstralBeamChatUpdate` omits them.
- Bump `@astralbeam/sdk` to `0.2.0`. Breaking rename with no compatibility shim, by request.
- Update the consumers and guides in this repo: `examples/todos` (`ASTRALBEAM_API_URL` pointing at `http://localhost:4500/api`), the SDK `README.md`, the root `README.md`, and the `/docs/sdk` pages for configuration, getting started, authentication, and security.
- Add `chatApiUrls` coverage for the hosted default, a self-hosted base with trailing slashes, and a relative same-origin base.
- `sdk/redesign.plan.md` keeps its historical Phase 1 wording; nanoknow and bmd-astralbeam-demo migrate separately once `0.2.0` is published.
