### PR TITLE
Document the limits the chat endpoint enforces

### DIFF
--- a/webapp/src/routes/docs/-content/sdk/attachments.md
+++ b/webapp/src/routes/docs/-content/sdk/attachments.md
@@ -35,5 +35,5 @@ A file's bytes are never pasted into the conversation. The user's message carrie
 - Excel sheets are profiled per sheet and read as CSV, with dates rendered as dates rather than serial numbers.
 - Parquet files and SQLite databases have no text view, so they need an agent with a sandbox; without one the file is refused with an explanation.
 - A file that cannot be sent keeps its chip in the composer and says why, instead of vanishing.
-- The endpoint enforces the same limits independently, so narrowing them here is an affordance, not a boundary.
+- The endpoint enforces the same limits independently, so narrowing them here is an affordance, not a boundary; see [Limits](./limits.md) for the exact values.
 - Attachments are agent policy: when the dashboard disables them, the endpoint refuses files and the widget hides the attach button; see [Security model](./security.md).

--- a/webapp/src/routes/docs/-content/sdk/limits.md
+++ b/webapp/src/routes/docs/-content/sdk/limits.md
@@ -1,0 +1,49 @@
+# Limits
+
+The chat endpoint enforces every limit below on every request, whatever the SDK composer already checked. Narrowing a limit through an SDK option is a UX affordance, not a boundary.
+
+## Requests
+
+| Limit                      | Value                                                                         | When it is exceeded                                                            |
+| -------------------------- | ----------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| Request body               | 32 MB, checked against `content-length` and again while reading               | `413` — "The message and its attachments are too large."                       |
+| Rate limit                 | 20 requests per 60 seconds, counted per organization, tenant, and tenant user | `429` — "Too many chat requests; try again in a minute."                       |
+| Chat auth token lifetime   | 60–600 seconds, 300 by default                                                | `createChatAuthToken` throws; a token outside the range is rejected as invalid |
+| Chat auth token size       | 16,384 bytes                                                                  | minting throws, and a longer bearer header is rejected before it is verified   |
+| `user` and `tenant` claims | 8,192 bytes of JSON                                                           | minting throws "user and tenant must not exceed 8192 bytes"                    |
+| Clock difference           | 30 seconds either way                                                         | the token reads as expired or not yet valid; the composer offers a retry       |
+
+## Attachments
+
+A refused file keeps its chip in the composer, and the agent is told in one sentence that the file could not be included and why.
+
+| Limit                    | Value                                                                                                  | What the agent is told                                                                                           |
+| ------------------------ | ------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------- |
+| Files per message        | 5                                                                                                      | "the message went over the limit of 5 attachments."                                                              |
+| One file, by kind        | 5 MB image, 10 MB PDF, 1 MB text, 10 MB data, 10 MB office                                             | "it is larger than the 5.0 MB limit for that file type."                                                         |
+| All files on one message | 20 MB                                                                                                  | "the message went over the 20 MB attachment limit."                                                              |
+| Accepted types           | PNG, JPEG, WebP, GIF, PDF, text and source files, CSV, TSV, Parquet, SQLite, `.docx`, `.pptx`, `.xlsx` | "this assistant reads images, PDFs, text and source files, CSV and TSV data, Word, Excel, and PowerPoint files." |
+| Declared type            | must match the file's leading bytes                                                                    | "its contents are not a `<type>` file."                                                                          |
+| Filename                 | 120 characters                                                                                         | truncated with an ellipsis rather than refused                                                                   |
+
+## Files the agent reads
+
+| Limit                      | Value                                                               | What happens at the limit                                                   |
+| -------------------------- | ------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| Office archive             | 96 MB declared uncompressed, 2,048 kept parts, 4,096 entries walked | "it declares more content than this assistant will unpack."                 |
+| Table shape                | 50,000 rows, 512 columns, 200,000 cells per sheet                   | cells outside the bounds are skipped and the table is reported as truncated |
+| Column type profile        | the first 50 data rows                                              | types stay a hint the agent should confirm against the file itself          |
+| Readable text per file     | 2,000,000 characters                                                | `read_attachment` returns `readableTextTruncated: true`                     |
+| One `read_attachment` page | 40,000 characters, whatever `limit` asks for                        | the result carries `nextOffset` to read on from                             |
+
+## Sandbox and artifacts
+
+| Limit                    | Value                                                                               | What happens at the limit                                                    |
+| ------------------------ | ----------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| Idle sandbox             | 15 minutes, swept every minute                                                      | destroyed; the conversation's next turn provisions a new one                 |
+| Live sandboxes           | 25 per server process                                                               | the least recently used sandbox is destroyed                                 |
+| Published artifact       | 10 MB                                                                               | "Artifacts are limited to 10485760 bytes. Compress or split the file."       |
+| Artifact download ticket | 15 minutes                                                                          | `404` — "The download has expired. Ask the agent to publish the file again." |
+| Text in the transcript   | 20,000 characters of command output, 40,000 of a file read, 200,000 of a file write | clamped with the middle elided                                               |
+
+Every value here is a constant in the deployment's source, in `webapp/src/routes/api/chat/-lib/constants.server.ts`; none of them is configurable, so a self-hosted deployment changes a limit by editing that file and rebuilding.

