### PR TITLE
Fix expired Discord invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AstralBeam
 
-**Links:** [Website](https://astralbeam.ai) · [Docs](https://app.astralbeam.ai/docs) · [Discord](https://discord.gg/S7j384JvSa) · [Cloud](https://app.astralbeam.ai)
+**Links:** [Website](https://astralbeam.ai) · [Docs](https://app.astralbeam.ai/docs) · [Discord](https://discord.gg/suehFycUvW) · [Cloud](https://app.astralbeam.ai)
 
 Adding agents to a web app today involves patching together a bunch of frontend libraries, backend frameworks, LLM providers, observability tools, billing APIs, etc. which is time-taking and error-prone.
 

--- a/www/src/pages/index.astro
+++ b/www/src/pages/index.astro
@@ -5,7 +5,7 @@ import { siteMetadata } from "@/lib/site"
 
 const signUpUrl = "https://app.astralbeam.ai/auth/sign-up"
 const logInUrl = "https://app.astralbeam.ai/auth/sign-in"
-const discordUrl = "https://discord.gg/S7j384JvSa"
+const discordUrl = "https://discord.gg/suehFycUvW"
 
 const features = [
   {

--- a/www/src/pages/llms.txt.ts
+++ b/www/src/pages/llms.txt.ts
@@ -36,7 +36,7 @@ Drop in the AstralBeam frontend SDK, and AstralBeam handles agentic chat, stream
 - [Hosted app](https://app.astralbeam.ai): Sign up for or log in to AstralBeam Cloud, the managed dashboard.
 - [Documentation](https://app.astralbeam.ai/docs): Guides and reference for the SDK and the platform.
 - [Source code](https://github.com/astralbeamai/astralbeam): The open-source platform under AGPL-3.0.
-- [Discord](https://discord.gg/S7j384JvSa): Community chat with the AstralBeam team.
+- [Discord](https://discord.gg/suehFycUvW): Community chat with the AstralBeam team.
 
 ## Contact
 


### PR DESCRIPTION
- Update the Discord invite link from the expired `discord.gg/S7j384JvSa` to `discord.gg/suehFycUvW` in `README.md`, `www/src/pages/index.astro`, and `www/src/pages/llms.txt.ts`
