### PR TITLE
Resolve SDK subpath types under classic moduleResolution

### DIFF
--- a/sdk/AGENTS.md
+++ b/sdk/AGENTS.md
@@ -6,6 +6,8 @@ Author guide for `@astralbeam/sdk`. Consumer documentation is the `README.md` qu
 
 Each folder under `src/` with an `index.ts(x)` named in `tsdown.config.ts` is a public entry point and maps 1:1 to the `exports` field in `package.json`; add new entry points in both places.
 
+Mirror every entry point in `typesVersions` as well. `exports` is invisible to TypeScript's classic `"moduleResolution": "node"`, which Ionic, Capacitor, and Create React App templates still ship, and without the [`typesVersions`](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#version-selection-with-typesversions) fallback those hosts get `Cannot find module "@astralbeam/sdk/react"`. The declarations themselves need TypeScript 5.0 for `const` type parameters, so 4.x hosts must upgrade; the fallback cannot help them.
+
 - `src/client/` — the vanilla loader entry; no React, tiny by design.
 - `src/core/` — the headless session and chat protocol; framework-free, bundled into `core.js` and into the React entry.
 - `src/react/` — the React wrapper; binds to the host's React.

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -141,6 +141,8 @@ There is no root export. Conversation history is not built yet.
 | `@astralbeam/sdk/server` | `createAstralBeamChatToken`, `createAstralBeamTokenRoute` | none                 |
 | `@astralbeam/sdk/vue`    | Vue components (placeholder)                              | `vue`                |
 
+Types resolve under every TypeScript module resolution mode, including the classic `"moduleResolution": "node"` that Ionic, Capacitor, and Create React App templates still ship. TypeScript 5.0 or later is required, because the declarations use `const` type parameters; on TypeScript 4.x the `.d.ts` files fail to parse.
+
 ## Example
 
 [`examples/todos`](../examples/todos) embeds the sidebar in a minimal TanStack Start app: a demo token route, host tools over live React state, and a `todoCard` widget. It uses no Tailwind or shadcn/ui of its own, to show the shadow-root boundary.

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@astralbeam/sdk",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Frontend SDK for AstralBeam: drop-in agent UI, chat streaming, and server helpers",
   "license": "MIT",
   "type": "module",
@@ -34,6 +34,15 @@
       "default": "./dist/vue.js"
     },
     "./package.json": "./package.json"
+  },
+  "typesVersions": {
+    "*": {
+      "client": ["./dist/client.d.ts"],
+      "core": ["./dist/core.d.ts"],
+      "server": ["./dist/server.d.ts"],
+      "react": ["./dist/react.d.ts"],
+      "vue": ["./dist/vue.d.ts"]
+    }
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
- Add a `typesVersions` fallback to `sdk/package.json` mirroring all five subpath exports, so `@astralbeam/sdk/react` and its siblings resolve types under TypeScript's classic `"moduleResolution": "node"`, which ignores `exports` entirely.
  - Reported by a customer on a Capacitor/Ionic React app with pnpm: `Cannot find module '@astralbeam/sdk/react' or its corresponding type declarations`. Reproduced against published `0.4.0` and confirmed fixed against a packed `0.4.1` tarball for all four real entry points, under both `node` and `bundler` resolution.
  - The Ionic, Capacitor, and Create React App templates still ship `"moduleResolution": "node"`, so this affects any host that has not migrated its tsconfig.
- Bump the SDK to `0.4.1`.
- Document in `sdk/README.md` that types now resolve under every module resolution mode, and that TypeScript 5.0 or later is required.
  - The declarations use [`const` type parameters](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-0.html#const-type-parameters) (TypeScript 5.0+) for `defineTool`/`defineWidget` literal inference. On TypeScript 4.x the `.d.ts` files fail to *parse*, which `skipLibCheck` does not suppress, so the resolution fallback alone cannot help those hosts — the reporting customer is on 4.9.5 and must upgrade.
- Record the entry-point/`typesVersions` mirroring rule in `sdk/AGENTS.md` alongside the existing `exports` rule.