--- a/webapp/src/routes/docs/-lib/content.test.ts
+++ b/webapp/src/routes/docs/-lib/content.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from "vitest"
+
+import limits from "../-content/sdk/limits.md?raw"
+import {
+  CHAT_ATTACHMENT_MAX_BYTES_BY_KIND,
+  CHAT_ATTACHMENT_MAX_COUNT,
+  CHAT_ATTACHMENT_MAX_TOTAL_BYTES,
+  CHAT_AUTH_TOKEN_MAX_LIFETIME_SECONDS,
+  CHAT_AUTH_TOKEN_MIN_LIFETIME_SECONDS,
+  CHAT_MAX_REQUEST_BYTES,
+  CHAT_RATE_LIMIT_MAX_REQUESTS,
+  CHAT_RATE_LIMIT_WINDOW_MS,
+} from "@/routes/api/chat/-lib/constants.server"
+
+/** The docs page's own form for a byte cap, so a changed constant reads as a changed page. */
+function megabytes(bytes: number): string {
+  return `${bytes / (1024 * 1024)} MB`
+}
+
+// Drift guard, not a structure test: each documented number is asserted as a substring rendered
+// from its constant, so the prose stays the owner's to reword while the values stay pinned.
+test("the Limits page quotes the caps the chat endpoint enforces", () => {
+  const expected = [
+    `limit of ${CHAT_ATTACHMENT_MAX_COUNT} attachments`,
+    ...Object.values(CHAT_ATTACHMENT_MAX_BYTES_BY_KIND).map(megabytes),
+    megabytes(CHAT_ATTACHMENT_MAX_TOTAL_BYTES),
+    megabytes(CHAT_MAX_REQUEST_BYTES),
+    `${CHAT_RATE_LIMIT_MAX_REQUESTS} requests per ${CHAT_RATE_LIMIT_WINDOW_MS / 1_000} seconds`,
+    `${CHAT_AUTH_TOKEN_MIN_LIFETIME_SECONDS}–${CHAT_AUTH_TOKEN_MAX_LIFETIME_SECONDS} seconds`,
+  ]
+  for (const value of expected) expect(limits).toContain(value)
+})

--- a/webapp/src/routes/docs/-lib/content.ts
+++ b/webapp/src/routes/docs/-lib/content.ts
@@ -5,6 +5,7 @@ import sdkAuthentication from "../-content/sdk/authentication.md?raw"
 import sdkConfiguration from "../-content/sdk/configuration.md?raw"
 import sdkGettingStarted from "../-content/sdk/getting-started.md?raw"
 import sdkHeadless from "../-content/sdk/headless.md?raw"
+import sdkLimits from "../-content/sdk/limits.md?raw"
 import sdkSandbox from "../-content/sdk/sandbox.md?raw"
 import sdkSecurity from "../-content/sdk/security.md?raw"
 import sdkTheming from "../-content/sdk/theming.md?raw"
@@ -35,6 +36,7 @@ export const DOCS_SECTIONS: DocsSection[] = [
       { slug: "theming", title: "Theming", markdown: sdkTheming },
       { slug: "tools-and-widgets", title: "Tools and widgets", markdown: sdkToolsAndWidgets },
       { slug: "attachments", title: "Attachments", markdown: sdkAttachments },
+      { slug: "limits", title: "Limits", markdown: sdkLimits },
       { slug: "sandbox", title: "Sandbox", markdown: sdkSandbox },
       { slug: "headless", title: "Headless", markdown: sdkHeadless },
       { slug: "security", title: "Security model", markdown: sdkSecurity },


### PR DESCRIPTION
- Add `webapp/src/routes/docs/-content/sdk/limits.md`, one consumer-facing reference page listing every limit `/api/chat` enforces on an integration, grouped as Requests, Attachments, Files the agent reads, and Sandbox and artifacts.
- Every value is read from the code rather than remembered: `-lib/constants.server.ts`, `-lib/rate-limit.server.ts`, `-lib/sandbox.server.ts`, `-lib/artifacts.server.ts`, `-lib/auth.server.ts`, `src/lib/schemas.ts`, and the SDK's `src/server/index.ts` and `src/widget/lib/constants.ts`.
- Each row names the limit, its value, and the refusal string or HTTP status a user or agent actually sees, so a developer never has to read source to learn why a request was refused.
- Register the page in `DOCS_SECTIONS` right after Attachments, and close with a plain statement that these are source constants a self-hosted deployment changes by editing `constants.server.ts` and rebuilding.
- Add `webapp/src/routes/docs/-lib/content.test.ts` as a drift guard: it imports the page with the same `?raw` import and asserts the attachment count, each per-kind byte cap, the total-bytes cap, the request-body ceiling, the rate limit count and window, and the token lifetime bounds all appear rendered from their constants.
- Point `attachments.md` at the new page in one line instead of duplicating the table.
- Validation: `deno task ready` from `webapp` — fmt check, lint, typecheck, knip, 268 tests in 44 files, and the production build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
