### PR TITLE
Replace the waitlist with login and Discord links, add site headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AstralBeam
 
-**Links:** [Website](https://astralbeam.ai) · [Docs](https://app.astralbeam.ai/docs) · [Hosted app](https://app.astralbeam.ai) · [Discord](https://discord.gg/S7j384JvSa)
+**Links:** [Website](https://astralbeam.ai) · [Docs](https://app.astralbeam.ai/docs) · [Discord](https://discord.gg/S7j384JvSa) · [Cloud](https://app.astralbeam.ai)
 
 Adding agents to a web app today involves patching together a bunch of frontend libraries, backend frameworks, LLM providers, observability tools, billing APIs, etc. which is time-taking and error-prone.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # AstralBeam
 
+**Links:** [Website](https://astralbeam.ai) · [Docs](https://app.astralbeam.ai/docs) · [Hosted app](https://app.astralbeam.ai) · [Discord](https://discord.gg/S7j384JvSa)
+
 Adding agents to a web app today involves patching together a bunch of frontend libraries, backend frameworks, LLM providers, observability tools, billing APIs, etc. which is time-taking and error-prone.
 
 [AstralBeam](https://astralbeam.ai) aims to provide a single service developers can integrate to add production-ready agents to any web app:

--- a/examples/todos/README.md
+++ b/examples/todos/README.md
@@ -32,7 +32,7 @@ The quickest path is `deno task --cwd webapp db-seed`, which creates the `acme` 
 8. With a sandbox provider on the agent, ask it for something that needs code: "write a script that exports my todos as CSV and run it".
 9. Each sandbox step appears as an expandable row. While the sandbox provisions, a slim status pill sits above the composer; the **Sandbox** panel (opt-in via `sandboxPanel`) collects every file it wrote — each downloadable — and the whole command log.
 
-The token route is local-demo-only: it grants every caller the fixed demo identity, so do not deploy it unchanged. Real hosts must derive stable `tenant.id` and tenant-local `user.id` values from their authenticated application session, never trust a browser-supplied identity, and avoid secrets because JWT payloads are signed but not encrypted.
+The token route is local-demo-only: it grants every caller the fixed demo identity, so do not deploy it unchanged. As a backstop it answers 503 whenever `NODE_ENV` is `production`, so a deployed copy mints nothing until it is rewritten. Real hosts must derive stable `tenant.id` and tenant-local `user.id` values from their authenticated application session, never trust a browser-supplied identity, and avoid secrets because JWT payloads are signed but not encrypted.
 
 ## Automated checks
 

--- a/examples/todos/src/lib/config.server.ts
+++ b/examples/todos/src/lib/config.server.ts
@@ -1,3 +1,4 @@
 import process from "node:process"
 
 export const API_KEY = process.env["ASTRALBEAM_API_KEY"]
+export const IS_PRODUCTION = process.env["NODE_ENV"] === "production"

--- a/examples/todos/src/routes/api/astralbeam/token.ts
+++ b/examples/todos/src/routes/api/astralbeam/token.ts
@@ -1,7 +1,7 @@
 import { createChatAuthToken } from "@astralbeam/sdk/server"
 import { createFileRoute } from "@tanstack/react-router"
 
-import { API_KEY } from "@/lib/config.server.ts"
+import { API_KEY, IS_PRODUCTION } from "@/lib/config.server.ts"
 import { DEMO_CHAT_TENANT, DEMO_CHAT_USER } from "@/lib/constants.server.ts"
 
 // A cached token would outlive its short expiry, so every answer carries no-store.
@@ -13,6 +13,10 @@ export const Route = createFileRoute("/api/astralbeam/token")({
   server: {
     handlers: {
       POST: async () => {
+        // This route hands the fixed demo identity to any caller, so it never runs in production.
+        if (IS_PRODUCTION) {
+          return tokenResponse({ error: "The demo token route is disabled in production" }, 503)
+        }
         if (!API_KEY) {
           return tokenResponse({ error: "The AstralBeam API key is not configured" }, 503)
         }

--- a/www/public/_headers
+++ b/www/public/_headers
@@ -1,0 +1,8 @@
+# Vite inlines the smallest font subsets as `data:` URLs and Astro emits an inline `<style>` on
+# some pages, so `font-src` allows `data:` and `style-src` allows `'unsafe-inline'`.
+/*
+  Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin
+  Strict-Transport-Security: max-age=63072000; includeSubDomains
+  Permissions-Policy: camera=(), microphone=(), geolocation=()

--- a/www/scripts/verify-build.test.ts
+++ b/www/scripts/verify-build.test.ts
@@ -102,19 +102,30 @@ describe("production website build", () => {
   })
 
   test("publishes discovery files", async () => {
-    const [robots, llms, licenses, sitemapIndex, sitemap, manifestText, mitLicense, oflLicense] =
-      await Promise.all([
-        readText("robots.txt"),
-        readText("llms.txt"),
-        readText("licenses.txt"),
-        readText("sitemap-index.xml"),
-        readText("sitemap-0.xml"),
-        readText("site.webmanifest"),
-        readFile(new URL("../../LICENSE-MIT", import.meta.url), "utf8"),
-        readFile(new URL("../../docs/legal/LICENSES/OFL-1.1.txt", import.meta.url), "utf8"),
-      ])
+    const [
+      headers,
+      robots,
+      llms,
+      licenses,
+      sitemapIndex,
+      sitemap,
+      manifestText,
+      mitLicense,
+      oflLicense,
+    ] = await Promise.all([
+      readText("_headers"),
+      readText("robots.txt"),
+      readText("llms.txt"),
+      readText("licenses.txt"),
+      readText("sitemap-index.xml"),
+      readText("sitemap-0.xml"),
+      readText("site.webmanifest"),
+      readFile(new URL("../../LICENSE-MIT", import.meta.url), "utf8"),
+      readFile(new URL("../../docs/legal/LICENSES/OFL-1.1.txt", import.meta.url), "utf8"),
+    ])
     const manifest: unknown = JSON.parse(manifestText)
 
+    expect(headers).toContain("frame-ancestors 'none'")
     expect(robots).toContain(`Sitemap: ${origin}/sitemap-index.xml`)
     expect(llms).toMatch(/^# AstralBeam$/mu)
     expect(llms).toContain(homeUrl)

--- a/www/src/pages/index.astro
+++ b/www/src/pages/index.astro
@@ -3,7 +3,8 @@ import astralbeamDarkWordmarkUrl from "@/assets/astralbeam-wordmark-dark.svg?url
 import SiteLayout from "@/layouts/SiteLayout.astro"
 import { siteMetadata } from "@/lib/site"
 
-const waitlistUrl = "https://airtable.com/app5bJZxFB5NoPBUX/paghAGYUoz5JoIQDs/form"
+const appUrl = "https://app.astralbeam.ai"
+const discordUrl = "https://discord.gg/S7j384JvSa"
 
 const features = [
   {
@@ -90,9 +91,10 @@ const githubUrl = "https://github.com/astralbeamai/astralbeam"
         </svg>
         <span class="hud-nav-label">GITHUB</span>
       </a>
+      <a href={discordUrl} target="_blank" rel="noopener noreferrer">DISCORD</a>
     </nav>
-    <a class="btn btn-primary hud-cta" href={waitlistUrl} target="_blank" rel="noopener noreferrer">
-        JOIN WAITLIST
+    <a class="btn btn-primary hud-cta" href={appUrl}>
+        OPEN THE APP
       </a>
   </header>
 
@@ -112,9 +114,8 @@ const githubUrl = "https://github.com/astralbeamai/astralbeam"
             Add agentic chat to your web app in five minutes or less. AstralBeam handles streaming, history, tools, billing and more...
           </p>
         <div class="hero-ctas reveal" style="--reveal-delay:.48s">
-          <a class="btn btn-primary btn-lg" href={waitlistUrl} target="_blank"
-            rel="noopener noreferrer">
-              JOIN WAITLIST
+          <a class="btn btn-primary btn-lg" href={appUrl}>
+              OPEN THE APP
             </a>
           <a class="btn btn-ghost btn-lg" href={githubUrl} target="_blank"
             rel="noopener noreferrer">
@@ -444,12 +445,14 @@ const githubUrl = "https://github.com/astralbeamai/astralbeam"
       <h2 class="display launch-title reveal scramble"
         data-text="READY FOR LAUNCH">READY FOR LAUNCH</h2>
       <p class="section-sub launch-sub reveal">
-          Get started with a few lines of code. Join the waitlist for early access.
+          Get started with a few lines of code, or come talk to us on Discord.
         </p>
-      <div class="reveal" style="--reveal-delay:.2s">
-        <a class="btn btn-primary btn-xl" href={waitlistUrl} target="_blank"
-          rel="noopener noreferrer">
-            JOIN WAITLIST
+      <div class="launch-ctas reveal" style="--reveal-delay:.2s">
+        <a class="btn btn-primary btn-xl" href={appUrl}>
+            OPEN THE APP
+          </a>
+        <a class="btn btn-ghost btn-xl" href={discordUrl} target="_blank" rel="noopener noreferrer">
+            JOIN THE DISCORD
           </a>
       </div>
     </section>
@@ -458,6 +461,7 @@ const githubUrl = "https://github.com/astralbeamai/astralbeam"
   <footer class="site-footer mono">
     <span>© 2026 ASTRALBEAM</span>
     <a href={githubUrl} target="_blank" rel="noopener noreferrer">GITHUB</a>
+    <a href={discordUrl} target="_blank" rel="noopener noreferrer">DISCORD</a>
     <a href="mailto:hello@astralbeam.ai">HELLO@ASTRALBEAM.AI</a>
     <a href="/terms">TERMS</a>
     <a href="/privacy">PRIVACY</a>

--- a/www/src/pages/index.astro
+++ b/www/src/pages/index.astro
@@ -3,7 +3,8 @@ import astralbeamDarkWordmarkUrl from "@/assets/astralbeam-wordmark-dark.svg?url
 import SiteLayout from "@/layouts/SiteLayout.astro"
 import { siteMetadata } from "@/lib/site"
 
-const appUrl = "https://app.astralbeam.ai"
+const signUpUrl = "https://app.astralbeam.ai/auth/sign-up"
+const logInUrl = "https://app.astralbeam.ai/auth/sign-in"
 const discordUrl = "https://discord.gg/S7j384JvSa"
 
 const features = [
@@ -80,21 +81,26 @@ const githubUrl = "https://github.com/astralbeamai/astralbeam"
         height="136" />
     </a>
     <nav class="hud-nav" aria-label="Primary">
-      <a href="#quickstart">QUICKSTART</a>
-      <a href="#features">FEATURES</a>
-      <a href="#open-source">OPEN&nbsp;SOURCE</a>
-      <a class="hud-nav-github" href={githubUrl} target="_blank" rel="noopener noreferrer"
+      <a class="hud-nav-social" href={githubUrl} target="_blank" rel="noopener noreferrer"
         aria-label="AstralBeam on GitHub">
-        <svg class="icon-github" viewBox="0 0 16 16" aria-hidden="true">
+        <svg class="icon-social" viewBox="0 0 16 16" aria-hidden="true">
           <path
             d="M8 0a8 8 0 0 0-2.53 15.59c.4.07.55-.17.55-.38l-.01-1.34c-2.23.48-2.7-1.07-2.7-1.07-.36-.93-.89-1.18-.89-1.18-.73-.5.05-.49.05-.49.8.06 1.23.83 1.23.83.72 1.23 1.88.87 2.34.67.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.28.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48l-.01 2.2c0 .21.14.46.55.38A8 8 0 0 0 8 0z"></path>
         </svg>
         <span class="hud-nav-label">GITHUB</span>
       </a>
-      <a href={discordUrl} target="_blank" rel="noopener noreferrer">DISCORD</a>
+      <a class="hud-nav-social" href={discordUrl} target="_blank" rel="noopener noreferrer"
+        aria-label="AstralBeam on Discord">
+        <svg class="icon-social" viewBox="0 0 16 16" aria-hidden="true">
+          <path
+            d="M13.545 2.907A13.2 13.2 0 0 0 10.29 1.9a.05.05 0 0 0-.052.025c-.141.25-.297.577-.406.833a12.2 12.2 0 0 0-3.658 0 8 8 0 0 0-.412-.833.05.05 0 0 0-.052-.025c-1.125.194-2.22.534-3.257 1.007a.04.04 0 0 0-.021.018C.356 6.024-.213 9.047.066 12.032q.003.022.021.033a13.3 13.3 0 0 0 3.995 2.02.05.05 0 0 0 .056-.019q.463-.63.818-1.329a.05.05 0 0 0-.01-.059l-.018-.011a8.9 8.9 0 0 1-1.248-.595.05.05 0 0 1-.02-.066l.015-.019q.127-.095.248-.195a.05.05 0 0 1 .051-.007c2.619 1.196 5.454 1.196 8.041 0a.05.05 0 0 1 .053.007q.121.1.248.195a.05.05 0 0 1-.004.085 8.3 8.3 0 0 1-1.249.594.05.05 0 0 0-.03.03.05.05 0 0 0 .003.041c.24.465.515.909.817 1.329a.05.05 0 0 0 .056.019 13.2 13.2 0 0 0 4.001-2.02.05.05 0 0 0 .021-.037c.334-3.451-.559-6.449-2.365-9.108a.04.04 0 0 0-.02-.018m-8.198 7.307c-.789 0-1.438-.724-1.438-1.612s.637-1.613 1.438-1.613c.807 0 1.45.73 1.438 1.613 0 .888-.637 1.612-1.438 1.612m5.316 0c-.788 0-1.438-.724-1.438-1.612s.637-1.613 1.438-1.613c.807 0 1.451.73 1.438 1.613 0 .888-.63 1.612-1.438 1.612"></path>
+        </svg>
+        <span class="hud-nav-label">DISCORD</span>
+      </a>
+      <a href={logInUrl}>LOG IN</a>
     </nav>
-    <a class="btn btn-primary hud-cta" href={appUrl}>
-        OPEN THE APP
+    <a class="btn btn-primary hud-cta" href={signUpUrl}>
+        GET STARTED
       </a>
   </header>
 
@@ -114,12 +120,12 @@ const githubUrl = "https://github.com/astralbeamai/astralbeam"
             Add agentic chat to your web app in five minutes or less. AstralBeam handles streaming, history, tools, billing and more...
           </p>
         <div class="hero-ctas reveal" style="--reveal-delay:.48s">
-          <a class="btn btn-primary btn-lg" href={appUrl}>
-              OPEN THE APP
+          <a class="btn btn-primary btn-lg" href={signUpUrl}>
+              GET STARTED
             </a>
           <a class="btn btn-ghost btn-lg" href={githubUrl} target="_blank"
             rel="noopener noreferrer">
-              <svg class="icon-github" viewBox="0 0 16 16" aria-hidden="true"><path d="M8 0a8 8 0 0 0-2.53 15.59c.4.07.55-.17.55-.38l-.01-1.34c-2.23.48-2.7-1.07-2.7-1.07-.36-.93-.89-1.18-.89-1.18-.73-.5.05-.49.05-.49.8.06 1.23.83 1.23.83.72 1.23 1.88.87 2.34.67.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.28.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48l-.01 2.2c0 .21.14.46.55.38A8 8 0 0 0 8 0z"></path></svg>
+              <svg class="icon-social" viewBox="0 0 16 16" aria-hidden="true"><path d="M8 0a8 8 0 0 0-2.53 15.59c.4.07.55-.17.55-.38l-.01-1.34c-2.23.48-2.7-1.07-2.7-1.07-.36-.93-.89-1.18-.89-1.18-.73-.5.05-.49.05-.49.8.06 1.23.83 1.23.83.72 1.23 1.88.87 2.34.67.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.28.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48l-.01 2.2c0 .21.14.46.55.38A8 8 0 0 0 8 0z"></path></svg>
               STAR ON GITHUB
             </a>
         </div>
@@ -433,7 +439,7 @@ const githubUrl = "https://github.com/astralbeamai/astralbeam"
 
       <div class="os-repo reveal" style="--reveal-delay:.35s">
         <a class="btn btn-ghost btn-lg" href={githubUrl} target="_blank" rel="noopener noreferrer">
-            <svg class="icon-github" viewBox="0 0 16 16" aria-hidden="true"><path d="M8 0a8 8 0 0 0-2.53 15.59c.4.07.55-.17.55-.38l-.01-1.34c-2.23.48-2.7-1.07-2.7-1.07-.36-.93-.89-1.18-.89-1.18-.73-.5.05-.49.05-.49.8.06 1.23.83 1.23.83.72 1.23 1.88.87 2.34.67.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.28.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48l-.01 2.2c0 .21.14.46.55.38A8 8 0 0 0 8 0z"></path></svg>
+            <svg class="icon-social" viewBox="0 0 16 16" aria-hidden="true"><path d="M8 0a8 8 0 0 0-2.53 15.59c.4.07.55-.17.55-.38l-.01-1.34c-2.23.48-2.7-1.07-2.7-1.07-.36-.93-.89-1.18-.89-1.18-.73-.5.05-.49.05-.49.8.06 1.23.83 1.23.83.72 1.23 1.88.87 2.34.67.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.28.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48l-.01 2.2c0 .21.14.46.55.38A8 8 0 0 0 8 0z"></path></svg>
             BROWSE THE SOURCE
           </a>
       </div>
@@ -448,10 +454,11 @@ const githubUrl = "https://github.com/astralbeamai/astralbeam"
           Get started with a few lines of code, or come talk to us on Discord.
         </p>
       <div class="launch-ctas reveal" style="--reveal-delay:.2s">
-        <a class="btn btn-primary btn-xl" href={appUrl}>
-            OPEN THE APP
+        <a class="btn btn-primary btn-xl" href={signUpUrl}>
+            GET STARTED
           </a>
         <a class="btn btn-ghost btn-xl" href={discordUrl} target="_blank" rel="noopener noreferrer">
+            <svg class="icon-social" viewBox="0 0 16 16" aria-hidden="true"><path d="M13.545 2.907A13.2 13.2 0 0 0 10.29 1.9a.05.05 0 0 0-.052.025c-.141.25-.297.577-.406.833a12.2 12.2 0 0 0-3.658 0 8 8 0 0 0-.412-.833.05.05 0 0 0-.052-.025c-1.125.194-2.22.534-3.257 1.007a.04.04 0 0 0-.021.018C.356 6.024-.213 9.047.066 12.032q.003.022.021.033a13.3 13.3 0 0 0 3.995 2.02.05.05 0 0 0 .056-.019q.463-.63.818-1.329a.05.05 0 0 0-.01-.059l-.018-.011a8.9 8.9 0 0 1-1.248-.595.05.05 0 0 1-.02-.066l.015-.019q.127-.095.248-.195a.05.05 0 0 1 .051-.007c2.619 1.196 5.454 1.196 8.041 0a.05.05 0 0 1 .053.007q.121.1.248.195a.05.05 0 0 1-.004.085 8.3 8.3 0 0 1-1.249.594.05.05 0 0 0-.03.03.05.05 0 0 0 .003.041c.24.465.515.909.817 1.329a.05.05 0 0 0 .056.019 13.2 13.2 0 0 0 4.001-2.02.05.05 0 0 0 .021-.037c.334-3.451-.559-6.449-2.365-9.108a.04.04 0 0 0-.02-.018m-8.198 7.307c-.789 0-1.438-.724-1.438-1.612s.637-1.613 1.438-1.613c.807 0 1.45.73 1.438 1.613 0 .888-.637 1.612-1.438 1.612m5.316 0c-.788 0-1.438-.724-1.438-1.612s.637-1.613 1.438-1.613c.807 0 1.451.73 1.438 1.613 0 .888-.63 1.612-1.438 1.612"></path></svg>
             JOIN THE DISCORD
           </a>
       </div>

--- a/www/src/pages/llms.txt.ts
+++ b/www/src/pages/llms.txt.ts
@@ -33,7 +33,7 @@ Drop in the AstralBeam frontend SDK, and AstralBeam handles agentic chat, stream
 ## Links
 
 - [Home](${homeUrl}): Product overview, features, and deployment model.
-- [Hosted app](https://app.astralbeam.ai): Log in to AstralBeam Cloud, the managed dashboard.
+- [Hosted app](https://app.astralbeam.ai): Sign up for or log in to AstralBeam Cloud, the managed dashboard.
 - [Documentation](https://app.astralbeam.ai/docs): Guides and reference for the SDK and the platform.
 - [Source code](https://github.com/astralbeamai/astralbeam): The open-source platform under AGPL-3.0.
 - [Discord](https://discord.gg/S7j384JvSa): Community chat with the AstralBeam team.

--- a/www/src/pages/llms.txt.ts
+++ b/www/src/pages/llms.txt.ts
@@ -32,8 +32,11 @@ Drop in the AstralBeam frontend SDK, and AstralBeam handles agentic chat, stream
 
 ## Links
 
-- [Home](${homeUrl}): Product overview, features, deployment model, and early-access waitlist.
+- [Home](${homeUrl}): Product overview, features, and deployment model.
+- [Hosted app](https://app.astralbeam.ai): Log in to AstralBeam Cloud, the managed dashboard.
+- [Documentation](https://app.astralbeam.ai/docs): Guides and reference for the SDK and the platform.
 - [Source code](https://github.com/astralbeamai/astralbeam): The open-source platform under AGPL-3.0.
+- [Discord](https://discord.gg/S7j384JvSa): Community chat with the AstralBeam team.
 
 ## Contact
 

--- a/www/src/styles/global.css
+++ b/www/src/styles/global.css
@@ -1374,6 +1374,13 @@ main {
   margin: 1.6rem auto 2.6rem;
 }
 
+.launch-ctas {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1rem;
+}
+
 /* ---------- footer ---------- */
 
 .site-footer {

--- a/www/src/styles/global.css
+++ b/www/src/styles/global.css
@@ -295,6 +295,7 @@ a[href] {
 
 .hud-nav a {
   cursor: pointer;
+  white-space: nowrap;
   color: var(--text-chrome);
   transition:
     color 0.2s,
@@ -306,13 +307,13 @@ a[href] {
   text-shadow: 0 0 12px var(--beam-soft);
 }
 
-.hud-nav-github {
+.hud-nav-social {
   display: inline-flex;
   align-items: center;
   gap: 0.45rem;
 }
 
-.icon-github {
+.icon-social {
   width: 1.05em;
   height: 1.05em;
   fill: currentColor;
@@ -1423,8 +1424,8 @@ main {
   }
 }
 
-/* The wordmark, four nav links, and the CTA stop fitting on one line before
-   the nav is dropped entirely at 640px, so tighten them first. */
+/* The wordmark, the nav, and the CTA stop fitting on one line well before the
+   narrowest phones, so tighten them in two steps. */
 @media (max-width: 820px) {
   .hud-top {
     gap: 1.25rem;
@@ -1451,16 +1452,22 @@ main {
     padding: 0.8rem 1rem;
   }
   .hud-nav {
+    gap: 0.7rem;
+    font-size: 0.6rem;
+    letter-spacing: 0.08em;
+  }
+  /* Only the log-in link fits beside the wordmark and the CTA on a phone;
+     GitHub and Discord stay one tap away in the footer. */
+  .hud-nav-social {
     display: none;
   }
   .hud-cta {
-    margin-left: auto;
     font-size: 0.62rem;
     padding: 0.6rem 0.9rem;
     letter-spacing: 0.1em;
   }
   .hud-brand-wordmark {
-    height: clamp(16px, 4.6vw, 18px);
+    height: clamp(14px, 4vw, 16px);
   }
   .features-grid,
   .os-grid {


### PR DESCRIPTION
- Replaces the Airtable waitlist on `www` with a `GET STARTED` primary call to action pointing at <https://app.astralbeam.ai/auth/sign-up>, in the header, the hero, and the closing section, reusing the existing `btn` classes.
- Trims the header nav to GitHub, Discord, `LOG IN` (<https://app.astralbeam.ai/auth/sign-in>), and the `GET STARTED` button; the in-page `QUICKSTART`, `FEATURES`, and `OPEN SOURCE` links are gone, and both social links carry their brand mark so the nav iconography is consistent.
- Adds Discord (<https://discord.gg/S7j384JvSa>) as a nav link, a `JOIN THE DISCORD` secondary button in the closing section, and a footer link; the closing copy now reads "Get started with a few lines of code, or come talk to us on Discord."
- Below 640px the two social links drop out so the wordmark, `LOG IN`, and the CTA fit on one line down to 360px; GitHub and Discord stay reachable in the footer.
- Removes the Airtable URL entirely and updates `llms.txt` to drop the early-access waitlist wording, adding hosted-app, documentation, and Discord links.
- Adds a `Links` line near the top of the root `README.md` for the website, docs, hosted app, and Discord.
- Adds `www/public/_headers` so the Cloudflare static assets send a CSP plus `X-Content-Type-Options`, `Referrer-Policy`, `Strict-Transport-Security`, and `Permissions-Policy`; Astro copies it into `dist/`.
- CSP audit of `dist/`: the only inline `<script>` is the `ld+json` block, page scripts are bundled to `/_astro/*.js`, the bundle has no `fetch`/`eval`/`WebSocket`, and there are no inline event handlers or external resource loads. Two directives are loosened and commented in the file: `style-src` needs `'unsafe-inline'` because Astro inlines a `<style>` on the legal pages and the page sets `--reveal-delay` style attributes, and `font-src` needs `data:` because Vite inlines six small `@fontsource` subsets as `data:font/woff2` URLs.
- Fences the todos demo token route: `POST /api/astralbeam/token` answers `503 {"error":"The demo token route is disabled in production"}` when `NODE_ENV` is `production`, keeping `cache-control: no-store` and the existing error shape, and the README's demo-only warning now says so.

Validation: `deno task ready` from `www` (check, build, 7 tests, including a new assertion that `dist/_headers` exists and contains `frame-ancestors 'none'`) and from `examples/todos` (check, 3 tests, build) after `deno task --cwd sdk build`; the built site served with the `_headers` values applied loads in headless Chromium at 1440px, 390px, and 360px with an empty console and no header overflow — no CSP violations, page errors, or failed requests — and the built todos server started with `NODE_ENV=production` returns the 503 above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
