### PR TITLE
Wait for the stylesheet before starting landing-page scripts

### DIFF
--- a/www/scripts/verify-build.test.ts
+++ b/www/scripts/verify-build.test.ts
@@ -93,22 +93,6 @@ describe("production website build", () => {
     expect(javascript).not.toContain("node:fs")
   })
 
-  test("keeps reveal content visible without client JavaScript", async () => {
-    const assetDirectory = new URL("_astro/", distUrl)
-    const assets = await readdir(assetDirectory)
-    const stylesheets = await Promise.all(
-      assets
-        .filter((asset) => asset.endsWith(".css"))
-        .map((asset) => readFile(new URL(asset, assetDirectory), "utf8")),
-    )
-    const css = stylesheets.join("\n")
-    const defaultRevealRule = css.match(/\.reveal\{([^}]*)\}/u)?.[1]
-
-    expect(defaultRevealRule).toBeDefined()
-    expect(defaultRevealRule).not.toContain("opacity:0")
-    expect(css).toMatch(/\.reveal\.reveal-pending\{[^}]*opacity:0/u)
-  })
-
   test("keeps the not-found page out of discovery", async () => {
     const html = await readText("404.html")
 

--- a/www/src/scripts/main.ts
+++ b/www/src/scripts/main.ts
@@ -172,43 +172,25 @@ function initReveals() {
   }
 
   const scrambled = new WeakSet<HTMLElement>()
-  function reveal(el: HTMLElement) {
-    el.classList.remove("reveal-pending")
-    el.classList.add("in-view")
-    if (el.classList.contains("scramble") && !scrambled.has(el)) {
-      scrambled.add(el)
-      const delay = parseFloat(getComputedStyle(el).getPropertyValue("--reveal-delay")) || 0
-      setTimeout(() => scramble(el), delay * 1000)
-    }
-  }
-
   const io = new IntersectionObserver(
     (entries) => {
       for (const entry of entries) {
         if (!entry.isIntersecting) continue
         const el = entry.target
         if (!(el instanceof HTMLElement)) continue
-        reveal(el)
+        el.classList.add("in-view")
+        if (el.classList.contains("scramble") && !scrambled.has(el)) {
+          scrambled.add(el)
+          const delay = parseFloat(getComputedStyle(el).getPropertyValue("--reveal-delay")) || 0
+          setTimeout(() => scramble(el), delay * 1000)
+        }
         io.unobserve(el)
       }
     },
     { threshold: 0.25, rootMargin: "0px 0px -8% 0px" },
   )
 
-  const initialRootBottom = window.innerHeight * 0.92
-  revealEls.forEach((el) => {
-    const rect = el.getBoundingClientRect()
-    const visibleHeight = Math.min(rect.bottom, initialRootBottom) - Math.max(rect.top, 0)
-    if (visibleHeight >= rect.height * 0.25) {
-      reveal(el)
-      return
-    }
-
-    // Keep content visible unless observation was installed successfully. This
-    // makes the animation a progressive enhancement instead of a JS dependency.
-    io.observe(el)
-    el.classList.add("reveal-pending")
-  })
+  revealEls.forEach((el) => io.observe(el))
 }
 
 /* ============ terminal typing ============ */
@@ -545,6 +527,6 @@ function initAgentDemo(codeReady: Promise<void>) {
   io.observe(panel)
 }
 
-initReveals()
 initStarfield()
+initReveals()
 initAgentDemo(initTerminal())

--- a/www/src/scripts/main.ts
+++ b/www/src/scripts/main.ts
@@ -527,6 +527,19 @@ function initAgentDemo(codeReady: Promise<void>) {
   io.observe(panel)
 }
 
-initStarfield()
-initReveals()
-initAgentDemo(initTerminal())
+function init() {
+  initStarfield()
+  initReveals()
+  initAgentDemo(initTerminal())
+}
+
+// WebKit runs module scripts before pending stylesheets finish loading, unlike Chromium and
+// Firefox, so on a cold Safari load the brand colors read from computed styles can still be
+// empty. That throws in initStarfield() before the reveals are wired up and leaves the page
+// blank. https://github.com/whatwg/html/issues/3890
+const stylesheet = document.querySelector<HTMLLinkElement>('link[rel="stylesheet"]')
+if (stylesheet && !stylesheet.sheet) {
+  stylesheet.addEventListener("load", init, { once: true })
+} else {
+  init()
+}

--- a/www/src/styles/global.css
+++ b/www/src/styles/global.css
@@ -397,16 +397,16 @@ a[href] {
 /* ---------- reveal / scramble ---------- */
 
 .reveal {
-  opacity: 1;
-  transform: none;
+  opacity: 0;
+  transform: translateY(26px);
   transition:
     opacity 0.7s cubic-bezier(0.16, 1, 0.3, 1) var(--reveal-delay, 0s),
     transform 0.7s cubic-bezier(0.16, 1, 0.3, 1) var(--reveal-delay, 0s);
 }
 
-.reveal.reveal-pending {
-  opacity: 0;
-  transform: translateY(26px);
+.reveal.in-view {
+  opacity: 1;
+  transform: none;
 }
 
 /* ---------- hero ---------- */
@@ -1491,8 +1491,7 @@ main {
     scroll-behavior: auto;
   }
 
-  .reveal,
-  .reveal.reveal-pending {
+  .reveal {
     opacity: 1;
     transform: none;
     transition: none;


### PR DESCRIPTION
- Revert the `www` changes from #97 so the landing page keeps its original reveal CSS and script order, then fix the actual cause of the blank mobile loads with a single change in `www/src/scripts/main.ts`.
- Root cause: WebKit executes module scripts before pending stylesheets finish loading, unlike Chromium and Firefox ([whatwg/html#3890](https://github.com/whatwg/html/issues/3890)). On a cold Safari load the brand colors read from computed styles are still empty, `initStarfield()` throws `Invalid --chart-5 brand color`, and `initReveals()` never runs, leaving every `.reveal` element at opacity 0. Cached loads win the race, which is why it looked intermittent.
- Fix: start the page scripts only once the stylesheet has loaded, by deferring to the `<link rel="stylesheet">` `load` event when its `sheet` is still null.
- Reproduced and verified with Playwright WebKit and Chromium using an iPhone 15 profile against the production build served with the stylesheet delayed by 1.5s: before the fix WebKit revealed 0 of 32 elements and logged the error; after the fix both engines reveal the above-fold elements with no errors, with or without the delay. Screenshots live on the deletable `screenshots/mobile-blank-landing` branch.
  - Before (WebKit, CSS delayed): ![before](https://raw.githubusercontent.com/astralbeamai/astralbeam/screenshots/mobile-blank-landing/before-webkit-css-delayed.png)
  - After (WebKit, CSS delayed): ![after](https://raw.githubusercontent.com/astralbeamai/astralbeam/screenshots/mobile-blank-landing/after-webkit-css-delayed.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
