### PR TITLE
Fix Deno production server shutdown

### DIFF
--- a/webapp/scripts/check-binary.ts
+++ b/webapp/scripts/check-binary.ts
@@ -82,6 +82,7 @@ async function stopBinaryCheckProcess(
   if (stopped) return
   signalBinaryCheckProcess(binaryProcess, "SIGKILL")
   await status
+  throw new Error("Binary did not exit within 5 seconds of SIGTERM")
 }
 
 async function runBinaryCheck() {
@@ -131,12 +132,15 @@ async function runBinaryCheck() {
     if (!(await stylesheetResponse.text())) {
       throw new Error("Binary served an empty stylesheet")
     }
-
-    console.log(`Binary smoke check passed (${binarySizeMiB.toFixed(1)} MiB)`)
   } finally {
-    await stopBinaryCheckProcess(binaryProcess, status)
-    await rm(temporaryDirectory, { recursive: true })
+    try {
+      await stopBinaryCheckProcess(binaryProcess, status)
+    } finally {
+      await rm(temporaryDirectory, { recursive: true })
+    }
   }
+
+  console.log(`Binary smoke check passed (${binarySizeMiB.toFixed(1)} MiB)`)
 }
 
 await runBinaryCheck()

--- a/webapp/vite.config.ts
+++ b/webapp/vite.config.ts
@@ -56,6 +56,21 @@ const viteConfig = defineConfig(({ mode }) => {
           for (const asset of legalAssets) this.emitFile({ type: "asset", ...asset })
         },
       },
+      {
+        name: "react-dom-deno-server",
+        apply: "build",
+        enforce: "pre",
+        // React maps Deno to its browser server build, whose referenced MessageChannel prevents
+        // process shutdown after the first request. Use the full Node server API in the SSR bundle.
+        // https://github.com/denoland/deno/issues/28919
+        resolveId(source, importer, options) {
+          if (!options.ssr || source !== "react-dom/server") return null
+          return this.resolve("react-dom/server.node", importer, {
+            ...options,
+            skipSelf: true,
+          })
+        },
+      },
       devtools(),
       ...(mode === "test" ? [] : nitro()),
       tailwindcss(),


### PR DESCRIPTION
- Resolve `react-dom/server` to React's full Node renderer only in production SSR bundles, avoiding the [Deno `MessageChannel` shutdown leak](https://github.com/denoland/deno/issues/28919) while preserving legacy and streaming render APIs.
- Make the compiled-binary smoke check fail when SIGTERM requires SIGKILL, while still cleaning up its temporary directory.
