### PR TITLE
Keep a user's attachments in the messages snapshot

### DIFF
--- a/.github/workflows/ci-push.yml
+++ b/.github/workflows/ci-push.yml
@@ -40,11 +40,16 @@ jobs:
         run: docker compose up --detach --wait
 
       - name: Auto-fix project issues
+        # Every project is formatted and lint-fixed here, so a config file that a Deno command
+        # rewrites unformatted (such as `allowScripts`) is corrected rather than failing the
+        # `format:check` in the step below.
         run: |
           deno task --cwd webapp knip:fix
           deno task --cwd webapp check:fix
           deno task --cwd www knip:fix
           deno task --cwd www check:fix
+          deno task --cwd sdk check:fix
+          deno task --cwd examples/todos check:fix
 
       - name: Check, test, and build projects
         run: |

--- a/examples/todos/package.json
+++ b/examples/todos/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "vite build",
     "check": "deno task format:check && deno task lint && deno task typecheck && deno task knip",
+    "check:fix": "deno fmt && deno lint --fix",
     "dev": "vite --port 4700",
     "format": "deno fmt",
     "format:check": "deno fmt --check",

--- a/sdk/deno.jsonc
+++ b/sdk/deno.jsonc
@@ -1,7 +1,12 @@
 {
   "$schema": "https://deno.land/x/deno/cli/schemas/config-file.v1.json",
   "nodeModulesDir": "auto",
-  "allowScripts": ["npm:@parcel/watcher@2.5.1", "npm:esbuild", "npm:fsevents@2.3.3", "npm:msgpackr-extract@3.0.4"],
+  "allowScripts": [
+    "npm:@parcel/watcher@2.5.1",
+    "npm:esbuild",
+    "npm:fsevents@2.3.3",
+    "npm:msgpackr-extract@3.0.4"
+  ],
   "fmt": {
     "lineWidth": 100,
     "semiColons": false,

--- a/webapp/src/routes/api/chat/-lib/attachments.server.test.ts
+++ b/webapp/src/routes/api/chat/-lib/attachments.server.test.ts
@@ -1,6 +1,11 @@
+import type { ChatMiddleware, ChatMiddlewareContext, StreamChunk } from "@tanstack/ai"
 import { expect, test } from "vitest"
 
-import { normalizeChatAttachments, redactChatAttachmentData } from "./attachments.server"
+import {
+  createChatAttachmentSnapshotMiddleware,
+  normalizeChatAttachments,
+  redactChatAttachmentData,
+} from "./attachments.server"
 import type { ChatMessages } from "./types"
 
 const base64 = (text: string) => btoa(text)
@@ -345,4 +350,49 @@ test("leaves a non-user message without media untouched", () => {
     { id: "a1", role: "assistant", parts: [{ type: "text", content: "hi" }] },
   ] as unknown as ChatMessages
   expect(normalizeChatAttachments(messages, withSandbox).messages).toEqual(messages)
+})
+
+function onChunk(middleware: ChatMiddleware, chunk: unknown) {
+  const hook = middleware.onChunk
+  if (!hook) throw new Error("The middleware declares no onChunk hook.")
+  return hook({} as ChatMiddlewareContext, chunk as StreamChunk)
+}
+
+// The client rebuilds its whole transcript from the snapshot an interrupt boundary emits. A turn
+// that arrived with a file therefore has to come back carrying that file: otherwise its chip
+// becomes the announcement line as text mid-conversation, and the next request no longer carries
+// the bytes the handle resolves against.
+test("restores the user's own attachments in a messages snapshot", () => {
+  const sent = [
+    {
+      id: "user-1",
+      role: "user",
+      content: [documentEntry("config.csv", "text/csv", base64("a\n1\n"))],
+    },
+    { id: "assistant-1", role: "assistant", content: "on it" },
+    { id: "user-2", role: "user", content: "and this one has no file" },
+  ] as unknown as ChatMessages
+  const snapshot = {
+    type: "MESSAGES_SNAPSHOT",
+    timestamp: 0,
+    messages: [
+      { id: "user-1", role: "user", content: "[Attached: config.csv]" },
+      { id: "assistant-1", role: "assistant", content: "on it" },
+      { id: "user-2", role: "user", content: "and this one has no file" },
+    ],
+  }
+  expect(onChunk(createChatAttachmentSnapshotMiddleware(sent), snapshot)).toMatchObject({
+    type: "MESSAGES_SNAPSHOT",
+    messages: [sent[0], snapshot.messages[1], snapshot.messages[2]],
+  })
+})
+
+test("leaves every other chunk, and a conversation with no attachment, untouched", () => {
+  const middleware = createChatAttachmentSnapshotMiddleware(
+    [{ id: "user-1", role: "user", content: "hello" }] as unknown as ChatMessages,
+  )
+  expect(onChunk(middleware, { type: "MESSAGES_SNAPSHOT", timestamp: 0, messages: [] }))
+    .toBeUndefined()
+  expect(onChunk(middleware, { type: "TEXT_MESSAGE_CONTENT", timestamp: 0, delta: "hi" }))
+    .toBeUndefined()
 })

--- a/webapp/src/routes/api/chat/-lib/attachments.server.ts
+++ b/webapp/src/routes/api/chat/-lib/attachments.server.ts
@@ -1,3 +1,5 @@
+import { type ChatMiddleware, EventType } from "@tanstack/ai"
+
 import { profileDelimitedText } from "./attachment-profile.server"
 import { extractOfficeDocument, isOfficeMimeType } from "./attachment-office.server"
 import {
@@ -452,4 +454,44 @@ export function redactChatAttachmentData(messages: ChatMessages): ChatMessages {
     if (Array.isArray(next.parts)) next.parts = redactEntries(next.parts)
     return next
   })
+}
+
+/**
+ * Puts a user's own attachments back into the `MESSAGES_SNAPSHOT` the client reads.
+ *
+ * {@link normalizeChatAttachments} rewrites a user message for the *model*, and the snapshot an
+ * interrupt boundary emits is built from those same rewritten messages. The client replaces its
+ * transcript with that snapshot, so without this pass a sent file's chip becomes the
+ * `[Attached: …]` line as text mid-conversation, and the bytes leave the client's copy of the
+ * turn: the next request no longer carries the file and its handle stops resolving.
+ *
+ * A user message that arrived with a media entry is restored exactly as it arrived, so the
+ * transcript the client keeps is the one it sent.
+ */
+export function createChatAttachmentSnapshotMiddleware(messages: ChatMessages): ChatMiddleware {
+  const sent = new Map<string, ChatMessages[number]>()
+  for (const message of messages) {
+    if (message.role !== "user") continue
+    const source = message as { id?: unknown; content?: unknown; parts?: unknown }
+    if (typeof source.id !== "string" || source.id.length === 0) continue
+    const entries = Array.isArray(source.parts) ? source.parts : source.content
+    if (Array.isArray(entries) && entries.some(isMediaEntry)) sent.set(source.id, message)
+  }
+  return {
+    name: "astralbeam-chat-attachment-snapshot",
+    onChunk: (_context, chunk) => {
+      if (sent.size === 0 || chunk.type !== EventType.MESSAGES_SNAPSHOT) return
+      let restored = false
+      const snapshot = chunk.messages.map((message) => {
+        const original = message.role === "user" ? sent.get(message.id) : undefined
+        if (original === undefined) return message
+        restored = true
+        // The original is a validated user message off the same request, so it is already the
+        // wire shape this event carries.
+        return original as typeof message
+      })
+      // Returning nothing leaves the chunk alone, which is what a run with no restored turn wants.
+      return restored ? { ...chunk, messages: snapshot } : undefined
+    },
+  }
 }

