### PR TITLE
Prevent blank mobile landing-page loads

### DIFF
--- a/www/scripts/verify-build.test.ts
+++ b/www/scripts/verify-build.test.ts
@@ -93,6 +93,22 @@ describe("production website build", () => {
     expect(javascript).not.toContain("node:fs")
   })
 
+  test("keeps reveal content visible without client JavaScript", async () => {
+    const assetDirectory = new URL("_astro/", distUrl)
+    const assets = await readdir(assetDirectory)
+    const stylesheets = await Promise.all(
+      assets
+        .filter((asset) => asset.endsWith(".css"))
+        .map((asset) => readFile(new URL(asset, assetDirectory), "utf8")),
+    )
+    const css = stylesheets.join("\n")
+    const defaultRevealRule = css.match(/\.reveal\{([^}]*)\}/u)?.[1]
+
+    expect(defaultRevealRule).toBeDefined()
+    expect(defaultRevealRule).not.toContain("opacity:0")
+    expect(css).toMatch(/\.reveal\.reveal-pending\{[^}]*opacity:0/u)
+  })
+
   test("keeps the not-found page out of discovery", async () => {
     const html = await readText("404.html")
 

--- a/www/src/scripts/main.ts
+++ b/www/src/scripts/main.ts
@@ -172,25 +172,43 @@ function initReveals() {
   }
 
   const scrambled = new WeakSet<HTMLElement>()
+  function reveal(el: HTMLElement) {
+    el.classList.remove("reveal-pending")
+    el.classList.add("in-view")
+    if (el.classList.contains("scramble") && !scrambled.has(el)) {
+      scrambled.add(el)
+      const delay = parseFloat(getComputedStyle(el).getPropertyValue("--reveal-delay")) || 0
+      setTimeout(() => scramble(el), delay * 1000)
+    }
+  }
+
   const io = new IntersectionObserver(
     (entries) => {
       for (const entry of entries) {
         if (!entry.isIntersecting) continue
         const el = entry.target
         if (!(el instanceof HTMLElement)) continue
-        el.classList.add("in-view")
-        if (el.classList.contains("scramble") && !scrambled.has(el)) {
-          scrambled.add(el)
-          const delay = parseFloat(getComputedStyle(el).getPropertyValue("--reveal-delay")) || 0
-          setTimeout(() => scramble(el), delay * 1000)
-        }
+        reveal(el)
         io.unobserve(el)
       }
     },
     { threshold: 0.25, rootMargin: "0px 0px -8% 0px" },
   )
 
-  revealEls.forEach((el) => io.observe(el))
+  const initialRootBottom = window.innerHeight * 0.92
+  revealEls.forEach((el) => {
+    const rect = el.getBoundingClientRect()
+    const visibleHeight = Math.min(rect.bottom, initialRootBottom) - Math.max(rect.top, 0)
+    if (visibleHeight >= rect.height * 0.25) {
+      reveal(el)
+      return
+    }
+
+    // Keep content visible unless observation was installed successfully. This
+    // makes the animation a progressive enhancement instead of a JS dependency.
+    io.observe(el)
+    el.classList.add("reveal-pending")
+  })
 }
 
 /* ============ terminal typing ============ */
@@ -527,6 +545,6 @@ function initAgentDemo(codeReady: Promise<void>) {
   io.observe(panel)
 }
 
-initStarfield()
 initReveals()
+initStarfield()
 initAgentDemo(initTerminal())

--- a/www/src/styles/global.css
+++ b/www/src/styles/global.css
@@ -397,16 +397,16 @@ a[href] {
 /* ---------- reveal / scramble ---------- */
 
 .reveal {
-  opacity: 0;
-  transform: translateY(26px);
+  opacity: 1;
+  transform: none;
   transition:
     opacity 0.7s cubic-bezier(0.16, 1, 0.3, 1) var(--reveal-delay, 0s),
     transform 0.7s cubic-bezier(0.16, 1, 0.3, 1) var(--reveal-delay, 0s);
 }
 
-.reveal.in-view {
-  opacity: 1;
-  transform: none;
+.reveal.reveal-pending {
+  opacity: 0;
+  transform: translateY(26px);
 }
 
 /* ---------- hero ---------- */
@@ -1491,7 +1491,8 @@ main {
     scroll-behavior: auto;
   }
 
-  .reveal {
+  .reveal,
+  .reveal.reveal-pending {
     opacity: 1;
     transform: none;
     transition: none;


### PR DESCRIPTION
- Make landing-page scroll reveals a progressive enhancement so content remains visible if client startup or initial observer delivery fails.
- Reveal above-fold elements synchronously and initialize them before the decorative starfield while preserving below-fold animation and reduced-motion behavior.
- Add production-build regression coverage for reveal visibility without client JavaScript.
