### PR TITLE
Authenticate the token request with authTokenHeaders

### DIFF
--- a/sdk/README.md
+++ b/sdk/README.md
@@ -64,16 +64,18 @@ export const POST = createAstralBeamTokenRoute({
 - Tokens use the API key's organization slug as issuer and the platform audience `astralbeam`; AstralBeam does not require or interpret `sub`.
 - Tokens are signed, not encrypted: never put a secret in them.
 - Lifetimes are 60–600 seconds; the SDK renews in memory before expiry.
+- The widget POSTs `authTokenUrl` with the page's cookies; pass `getAuthToken` to fetch the token yourself when your backend is on another origin behind header auth.
 
 ## Options
 
-Every option is also a prop on `<AstralBeamChat>`; `handle.update(options)` applies any subset in place. `agentId`, `apiUrl`, and `authTokenUrl` are fixed at mount. Details in [Configuration](https://app.astralbeam.ai/docs/sdk/configuration).
+Every option is also a prop on `<AstralBeamChat>`; `handle.update(options)` applies any subset in place. `agentId`, `apiUrl`, `authTokenUrl`, and `getAuthToken` are fixed at mount. Details in [Configuration](https://app.astralbeam.ai/docs/sdk/configuration).
 
 | Option                               | Default                         | Meaning                                                         |
 | ------------------------------------ | ------------------------------- | --------------------------------------------------------------- |
 | `agentId`                            | organization's default          | `agt_<organization>_<agent>` from the dashboard                 |
 | `apiUrl`                             | `https://app.astralbeam.ai/api` | Base URL of the AstralBeam API; the widget calls `/chat` there  |
 | `authTokenUrl`                       | `/api/astralbeam/token`         | Your token endpoint                                             |
+| `getAuthToken`                       | none                            | Mint the token in host code, for a backend on another origin    |
 | `title`, `showHeader`                | `"AstralBeam"`, `true`          | Header text, and whether the header and reset button show       |
 | `emptyTitle`, `emptyDescription`     | generic copy                    | Headline and subtitle of the empty transcript                   |
 | `colorScheme`, `theme`               | `"system"`, built-in palette    | Light/dark/system, and shadcn token overrides                   |

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -64,18 +64,18 @@ export const POST = createAstralBeamTokenRoute({
 - Tokens use the API key's organization slug as issuer and the platform audience `astralbeam`; AstralBeam does not require or interpret `sub`.
 - Tokens are signed, not encrypted: never put a secret in them.
 - Lifetimes are 60–600 seconds; the SDK renews in memory before expiry.
-- The widget POSTs `authTokenUrl` with the page's cookies; pass `getAuthToken` to fetch the token yourself when your backend is on another origin behind header auth.
+- The widget POSTs `authTokenUrl` with the page's cookies; pass `authTokenHeaders` (an object, or a function for a rotating credential) when your backend is on another origin behind header auth.
 
 ## Options
 
-Every option is also a prop on `<AstralBeamChat>`; `handle.update(options)` applies any subset in place. `agentId`, `apiUrl`, `authTokenUrl`, and `getAuthToken` are fixed at mount. Details in [Configuration](https://app.astralbeam.ai/docs/sdk/configuration).
+Every option is also a prop on `<AstralBeamChat>`; `handle.update(options)` applies any subset in place. `agentId`, `apiUrl`, `authTokenUrl`, and `authTokenHeaders` are fixed at mount. Details in [Configuration](https://app.astralbeam.ai/docs/sdk/configuration).
 
 | Option                               | Default                         | Meaning                                                         |
 | ------------------------------------ | ------------------------------- | --------------------------------------------------------------- |
 | `agentId`                            | organization's default          | `agt_<organization>_<agent>` from the dashboard                 |
 | `apiUrl`                             | `https://app.astralbeam.ai/api` | Base URL of the AstralBeam API; the widget calls `/chat` there  |
 | `authTokenUrl`                       | `/api/astralbeam/token`         | Your token endpoint                                             |
-| `getAuthToken`                       | none                            | Mint the token in host code, for a backend on another origin    |
+| `authTokenHeaders`                   | none                            | Extra token-request headers, for a backend on another origin    |
 | `title`, `showHeader`                | `"AstralBeam"`, `true`          | Header text, and whether the header and reset button show       |
 | `emptyTitle`, `emptyDescription`     | generic copy                    | Headline and subtitle of the empty transcript                   |
 | `colorScheme`, `theme`               | `"system"`, built-in palette    | Light/dark/system, and shadcn token overrides                   |

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@astralbeam/sdk",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Frontend SDK for AstralBeam: drop-in agent UI, chat streaming, and server helpers",
   "license": "MIT",
   "type": "module",

--- a/sdk/src/client/index.ts
+++ b/sdk/src/client/index.ts
@@ -102,9 +102,9 @@ export function mountAstralBeamChat(
     update: (next) => {
       if (
         Object.hasOwn(next, "agentId") || Object.hasOwn(next, "apiUrl") ||
-        Object.hasOwn(next, "authTokenUrl")
+        Object.hasOwn(next, "authTokenUrl") || Object.hasOwn(next, "getAuthToken")
       ) {
-        throw new Error("agentId, apiUrl, and authTokenUrl are fixed at mount")
+        throw new Error("agentId, apiUrl, authTokenUrl, and getAuthToken are fixed at mount")
       }
       // A fresh object rather than a mutation, so the widget's memoized derivations compare the
       // new option values by identity instead of seeing the same object twice.

--- a/sdk/src/client/index.ts
+++ b/sdk/src/client/index.ts
@@ -13,6 +13,7 @@ import type { ChatHandle } from "../widget/index.tsx"
 
 export type {
   AstralBeamChatAttachmentOptions,
+  AstralBeamChatAuthTokenHeaders,
   AstralBeamChatColorScheme,
   AstralBeamChatHandle,
   AstralBeamChatSlotRenderer,
@@ -102,9 +103,9 @@ export function mountAstralBeamChat(
     update: (next) => {
       if (
         Object.hasOwn(next, "agentId") || Object.hasOwn(next, "apiUrl") ||
-        Object.hasOwn(next, "authTokenUrl") || Object.hasOwn(next, "getAuthToken")
+        Object.hasOwn(next, "authTokenUrl") || Object.hasOwn(next, "authTokenHeaders")
       ) {
-        throw new Error("agentId, apiUrl, authTokenUrl, and getAuthToken are fixed at mount")
+        throw new Error("agentId, apiUrl, authTokenUrl, and authTokenHeaders are fixed at mount")
       }
       // A fresh object rather than a mutation, so the widget's memoized derivations compare the
       // new option values by identity instead of seeing the same object twice.

--- a/sdk/src/core/auth.test.ts
+++ b/sdk/src/core/auth.test.ts
@@ -3,7 +3,6 @@ import { expect, test } from "vitest"
 import {
   type ChatAuthenticationOptions,
   type ChatAuthenticationState,
-  disposeChatAuthentication,
   fetchAuthenticatedChat,
   getValidChatToken,
   initializeChatAuthentication,
@@ -27,7 +26,7 @@ test("chat authentication loads once and caches a token away from expiry", async
   }) as typeof fetch
   const authentication = {
     authTokenUrl: "/auth",
-    getAuthToken: undefined,
+    authTokenHeaders: undefined,
     session: {
       cached: undefined,
       refreshPromise: undefined,
@@ -57,7 +56,7 @@ test("chat authentication deduplicates concurrent refreshes", async () => {
   }) as typeof fetch
   const authentication = {
     authTokenUrl: "/auth",
-    getAuthToken: undefined,
+    authTokenHeaders: undefined,
     session: {
       cached: undefined,
       refreshPromise: undefined,
@@ -82,7 +81,7 @@ test("chat authentication refreshes tokens near expiry", async () => {
     (() => Promise.resolve(Response.json({ token: tokens[requestCount++] }))) as typeof fetch
   const authentication = {
     authTokenUrl: "/auth",
-    getAuthToken: undefined,
+    authTokenHeaders: undefined,
     session: {
       cached: undefined,
       refreshPromise: undefined,
@@ -120,7 +119,7 @@ test("chat authentication refreshes and retries a rejected chat request once", a
   }) as typeof fetch
   const authentication = {
     authTokenUrl: "/auth",
-    getAuthToken: undefined,
+    authTokenHeaders: undefined,
     session: {
       cached: undefined,
       refreshPromise: undefined,
@@ -160,7 +159,7 @@ test("a stale rejected request reuses a token another request already refreshed"
   }) as typeof fetch
   const authentication = {
     authTokenUrl: "/auth",
-    getAuthToken: undefined,
+    authTokenHeaders: undefined,
     session: {
       cached: undefined,
       refreshPromise: undefined,
@@ -187,7 +186,7 @@ test("chat authentication fails closed for malformed endpoint responses", async 
   const fetchClient = (() => Promise.resolve(Response.json({ token: "not-a-jwt" }))) as typeof fetch
   const authentication = {
     authTokenUrl: "/auth",
-    getAuthToken: undefined,
+    authTokenHeaders: undefined,
     session: {
       cached: undefined,
       refreshPromise: undefined,
@@ -202,75 +201,82 @@ test("chat authentication fails closed for malformed endpoint responses", async 
   expect(lastState?.status).toBe("error")
 })
 
-test("getAuthToken mints the token instead of the widget calling the endpoint", async () => {
+test("authTokenHeaders are sent on the token request and resolved per request", async () => {
   const tokens = [jwt(Date.now() + 30_000, "short"), jwt(Date.now() + 300_000, "rotated")]
-  let calls = 0
-  const states: ChatAuthenticationState[] = []
-  const fetchClient = (() => {
-    throw new Error("the token endpoint must not be called when getAuthToken is set")
+  const sent: Array<string | null> = []
+  let credential = "first"
+  const fetchClient = ((_input: RequestInfo | URL, init?: RequestInit) => {
+    const headers = new Headers(init?.headers)
+    sent.push(headers.get("authorization"))
+    expect(headers.get("accept")).toBe("application/json")
+    return Promise.resolve(Response.json({ token: tokens[sent.length - 1] }))
   }) as typeof fetch
   const authentication = {
     authTokenUrl: "/auth",
-    getAuthToken: () => tokens[calls++]!,
+    authTokenHeaders: () => ({ authorization: `Bearer ${credential}` }),
     session: {
       cached: undefined,
       refreshPromise: undefined,
       abortController: new AbortController(),
     },
-    onStateChange: (state: ChatAuthenticationState) => states.push(state),
+    onStateChange: () => undefined,
     fetchClient,
     debug: undefined,
   } satisfies ChatAuthenticationOptions
 
   await initializeChatAuthentication(authentication)
-  expect(states.map(({ status }) => status)).toEqual(["loading", "ready"])
-  // The first token sits inside the refresh skew, so the next read must ask the host again.
+  // The first token sits inside the refresh skew, so the next read refetches with the credential
+  // the host holds by then rather than the one captured at mount.
+  credential = "rotated"
   expect(await getValidChatToken(authentication)).toBe(tokens[1])
-  expect(calls).toBe(2)
+  expect(sent).toEqual(["Bearer first", "Bearer rotated"])
 })
 
-test("getAuthToken failures fail closed", async () => {
-  let lastState: ChatAuthenticationState | undefined
+test("static authTokenHeaders are sent as given", async () => {
+  const token = jwt(Date.now() + 300_000, "static")
+  let sent: Headers | undefined
+  const fetchClient = ((_input: RequestInfo | URL, init?: RequestInit) => {
+    sent = new Headers(init?.headers)
+    return Promise.resolve(Response.json({ token }))
+  }) as typeof fetch
   const authentication = {
     authTokenUrl: "/auth",
-    getAuthToken: () => Promise.reject(new Error("the host session expired")),
+    authTokenHeaders: { "x-tenant-key": "acme" },
+    session: {
+      cached: undefined,
+      refreshPromise: undefined,
+      abortController: new AbortController(),
+    },
+    onStateChange: () => undefined,
+    fetchClient,
+    debug: undefined,
+  } satisfies ChatAuthenticationOptions
+
+  await initializeChatAuthentication(authentication)
+  expect(sent?.get("x-tenant-key")).toBe("acme")
+})
+
+test("a failing authTokenHeaders callback fails closed without a request", async () => {
+  let lastState: ChatAuthenticationState | undefined
+  let requests = 0
+  const fetchClient = (() => {
+    requests += 1
+    return Promise.resolve(Response.json({ token: jwt(Date.now() + 300_000, "unreachable") }))
+  }) as typeof fetch
+  const authentication = {
+    authTokenUrl: "/auth",
+    authTokenHeaders: () => Promise.reject(new Error("the host session expired")),
     session: {
       cached: undefined,
       refreshPromise: undefined,
       abortController: new AbortController(),
     },
     onStateChange: (state: ChatAuthenticationState) => lastState = state,
-    fetchClient: globalThis.fetch.bind(globalThis),
+    fetchClient,
     debug: undefined,
   } satisfies ChatAuthenticationOptions
 
   await expect(initializeChatAuthentication(authentication)).rejects.toThrow(/host session expired/)
   expect(lastState?.status).toBe("error")
-})
-
-test("a token that arrives after disposal is dropped", async () => {
-  const states: ChatAuthenticationState[] = []
-  let release: (() => void) | undefined
-  const authentication = {
-    authTokenUrl: "/auth",
-    getAuthToken: async () => {
-      await new Promise<void>((resolve) => release = resolve)
-      return jwt(Date.now() + 300_000, "late")
-    },
-    session: {
-      cached: undefined,
-      refreshPromise: undefined,
-      abortController: new AbortController(),
-    },
-    onStateChange: (state: ChatAuthenticationState) => states.push(state),
-    fetchClient: globalThis.fetch.bind(globalThis),
-    debug: undefined,
-  } satisfies ChatAuthenticationOptions
-
-  const pending = getValidChatToken(authentication).catch(() => undefined)
-  disposeChatAuthentication(authentication)
-  release?.()
-  await pending
-  expect(states.map(({ status }) => status)).toEqual(["loading"])
-  expect(authentication.session.cached).toBeUndefined()
+  expect(requests).toBe(0)
 })

--- a/sdk/src/core/auth.test.ts
+++ b/sdk/src/core/auth.test.ts
@@ -3,6 +3,7 @@ import { expect, test } from "vitest"
 import {
   type ChatAuthenticationOptions,
   type ChatAuthenticationState,
+  disposeChatAuthentication,
   fetchAuthenticatedChat,
   getValidChatToken,
   initializeChatAuthentication,
@@ -26,6 +27,7 @@ test("chat authentication loads once and caches a token away from expiry", async
   }) as typeof fetch
   const authentication = {
     authTokenUrl: "/auth",
+    getAuthToken: undefined,
     session: {
       cached: undefined,
       refreshPromise: undefined,
@@ -55,6 +57,7 @@ test("chat authentication deduplicates concurrent refreshes", async () => {
   }) as typeof fetch
   const authentication = {
     authTokenUrl: "/auth",
+    getAuthToken: undefined,
     session: {
       cached: undefined,
       refreshPromise: undefined,
@@ -79,6 +82,7 @@ test("chat authentication refreshes tokens near expiry", async () => {
     (() => Promise.resolve(Response.json({ token: tokens[requestCount++] }))) as typeof fetch
   const authentication = {
     authTokenUrl: "/auth",
+    getAuthToken: undefined,
     session: {
       cached: undefined,
       refreshPromise: undefined,
@@ -116,6 +120,7 @@ test("chat authentication refreshes and retries a rejected chat request once", a
   }) as typeof fetch
   const authentication = {
     authTokenUrl: "/auth",
+    getAuthToken: undefined,
     session: {
       cached: undefined,
       refreshPromise: undefined,
@@ -155,6 +160,7 @@ test("a stale rejected request reuses a token another request already refreshed"
   }) as typeof fetch
   const authentication = {
     authTokenUrl: "/auth",
+    getAuthToken: undefined,
     session: {
       cached: undefined,
       refreshPromise: undefined,
@@ -181,6 +187,7 @@ test("chat authentication fails closed for malformed endpoint responses", async 
   const fetchClient = (() => Promise.resolve(Response.json({ token: "not-a-jwt" }))) as typeof fetch
   const authentication = {
     authTokenUrl: "/auth",
+    getAuthToken: undefined,
     session: {
       cached: undefined,
       refreshPromise: undefined,
@@ -193,4 +200,77 @@ test("chat authentication fails closed for malformed endpoint responses", async 
 
   await expect(initializeChatAuthentication(authentication)).rejects.toThrow(/not a JWT/)
   expect(lastState?.status).toBe("error")
+})
+
+test("getAuthToken mints the token instead of the widget calling the endpoint", async () => {
+  const tokens = [jwt(Date.now() + 30_000, "short"), jwt(Date.now() + 300_000, "rotated")]
+  let calls = 0
+  const states: ChatAuthenticationState[] = []
+  const fetchClient = (() => {
+    throw new Error("the token endpoint must not be called when getAuthToken is set")
+  }) as typeof fetch
+  const authentication = {
+    authTokenUrl: "/auth",
+    getAuthToken: () => tokens[calls++]!,
+    session: {
+      cached: undefined,
+      refreshPromise: undefined,
+      abortController: new AbortController(),
+    },
+    onStateChange: (state: ChatAuthenticationState) => states.push(state),
+    fetchClient,
+    debug: undefined,
+  } satisfies ChatAuthenticationOptions
+
+  await initializeChatAuthentication(authentication)
+  expect(states.map(({ status }) => status)).toEqual(["loading", "ready"])
+  // The first token sits inside the refresh skew, so the next read must ask the host again.
+  expect(await getValidChatToken(authentication)).toBe(tokens[1])
+  expect(calls).toBe(2)
+})
+
+test("getAuthToken failures fail closed", async () => {
+  let lastState: ChatAuthenticationState | undefined
+  const authentication = {
+    authTokenUrl: "/auth",
+    getAuthToken: () => Promise.reject(new Error("the host session expired")),
+    session: {
+      cached: undefined,
+      refreshPromise: undefined,
+      abortController: new AbortController(),
+    },
+    onStateChange: (state: ChatAuthenticationState) => lastState = state,
+    fetchClient: globalThis.fetch.bind(globalThis),
+    debug: undefined,
+  } satisfies ChatAuthenticationOptions
+
+  await expect(initializeChatAuthentication(authentication)).rejects.toThrow(/host session expired/)
+  expect(lastState?.status).toBe("error")
+})
+
+test("a token that arrives after disposal is dropped", async () => {
+  const states: ChatAuthenticationState[] = []
+  let release: (() => void) | undefined
+  const authentication = {
+    authTokenUrl: "/auth",
+    getAuthToken: async () => {
+      await new Promise<void>((resolve) => release = resolve)
+      return jwt(Date.now() + 300_000, "late")
+    },
+    session: {
+      cached: undefined,
+      refreshPromise: undefined,
+      abortController: new AbortController(),
+    },
+    onStateChange: (state: ChatAuthenticationState) => states.push(state),
+    fetchClient: globalThis.fetch.bind(globalThis),
+    debug: undefined,
+  } satisfies ChatAuthenticationOptions
+
+  const pending = getValidChatToken(authentication).catch(() => undefined)
+  disposeChatAuthentication(authentication)
+  release?.()
+  await pending
+  expect(states.map(({ status }) => status)).toEqual(["loading"])
+  expect(authentication.session.cached).toBeUndefined()
 })

--- a/sdk/src/core/auth.ts
+++ b/sdk/src/core/auth.ts
@@ -21,6 +21,7 @@ interface ChatAuthenticationSession {
 
 export interface ChatAuthenticationOptions {
   authTokenUrl: string
+  getAuthToken: (() => string | Promise<string>) | undefined
   session: ChatAuthenticationSession
   onStateChange: (state: ChatAuthenticationState) => void
   fetchClient: typeof globalThis.fetch
@@ -60,26 +61,40 @@ function bearerToken(headers: Headers): string | undefined {
   return authorization?.startsWith("Bearer ") ? authorization.slice(7) : undefined
 }
 
+async function postChatToken(
+  authTokenUrl: string,
+  fetchClient: typeof globalThis.fetch,
+  signal: AbortSignal,
+): Promise<unknown> {
+  const response = await fetchClient(authTokenUrl, {
+    method: "POST",
+    headers: { accept: "application/json" },
+    credentials: "include",
+    cache: "no-store",
+    signal,
+  })
+  if (!response.ok) throw new Error(`Authentication endpoint returned HTTP ${response.status}`)
+  const body: unknown = await response.json()
+  return (body as { token?: unknown } | null)?.token
+}
+
 async function fetchChatToken(options: ChatAuthenticationOptions): Promise<string> {
-  const { authTokenUrl, session, onStateChange, fetchClient, debug } = options
+  const { authTokenUrl, getAuthToken, session, onStateChange, fetchClient, debug } = options
   const { signal } = session.abortController
+  const source = getAuthToken ? "getAuthToken" : "Authentication endpoint"
   try {
-    const response = await fetchClient(authTokenUrl, {
-      method: "POST",
-      headers: { accept: "application/json" },
-      credentials: "include",
-      cache: "no-store",
-      signal,
-    })
-    if (!response.ok) throw new Error(`Authentication endpoint returned HTTP ${response.status}`)
-    const body: unknown = await response.json()
-    const token = (body as { token?: unknown } | null)?.token
+    const token = getAuthToken
+      ? await getAuthToken()
+      : await postChatToken(authTokenUrl, fetchClient, signal)
+    // `getAuthToken` cannot observe the signal, so a token that arrives after disposal is dropped
+    // here rather than reported as a ready state on a session the host already tore down.
+    if (signal.aborted) throw new Error("Chat authentication was disposed")
     if (typeof token !== "string" || !token) {
-      throw new Error("Authentication endpoint did not return a token")
+      throw new Error(`${source} did not return a token`)
     }
     const expiresAt = tokenExpiry(token)
     if (expiresAt <= Date.now()) {
-      throw new Error("Authentication endpoint returned an expired token")
+      throw new Error(`${source} returned an expired token`)
     }
     session.cached = { value: token, expiresAt }
     onStateChange({ status: "ready" })

--- a/sdk/src/core/auth.ts
+++ b/sdk/src/core/auth.ts
@@ -1,4 +1,5 @@
 import type { DebugLogger } from "../lib/debug.ts"
+import type { AstralBeamChatAuthTokenHeaders } from "../lib/types.ts"
 
 const REFRESH_SKEW_MS = 60_000
 const MAX_TOKEN_LENGTH = 16_384
@@ -21,7 +22,7 @@ interface ChatAuthenticationSession {
 
 export interface ChatAuthenticationOptions {
   authTokenUrl: string
-  getAuthToken: (() => string | Promise<string>) | undefined
+  authTokenHeaders: AstralBeamChatAuthTokenHeaders | undefined
   session: ChatAuthenticationSession
   onStateChange: (state: ChatAuthenticationState) => void
   fetchClient: typeof globalThis.fetch
@@ -62,13 +63,22 @@ function bearerToken(headers: Headers): string | undefined {
 }
 
 async function postChatToken(
-  authTokenUrl: string,
-  fetchClient: typeof globalThis.fetch,
+  options: ChatAuthenticationOptions,
   signal: AbortSignal,
 ): Promise<unknown> {
+  const { authTokenUrl, authTokenHeaders, fetchClient } = options
+  const headers = new Headers({ accept: "application/json" })
+  // Resolved per request, so a rotating credential is never captured once, and only awaited when
+  // the host configured headers, so the default cookie request still starts in the caller's tick.
+  if (authTokenHeaders) {
+    const extra = typeof authTokenHeaders === "function"
+      ? await authTokenHeaders()
+      : authTokenHeaders
+    for (const [name, value] of Object.entries(extra)) headers.set(name, value)
+  }
   const response = await fetchClient(authTokenUrl, {
     method: "POST",
-    headers: { accept: "application/json" },
+    headers,
     credentials: "include",
     cache: "no-store",
     signal,
@@ -79,22 +89,16 @@ async function postChatToken(
 }
 
 async function fetchChatToken(options: ChatAuthenticationOptions): Promise<string> {
-  const { authTokenUrl, getAuthToken, session, onStateChange, fetchClient, debug } = options
+  const { session, onStateChange, debug } = options
   const { signal } = session.abortController
-  const source = getAuthToken ? "getAuthToken" : "Authentication endpoint"
   try {
-    const token = getAuthToken
-      ? await getAuthToken()
-      : await postChatToken(authTokenUrl, fetchClient, signal)
-    // `getAuthToken` cannot observe the signal, so a token that arrives after disposal is dropped
-    // here rather than reported as a ready state on a session the host already tore down.
-    if (signal.aborted) throw new Error("Chat authentication was disposed")
+    const token = await postChatToken(options, signal)
     if (typeof token !== "string" || !token) {
-      throw new Error(`${source} did not return a token`)
+      throw new Error("Authentication endpoint did not return a token")
     }
     const expiresAt = tokenExpiry(token)
     if (expiresAt <= Date.now()) {
-      throw new Error(`${source} returned an expired token`)
+      throw new Error("Authentication endpoint returned an expired token")
     }
     session.cached = { value: token, expiresAt }
     onStateChange({ status: "ready" })

--- a/sdk/src/core/session.ts
+++ b/sdk/src/core/session.ts
@@ -38,6 +38,12 @@ export interface AstralBeamChatCoreOptions {
   apiUrl?: string | undefined
   /** The application endpoint that mints short-lived chat JWTs. Default `/api/astralbeam/token`. */
   authTokenUrl?: string | undefined
+  /**
+   * Mints the chat JWT in host code instead of POSTing `authTokenUrl` with the page's cookies, for
+   * hosts whose backend sits on another origin behind bearer or custom-header auth. Called again
+   * whenever a token is needed, so it must mint a fresh one rather than return a memoized token.
+   */
+  getAuthToken?: (() => string | Promise<string>) | undefined
   /** Host tools the agent can call; `execute` runs wherever this session lives. */
   tools?: Record<string, ToolDefinition> | undefined
   /** Widgets declared to the agent; `onRenderWidget` is asked to draw them. */
@@ -104,6 +110,7 @@ export function createAstralBeamChat(options: AstralBeamChatCoreOptions): Astral
 
   const authentication: ChatAuthenticationOptions = {
     authTokenUrl: options.authTokenUrl ?? DEFAULT_AUTH_TOKEN_URL,
+    getAuthToken: options.getAuthToken,
     session: {
       cached: undefined,
       refreshPromise: undefined,

--- a/sdk/src/core/session.ts
+++ b/sdk/src/core/session.ts
@@ -7,7 +7,7 @@ import {
 } from "@tanstack/ai-client"
 import { chatApiUrls, DEFAULT_AUTH_TOKEN_URL } from "../lib/constants.ts"
 import { createDebugLogger } from "../lib/debug.ts"
-import type { ToolDefinition } from "../lib/types.ts"
+import type { AstralBeamChatAuthTokenHeaders, ToolDefinition } from "../lib/types.ts"
 import { buildAgentTools, type WidgetDeclaration } from "./agent-tools.ts"
 import {
   type ChatAuthenticationOptions,
@@ -39,11 +39,11 @@ export interface AstralBeamChatCoreOptions {
   /** The application endpoint that mints short-lived chat JWTs. Default `/api/astralbeam/token`. */
   authTokenUrl?: string | undefined
   /**
-   * Mints the chat JWT in host code instead of POSTing `authTokenUrl` with the page's cookies, for
-   * hosts whose backend sits on another origin behind bearer or custom-header auth. Called again
-   * whenever a token is needed, so it must mint a fresh one rather than return a memoized token.
+   * Extra headers for the token request, for a backend on another origin that authenticates with a
+   * bearer token or custom header instead of cookies. Resolved on every token request, so pass the
+   * function form for a credential that rotates.
    */
-  getAuthToken?: (() => string | Promise<string>) | undefined
+  authTokenHeaders?: AstralBeamChatAuthTokenHeaders | undefined
   /** Host tools the agent can call; `execute` runs wherever this session lives. */
   tools?: Record<string, ToolDefinition> | undefined
   /** Widgets declared to the agent; `onRenderWidget` is asked to draw them. */
@@ -110,7 +110,7 @@ export function createAstralBeamChat(options: AstralBeamChatCoreOptions): Astral
 
   const authentication: ChatAuthenticationOptions = {
     authTokenUrl: options.authTokenUrl ?? DEFAULT_AUTH_TOKEN_URL,
-    getAuthToken: options.getAuthToken,
+    authTokenHeaders: options.authTokenHeaders,
     session: {
       cached: undefined,
       refreshPromise: undefined,

--- a/sdk/src/lib/types.ts
+++ b/sdk/src/lib/types.ts
@@ -150,6 +150,13 @@ export interface MountAstralBeamChatOptions {
   apiUrl?: string | undefined
   /** Application endpoint that mints a short-lived chat JWT. Fixed at mount. Default `"/api/astralbeam/token"`. */
   authTokenUrl?: string | undefined
+  /**
+   * Mints the chat JWT in host code instead of letting the widget POST `authTokenUrl` with the
+   * page's cookies, for hosts whose backend sits on another origin behind bearer or custom-header
+   * auth. Called again whenever the widget needs a token (near expiry, or after one is rejected),
+   * so it must mint a fresh token rather than return a memoized one. Fixed at mount.
+   */
+  getAuthToken?: (() => string | Promise<string>) | undefined
   /** Host-defined tools the agent can call, executed in the host page, keyed by tool name. */
   tools?: Record<string, ToolDefinition> | undefined
   /** Host-defined widgets the agent can render inline in the conversation, keyed by identifier. */
@@ -183,7 +190,7 @@ export interface MountAstralBeamChatOptions {
  * changing any of them would mean a new client and a discarded transcript.
  */
 export type AstralBeamChatUpdate = Partial<
-  Omit<MountAstralBeamChatOptions, "agentId" | "apiUrl" | "authTokenUrl">
+  Omit<MountAstralBeamChatOptions, "agentId" | "apiUrl" | "authTokenUrl" | "getAuthToken">
 >
 
 export interface AstralBeamChatHandle {

--- a/sdk/src/lib/types.ts
+++ b/sdk/src/lib/types.ts
@@ -115,6 +115,14 @@ export type AstralBeamChatColorScheme = "light" | "dark" | "system"
 export type AstralBeamChatThemeVariables = Record<`--${string}`, string>
 
 /**
+ * Headers added to the token request: an object for a fixed credential, or a function for one the
+ * host must read or await per request, such as a rotating access token.
+ */
+export type AstralBeamChatAuthTokenHeaders =
+  | Record<string, string>
+  | (() => Record<string, string> | Promise<Record<string, string>>)
+
+/**
  * Custom values for the CSS variables the widget's shadcn theme exposes (`--background`,
  * `--primary`, `--radius`, and the `--font-sans`/`--font-heading`/`--font-mono` stacks, ...),
  * mirroring shadcn's `:root`/`.dark` split: `light` is the base applied in both color schemes,
@@ -151,12 +159,12 @@ export interface MountAstralBeamChatOptions {
   /** Application endpoint that mints a short-lived chat JWT. Fixed at mount. Default `"/api/astralbeam/token"`. */
   authTokenUrl?: string | undefined
   /**
-   * Mints the chat JWT in host code instead of letting the widget POST `authTokenUrl` with the
-   * page's cookies, for hosts whose backend sits on another origin behind bearer or custom-header
-   * auth. Called again whenever the widget needs a token (near expiry, or after one is rejected),
-   * so it must mint a fresh token rather than return a memoized one. Fixed at mount.
+   * Extra request headers for `authTokenUrl`, for hosts whose backend sits on another origin and
+   * authenticates with a bearer token or a custom header rather than the page's cookies. Resolved
+   * again on every token request, so pass the function form for a credential that rotates.
+   * Fixed at mount.
    */
-  getAuthToken?: (() => string | Promise<string>) | undefined
+  authTokenHeaders?: AstralBeamChatAuthTokenHeaders | undefined
   /** Host-defined tools the agent can call, executed in the host page, keyed by tool name. */
   tools?: Record<string, ToolDefinition> | undefined
   /** Host-defined widgets the agent can render inline in the conversation, keyed by identifier. */
@@ -190,7 +198,7 @@ export interface MountAstralBeamChatOptions {
  * changing any of them would mean a new client and a discarded transcript.
  */
 export type AstralBeamChatUpdate = Partial<
-  Omit<MountAstralBeamChatOptions, "agentId" | "apiUrl" | "authTokenUrl" | "getAuthToken">
+  Omit<MountAstralBeamChatOptions, "agentId" | "apiUrl" | "authTokenUrl" | "authTokenHeaders">
 >
 
 export interface AstralBeamChatHandle {

--- a/sdk/src/react/index.tsx
+++ b/sdk/src/react/index.tsx
@@ -13,6 +13,7 @@ import { createPortal } from "react-dom"
 // chunk and its bundled React instead of bundling a second copy.
 import {
   type AstralBeamChatAttachmentOptions,
+  type AstralBeamChatAuthTokenHeaders,
   type AstralBeamChatColorScheme,
   type AstralBeamChatHandle,
   type AstralBeamChatSlotRenderer,
@@ -37,6 +38,7 @@ import {
 
 export type {
   AstralBeamChatAttachmentOptions,
+  AstralBeamChatAuthTokenHeaders,
   AstralBeamChatColorScheme,
   AstralBeamChatTheme,
   InferParameters,
@@ -157,12 +159,11 @@ export interface AstralBeamChatProps {
   /** Application endpoint that mints a short-lived chat JWT. Default `"/api/astralbeam/token"`. */
   authTokenUrl?: string
   /**
-   * Mints the chat JWT in host code instead of letting the widget POST `authTokenUrl` with the
-   * page's cookies, for hosts whose backend sits on another origin behind bearer or custom-header
-   * auth. Always reads the latest prop, so an inline callback over current auth state is fine; it
-   * must mint a fresh token on every call, because the widget calls it only when it needs one.
+   * Extra headers for the token request, for a backend on another origin that authenticates with a
+   * bearer token or custom header instead of cookies. Always read from the latest render, so an
+   * inline object or callback over current auth state is fine and needs no memoization.
    */
-  getAuthToken?: () => string | Promise<string>
+  authTokenHeaders?: AstralBeamChatAuthTokenHeaders
   /** Host-defined tools the agent can call, executed in the host's React app, keyed by name. */
   tools?: Record<string, ToolDefinition>
   /** Host-defined widgets the agent can render inline in the conversation, keyed by identifier. */
@@ -204,7 +205,7 @@ export const AstralBeamChat = forwardRef<AstralBeamChatRef, AstralBeamChatProps>
       emptyDescription,
       apiUrl,
       authTokenUrl,
-      getAuthToken,
+      authTokenHeaders,
       tools,
       widgets = {},
       colorScheme = DEFAULT_COLOR_SCHEME,
@@ -230,11 +231,11 @@ export const AstralBeamChat = forwardRef<AstralBeamChatRef, AstralBeamChatProps>
     useEffect(() => {
       toolsRef.current = tools
     })
-    // Same reason, and the widget mints tokens for as long as it lives: a callback frozen at mount
-    // would keep sending the first render's credentials once the host's session rotates.
-    const getAuthTokenRef = useRef(getAuthToken)
+    // Same reason, and the widget mints tokens for as long as it lives: headers frozen at mount
+    // would keep sending the first render's credential once the host's session rotates.
+    const authTokenHeadersRef = useRef(authTokenHeaders)
     useEffect(() => {
-      getAuthTokenRef.current = getAuthToken
+      authTokenHeadersRef.current = authTokenHeaders
     })
     // The chat keeps one render per tool call, so several renders of the same widget can be live
     // at once (a listing that renders a card per item); each needs its own portal and React key.
@@ -347,8 +348,16 @@ export const AstralBeamChat = forwardRef<AstralBeamChatRef, AstralBeamChatProps>
         agentId,
         apiUrl,
         authTokenUrl,
-        // Stable wrapper so a new inline callback each render is not a changed mount-fixed option.
-        ...(getAuthTokenRef.current ? { getAuthToken: () => getAuthTokenRef.current!() } : {}),
+        // Always a function, so a new inline object or callback each render is neither a changed
+        // mount-fixed option nor a stale credential.
+        ...(authTokenHeadersRef.current
+          ? {
+            authTokenHeaders: () => {
+              const current = authTokenHeadersRef.current
+              return typeof current === "function" ? current() : current ?? {}
+            },
+          }
+          : {}),
       })
       handleRef.current = handle
       return () => {

--- a/sdk/src/react/index.tsx
+++ b/sdk/src/react/index.tsx
@@ -161,7 +161,8 @@ export interface AstralBeamChatProps {
   /**
    * Extra headers for the token request, for a backend on another origin that authenticates with a
    * bearer token or custom header instead of cookies. Always read from the latest render, so an
-   * inline object or callback over current auth state is fine and needs no memoization.
+   * inline object or callback over current auth state is fine, needs no memoization, and may
+   * start out undefined while the host's own credential loads.
    */
   authTokenHeaders?: AstralBeamChatAuthTokenHeaders
   /** Host-defined tools the agent can call, executed in the host's React app, keyed by name. */
@@ -348,16 +349,12 @@ export const AstralBeamChat = forwardRef<AstralBeamChatRef, AstralBeamChatProps>
         agentId,
         apiUrl,
         authTokenUrl,
-        // Always a function, so a new inline object or callback each render is neither a changed
-        // mount-fixed option nor a stale credential.
-        ...(authTokenHeadersRef.current
-          ? {
-            authTokenHeaders: () => {
-              const current = authTokenHeadersRef.current
-              return typeof current === "function" ? current() : current ?? {}
-            },
-          }
-          : {}),
+        // Always a function over the latest render, so an inline object is neither a changed
+        // mount-fixed option nor a stale credential, and one that resolves after mount still lands.
+        authTokenHeaders: () => {
+          const current = authTokenHeadersRef.current
+          return typeof current === "function" ? current() : current ?? {}
+        },
       })
       handleRef.current = handle
       return () => {

--- a/sdk/src/react/index.tsx
+++ b/sdk/src/react/index.tsx
@@ -156,6 +156,13 @@ export interface AstralBeamChatProps {
   apiUrl?: string
   /** Application endpoint that mints a short-lived chat JWT. Default `"/api/astralbeam/token"`. */
   authTokenUrl?: string
+  /**
+   * Mints the chat JWT in host code instead of letting the widget POST `authTokenUrl` with the
+   * page's cookies, for hosts whose backend sits on another origin behind bearer or custom-header
+   * auth. Always reads the latest prop, so an inline callback over current auth state is fine; it
+   * must mint a fresh token on every call, because the widget calls it only when it needs one.
+   */
+  getAuthToken?: () => string | Promise<string>
   /** Host-defined tools the agent can call, executed in the host's React app, keyed by name. */
   tools?: Record<string, ToolDefinition>
   /** Host-defined widgets the agent can render inline in the conversation, keyed by identifier. */
@@ -197,6 +204,7 @@ export const AstralBeamChat = forwardRef<AstralBeamChatRef, AstralBeamChatProps>
       emptyDescription,
       apiUrl,
       authTokenUrl,
+      getAuthToken,
       tools,
       widgets = {},
       colorScheme = DEFAULT_COLOR_SCHEME,
@@ -221,6 +229,12 @@ export const AstralBeamChat = forwardRef<AstralBeamChatRef, AstralBeamChatProps>
     const toolsRef = useRef(tools)
     useEffect(() => {
       toolsRef.current = tools
+    })
+    // Same reason, and the widget mints tokens for as long as it lives: a callback frozen at mount
+    // would keep sending the first render's credentials once the host's session rotates.
+    const getAuthTokenRef = useRef(getAuthToken)
+    useEffect(() => {
+      getAuthTokenRef.current = getAuthToken
     })
     // The chat keeps one render per tool call, so several renders of the same widget can be live
     // at once (a listing that renders a card per item); each needs its own portal and React key.
@@ -333,6 +347,8 @@ export const AstralBeamChat = forwardRef<AstralBeamChatRef, AstralBeamChatProps>
         agentId,
         apiUrl,
         authTokenUrl,
+        // Stable wrapper so a new inline callback each render is not a changed mount-fixed option.
+        ...(getAuthTokenRef.current ? { getAuthToken: () => getAuthTokenRef.current!() } : {}),
       })
       handleRef.current = handle
       return () => {

--- a/sdk/src/widget/chat-widget.tsx
+++ b/sdk/src/widget/chat-widget.tsx
@@ -62,7 +62,7 @@ export function ChatWidget(
   })
   const [authentication] = useState<ChatAuthenticationOptions>(() => ({
     authTokenUrl: options.authTokenUrl ?? DEFAULT_AUTH_TOKEN_URL,
-    getAuthToken: options.getAuthToken,
+    authTokenHeaders: options.authTokenHeaders,
     session: {
       cached: undefined,
       refreshPromise: undefined,

--- a/sdk/src/widget/chat-widget.tsx
+++ b/sdk/src/widget/chat-widget.tsx
@@ -62,6 +62,7 @@ export function ChatWidget(
   })
   const [authentication] = useState<ChatAuthenticationOptions>(() => ({
     authTokenUrl: options.authTokenUrl ?? DEFAULT_AUTH_TOKEN_URL,
+    getAuthToken: options.getAuthToken,
     session: {
       cached: undefined,
       refreshPromise: undefined,

--- a/webapp/src/routes/docs/-content/sdk/authentication.md
+++ b/webapp/src/routes/docs/-content/sdk/authentication.md
@@ -27,6 +27,31 @@ export const POST = createAstralBeamTokenRoute({
 
 For full control, mint the token with `createAstralBeamChatToken({ apiKey, user, tenant })` and answer with `Response.json({ token })` plus `cache-control: no-store`.
 
+## A backend on another origin
+
+By default the widget POSTs `authTokenUrl` with the page's cookies, which needs a session cookie the browser will send. When your API lives on another origin behind bearer or custom-header auth, pass `getAuthToken` and fetch the token yourself.
+
+```tsx
+<AstralBeamChat
+  agentId="agt_acme_support"
+  getAuthToken={async () => {
+    const response = await fetch("https://api.acme.com/astralbeam/token", {
+      method: "POST",
+      headers: { authorization: `Bearer ${accessToken}` },
+    })
+    if (!response.ok) throw new Error(`The token endpoint answered ${response.status}`)
+    return (await response.json()).token
+  }}
+/>
+```
+
+- `getAuthToken` replaces the widget's own request entirely: you choose the method, headers, body, and response shape, and it never reads `authTokenUrl`.
+- It is called whenever the widget needs a token, near expiry and after one is rejected, so mint a fresh token instead of returning a memoized one.
+- Throw to fail closed; the composer shows the error and its retry link calls `getAuthToken` again.
+- The React prop always reads the latest render's callback, so an inline arrow over current auth state is fine and needs no memoization.
+- Like `authTokenUrl`, it is fixed at mount: `handle.update` rejects it.
+- Cookies do work cross-origin without it if your endpoint returns `Access-Control-Allow-Credentials: true` with an exact origin, its cookie is `SameSite=None; Secure`, and it answers the preflight; browser cookie policies make this the more fragile route.
+
 ## Rules
 
 The token identifies the tenant user to AstralBeam, so treat it like a session credential.

--- a/webapp/src/routes/docs/-content/sdk/authentication.md
+++ b/webapp/src/routes/docs/-content/sdk/authentication.md
@@ -29,28 +29,24 @@ For full control, mint the token with `createAstralBeamChatToken({ apiKey, user,
 
 ## A backend on another origin
 
-By default the widget POSTs `authTokenUrl` with the page's cookies, which needs a session cookie the browser will send. When your API lives on another origin behind bearer or custom-header auth, pass `getAuthToken` and fetch the token yourself.
+By default the widget POSTs `authTokenUrl` with the page's cookies, which needs a session cookie the browser will send. When your API lives on another origin and authenticates with a bearer token or a custom header, point `authTokenUrl` at it and pass `authTokenHeaders`.
 
 ```tsx
 <AstralBeamChat
   agentId="agt_acme_support"
-  getAuthToken={async () => {
-    const response = await fetch("https://api.acme.com/astralbeam/token", {
-      method: "POST",
-      headers: { authorization: `Bearer ${accessToken}` },
-    })
-    if (!response.ok) throw new Error(`The token endpoint answered ${response.status}`)
-    return (await response.json()).token
-  }}
+  authTokenUrl="https://api.acme.com/astralbeam/token"
+  authTokenHeaders={{ authorization: `Bearer ${accessToken}` }}
 />
 ```
 
-- `getAuthToken` replaces the widget's own request entirely: you choose the method, headers, body, and response shape, and it never reads `authTokenUrl`.
-- It is called whenever the widget needs a token, near expiry and after one is rejected, so mint a fresh token instead of returning a memoized one.
-- Throw to fail closed; the composer shows the error and its retry link calls `getAuthToken` again.
-- The React prop always reads the latest render's callback, so an inline arrow over current auth state is fine and needs no memoization.
+- Pass an object for a fixed credential, or a function, which may be async, for one you must read or await per request: `authTokenHeaders={async () => ({ authorization: "Bearer " + await getAccessToken() })}`.
+- Headers are resolved on every token request, near expiry and after a token is rejected, so a rotating credential stays current instead of being captured once.
+- The React prop is read from the latest render, so an inline object or callback over current auth state is fine and needs no memoization.
+- Throwing from the callback fails closed before any request; the composer shows the error and its retry link resolves the headers again.
+- The endpoint keeps its contract: the SDK still sends `POST` with `accept: application/json` and expects `{ token }`, and still checks the response status for you.
 - Like `authTokenUrl`, it is fixed at mount: `handle.update` rejects it.
-- Cookies do work cross-origin without it if your endpoint returns `Access-Control-Allow-Credentials: true` with an exact origin, its cookie is `SameSite=None; Secure`, and it answers the preflight; browser cookie policies make this the more fragile route.
+- A custom header makes the cross-origin request preflighted, so the endpoint must answer `OPTIONS` and return `Access-Control-Allow-Headers: authorization` with an exact `Access-Control-Allow-Origin`.
+- With header auth you need no cookies at all. Cookies do work cross-origin instead if the endpoint returns `Access-Control-Allow-Credentials: true` and its cookie is `SameSite=None; Secure`, but browser cookie policies make that the more fragile route.
 
 ## Rules
 

--- a/webapp/src/routes/docs/-content/sdk/authentication.md
+++ b/webapp/src/routes/docs/-content/sdk/authentication.md
@@ -41,7 +41,7 @@ By default the widget POSTs `authTokenUrl` with the page's cookies, which needs 
 
 - Pass an object for a fixed credential, or a function, which may be async, for one you must read or await per request: `authTokenHeaders={async () => ({ authorization: "Bearer " + await getAccessToken() })}`.
 - Headers are resolved on every token request, near expiry and after a token is rejected, so a rotating credential stays current instead of being captured once.
-- The React prop is read from the latest render, so an inline object or callback over current auth state is fine and needs no memoization.
+- The React prop is read from the latest render, so an inline object or callback over current auth state is fine, needs no memoization, and may start out undefined while your own credential loads.
 - Throwing from the callback fails closed before any request; the composer shows the error and its retry link resolves the headers again.
 - The endpoint keeps its contract: the SDK still sends `POST` with `accept: application/json` and expects `{ token }`, and still checks the response status for you.
 - Like `authTokenUrl`, it is fixed at mount: `handle.update` rejects it.


### PR DESCRIPTION
## Why

- The SDK's token request was a hard-coded `POST` with `credentials: "include"` and no way to add headers (`sdk/src/core/auth.ts`), so it only worked when the host's session was a cookie the browser would send.
- Hosts whose frontend and backend are separate origins, with the session as a bearer token rather than a cookie, could not authenticate the token endpoint at all. Everything after that step already uses `Authorization: Bearer`, so this was the only cookie-bound request.

## What

- Adds `authTokenHeaders`, extra headers for the `authTokenUrl` request: an object for a fixed credential, or a function (may be async) for one the host reads or awaits per request.
- The SDK keeps owning the request. Its contract is ours (`createAstralBeamTokenRoute` → `POST`, `{ token }`), so the host supplies only the credential and does not re-implement the status check, the `{ token }` parsing, or the error messages.
- Headers are resolved on every token request rather than captured once, so a rotating access token stays current across the widget's lifetime; a throwing callback fails closed before any request is made.
- React reads the prop through a ref (like `tools`), so an inline object needs no memoization, never remounts, and may start out `undefined` while the host's own credential loads — a value that arrives after mount still lands.
- Fixed at mount alongside `agentId`, `apiUrl`, and `authTokenUrl`; `handle.update` rejects it.
- Bumps the SDK to `0.4.0`, and documents the option in `README.md` plus a new "A backend on another origin" section in the hosted authentication guide, including the required `Access-Control-Allow-Headers` preflight response and the cross-origin cookie alternative.

## Notes

- Header resolution is awaited only when the host configured headers, so the default cookie request still starts in the caller's tick — without that, the existing concurrent-refresh dedup test times out, since the token fetch no longer began synchronously.
- An earlier revision of this PR exposed a full `getAuthToken` callback instead. Injecting the credential is the narrower fit for an endpoint contract we define, and a callback stays additive if a host ever needs one (an SSR-bootstrapped token, or routing through its own API client).

## Validation

- `deno task check` in `sdk`: format, lint, `tsc --noEmit`, and knip clean.
- `deno task test` in `sdk`: 47 tests pass, including three new ones covering per-request resolution of a rotating credential, static headers, and failing closed with no request when the callback throws.
- `webapp` has no code change here (one docs Markdown file); its `deno task check` reports 64 pre-existing errors, all under the untracked `.output` build directory.