--- a/webapp/src/routes/api/chat/index.ts
+++ b/webapp/src/routes/api/chat/index.ts
@@ -11,7 +11,11 @@ import { runDatabaseEffect } from "@/db"
 import { createChatAdapter } from "./-lib/adapter.server"
 import { resolveChatAgent } from "./-lib/agent.server"
 import { createChatAttachmentTools } from "./-lib/attachment-tools.server"
-import { normalizeChatAttachments, redactChatAttachmentData } from "./-lib/attachments.server"
+import {
+  createChatAttachmentSnapshotMiddleware,
+  normalizeChatAttachments,
+  redactChatAttachmentData,
+} from "./-lib/attachments.server"
 import { authenticateChatRequest, isChatAuthenticationError } from "./-lib/auth.server"
 import {
   CHAT_ATTACHMENT_SYSTEM_PROMPT,
@@ -191,6 +195,9 @@ export const Route = createFileRoute("/api/chat/")({
             // Every other tool executes in the host page and arrives declared in the request body;
             // a client tool reusing a server tool's name is dropped by `mergeAgentTools`.
             tools: mergeAgentTools([...sandboxTools, ...attachmentTools], params.tools),
+            // The client rebuilds its transcript from the snapshot an interrupt boundary emits,
+            // so the turns it sent have to survive the rewrite above.
+            middleware: [createChatAttachmentSnapshotMiddleware(params.messages)],
             threadId: params.threadId,
             runId: params.runId,
             parentRunId: params.parentRunId,


### PR DESCRIPTION
- Keeps a user's attachments in the transcript the chat widget rebuilds from a `MESSAGES_SNAPSHOT`, so an uploaded file stays a chip instead of turning into the `[Attached: tasks.csv]` line as text a few turns later
  - An interrupt boundary — reached on the first host-tool call of a run — emits a snapshot built from the messages handed to `chat()`, and those are the ones `normalizeChatAttachments` already rewrote for the model
  - The client replaces its whole message list with that snapshot, so the file's parts left its copy of the turn: the chip disappeared **and** the next request no longer carried the bytes, which left `read_attachment` undeclared and the handle unresolvable for the rest of the conversation
  - A new `createChatAttachmentSnapshotMiddleware` restores each user turn that arrived with a media entry, exactly as it arrived, through the chat middleware `onChunk` hook; every other chunk and every attachment-free run pass through untouched
  - Image and PDF turns are restored the same way, which also keeps their `metadata.filename`/`size` on the chip after a snapshot
- Before, on the second turn: the bubble shows the announcement line, no chip, and no `read_attachment` — the agent answered from memory and duplicated the todo

  ![before](https://github.com/user-attachments/assets/3a8e21ff-51f1-45b0-aec5-d044a3e1b6c6)
- After, on the second turn: the chip stays, the bubble holds only the user's own text, and `read_attachment` resolves the handle again

  ![after](https://github.com/user-attachments/assets/9a00eca0-b3f6-4fba-8578-f684e581ee99)
- Formats `sdk/deno.jsonc`, which `deno install --allow-scripts` rewrote unformatted in #108 and which currently fails `deno task --cwd sdk ready` on `main`
- Runs the CI auto-fix step for `sdk` and `examples/todos` as well, so the next config file a Deno command rewrites is corrected there rather than failing `format:check`; adds the missing `check:fix` script to `examples/todos`
- Verified with `deno task ready` in `webapp`, `sdk`, and `examples/todos`, plus the browser run above against the todos example and a local agent
