### PR TITLE
Rerun the workspace bootstrap once Compose is up in Cursor and the devcontainer

### DIFF
--- a/.cursor/README.md
+++ b/.cursor/README.md
@@ -2,6 +2,8 @@
 
 The checked-in [environment](environment.json) installs dependencies, starts Docker and the root Compose stack, exposes ports `4500`, `4600`, and `4700`, and opens both application terminals. Port `4700` is the todos example, which `deno task dev:todos` or the root `deno task dev` serves.
 
+The `install` step runs before Docker exists, so it can only install dependencies; the `start` step therefore reruns `./scripts/setup.sh` after Compose is healthy so every machine start migrates, seeds, and builds the SDK.
+
 In the Cursor dashboard:
 
 - Grant the GitHub app read/write access only to `AstralBeamAI/astralbeam` and enable Privacy Mode.

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -5,7 +5,7 @@
     "context": ".."
   },
   "install": "./scripts/setup.sh",
-  "start": "service docker start && docker compose up -d --wait",
+  "start": "service docker start && docker compose up -d --wait && ./scripts/setup.sh",
   "ports": [
     {
       "name": "Product application",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,8 @@
   "dockerComposeFile": ["../docker-compose.yml", "docker-compose.yml"],
   "service": "astralbeam",
   "workspaceFolder": "/workspaces/astralbeam",
-  "postCreateCommand": "deno task --cwd webapp --eval 'deno install --frozen' && deno task --cwd www --eval 'deno install --frozen'",
+  // Compose is healthy by now, so the shared setup script can install every project and then migrate, seed, and build the SDK.
+  "postCreateCommand": "./scripts/setup.sh",
   // .env.development defaults to 127.0.0.1 for host workflows, but inside this container that loops back to astralbeam rather than its dependencies.
   // Override only editor subprocesses with Compose service DNS https://code.visualstudio.com/remote/advancedcontainers/environment-variables
   "remoteEnv": {

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -14,6 +14,8 @@ services:
       # Keep Linux-native dependencies and Deno's cache isolated from the macOS checkout. https://docs.deno.com/runtime/reference/deno_json/#node-modules-directory
       - webapp-node-modules:/workspaces/astralbeam/webapp/node_modules
       - www-node-modules:/workspaces/astralbeam/www/node_modules
+      - sdk-node-modules:/workspaces/astralbeam/sdk/node_modules
+      - todos-node-modules:/workspaces/astralbeam/examples/todos/node_modules
       - deno-cache:/root/.cache/deno
       # Persist Cursor/VS Code server + extensions across rebuilds
       - ./tmp/.cursor-server:/root/.cursor-server:cached
@@ -35,4 +37,6 @@ services:
 volumes:
   webapp-node-modules:
   www-node-modules:
+  sdk-node-modules:
+  todos-node-modules:
   deno-cache:

--- a/SETUP.md
+++ b/SETUP.md
@@ -25,7 +25,7 @@ Choose one of the two local workflows below: use the devcontainer or run the cod
 
 ### Option 1: Use the devcontainer
 
-- Open the repository root in Cursor or VS Code and choose **Reopen in Container**. The devcontainer finishes setup after PostgreSQL and Valkey are healthy.
+- Open the repository root in Cursor or VS Code and choose **Reopen in Container**. Once PostgreSQL and Valkey are healthy the devcontainer runs `./scripts/setup.sh`, which installs every project's dependencies and then applies the migrations, seeds the database, and builds the SDK.
 
 #### Optional: Match the devcontainer workspace path
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -184,7 +184,7 @@ bootstrap_workspace() {
   # Checked on every platform: a caller can reach here before its database is up — Cursor Cloud
   # installs before it starts Compose — and a named skip is more use than a `set -e` failure.
   if ! database_is_reachable "$url"; then
-    echo "Skipped the migrate, seed, and SDK build steps: nothing is listening at ${url##*@}. Start PostgreSQL, then run './scripts/setup.sh' again." >&2
+    echo "Skipped the migrate, seed, and SDK build steps: nothing is listening at ${url##*@}. Start PostgreSQL, then rerun './scripts/setup.sh' to migrate, seed, and build the SDK." >&2
     set -x
     return 0
   fi


### PR DESCRIPTION
- Cursor Cloud runs `install` (`./scripts/setup.sh`) before `start` launches Docker, so `bootstrap_workspace` always hit its "nothing is listening" skip and a fresh environment ended with a running but uninitialized database, no seed, no `examples/todos/.env`, and no `sdk/dist`, with nothing to rerun it.
- `.cursor/environment.json`: `start` now reruns `./scripts/setup.sh` after `docker compose up -d --wait`, rather than adding a flag or a second script, because every step is idempotent and cheap on a rerun: the apt and Deno installs short-circuit on their version checks, `deno install --frozen` is a no-op, `drizzle-kit migrate` skips applied migrations, the seed upserts with `onConflictDoUpdate` and never overwrites an existing `examples/todos/.env`, and the SDK build takes about five seconds.
- `.cursor/README.md`: one sentence explaining that `install` predates Docker, so `start` reruns the setup script once Compose is healthy.
- `.devcontainer/devcontainer.json`: `postCreateCommand` becomes `./scripts/setup.sh`, replacing a command that only installed `webapp` and `www` and had therefore never migrated, seeded, or built the SDK. It is safe here: Compose is already healthy via `depends_on`, the container is root on Ubuntu 24.04 so the package check short-circuits against the image, and `remoteEnv` reaches lifecycle hooks (`runLifecycleCommand` passes it as the exec env in `devcontainers/cli`), so `POSTGRES_HOST`/`VALKEY_HOST` make `databases_are_external` skip Compose and `DATABASE_URL` points the bootstrap at `pgbouncer`.
- `.devcontainer/docker-compose.yml`: adds `sdk-node-modules` and `todos-node-modules` volumes. This is a prerequisite, not a cleanup: installing all four projects without them would write Linux-native dependencies into the host-mounted macOS checkout, which is exactly what the existing `webapp` and `www` volumes prevent.
- `SETUP.md`: the devcontainer step now names what the script does.
- `scripts/setup.sh`: the skip message names the rerun and its consequence ("Start PostgreSQL, then rerun './scripts/setup.sh' to migrate, seed, and build the SDK"); no logic change.
- Codex needs no change: `.codex/environments/environment.toml` runs `copy-worktree-env.sh` (which recreates the worktree database) before `setup.sh`, and Codex Cloud's `INSTALL_EXTRA=codex-db` runs inside `run_install_extras`, which precedes `bootstrap_workspace`.
- Validation: `bash -n scripts/setup.sh`; `.cursor/environment.json` parses as strict JSON and `.devcontainer/devcontainer.json` as JSONC via `@std/jsonc`; `.devcontainer/docker-compose.yml` parses via `@std/yaml` with every `node_modules` mount resolving to a declared named volume; `./scripts/setup.sh` run twice against a fresh worktree PostgreSQL 18.6 database, the first run applying 12 migrations, seeding, writing `examples/todos/.env`, and building the SDK, and the second exiting 0 in 7.85s wall clock with migrations a no-op, the seed upserted, and the todos `.env` left alone; `git diff --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
