### PR TITLE
Remove hero/launch beam lines, even out launch CTA widths

### DIFF
--- a/www/src/pages/index.astro
+++ b/www/src/pages/index.astro
@@ -107,8 +107,6 @@ const githubUrl = "https://github.com/astralbeamai/astralbeam"
   <main>
     <!-- ============ HERO ============ -->
     <section class="hero" id="top">
-      <div class="hero-beam" aria-hidden="true"></div>
-
       <div class="hero-inner">
         <p class="eyebrow reveal">OPEN SOURCE AI INFRASTRUCTURE</p>
         <h1 class="display hero-title">
@@ -447,7 +445,6 @@ const githubUrl = "https://github.com/astralbeamai/astralbeam"
 
     <!-- ============ LAUNCH ============ -->
     <section class="section launch" id="launch">
-      <div class="launch-beam" aria-hidden="true"></div>
       <h2 class="display launch-title reveal scramble"
         data-text="READY FOR LAUNCH">READY FOR LAUNCH</h2>
       <p class="section-sub launch-sub reveal">
@@ -459,7 +456,7 @@ const githubUrl = "https://github.com/astralbeamai/astralbeam"
           </a>
         <a class="btn btn-ghost btn-xl" href={discordUrl} target="_blank" rel="noopener noreferrer">
             <svg class="icon-social" viewBox="0 0 16 16" aria-hidden="true"><path d="M13.545 2.907A13.2 13.2 0 0 0 10.29 1.9a.05.05 0 0 0-.052.025c-.141.25-.297.577-.406.833a12.2 12.2 0 0 0-3.658 0 8 8 0 0 0-.412-.833.05.05 0 0 0-.052-.025c-1.125.194-2.22.534-3.257 1.007a.04.04 0 0 0-.021.018C.356 6.024-.213 9.047.066 12.032q.003.022.021.033a13.3 13.3 0 0 0 3.995 2.02.05.05 0 0 0 .056-.019q.463-.63.818-1.329a.05.05 0 0 0-.01-.059l-.018-.011a8.9 8.9 0 0 1-1.248-.595.05.05 0 0 1-.02-.066l.015-.019q.127-.095.248-.195a.05.05 0 0 1 .051-.007c2.619 1.196 5.454 1.196 8.041 0a.05.05 0 0 1 .053.007q.121.1.248.195a.05.05 0 0 1-.004.085 8.3 8.3 0 0 1-1.249.594.05.05 0 0 0-.03.03.05.05 0 0 0 .003.041c.24.465.515.909.817 1.329a.05.05 0 0 0 .056.019 13.2 13.2 0 0 0 4.001-2.02.05.05 0 0 0 .021-.037c.334-3.451-.559-6.449-2.365-9.108a.04.04 0 0 0-.02-.018m-8.198 7.307c-.789 0-1.438-.724-1.438-1.612s.637-1.613 1.438-1.613c.807 0 1.45.73 1.438 1.613 0 .888-.637 1.612-1.438 1.612m5.316 0c-.788 0-1.438-.724-1.438-1.612s.637-1.613 1.438-1.613c.807 0 1.451.73 1.438 1.613 0 .888-.63 1.612-1.438 1.612"></path></svg>
-            JOIN THE DISCORD
+            JOIN DISCORD
           </a>
       </div>
     </section>

--- a/www/src/styles/global.css
+++ b/www/src/styles/global.css
@@ -428,51 +428,6 @@ main {
   padding: 6.5rem 1.5rem 7rem;
 }
 
-.hero-beam {
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 50%;
-  width: 2px;
-  transform: translateX(-50%);
-  background: linear-gradient(
-    to bottom,
-    transparent 0%,
-    var(--beam-faint) 18%,
-    color-mix(in srgb, var(--primary) 50%, transparent) 50%,
-    var(--beam-faint) 82%,
-    transparent 100%
-  );
-  filter: blur(0.5px);
-  animation: beam-pulse 5s ease-in-out infinite;
-  pointer-events: none;
-}
-
-.hero-beam::before {
-  content: "";
-  position: absolute;
-  inset: 0 -34px;
-  background: linear-gradient(
-    to bottom,
-    transparent,
-    color-mix(in srgb, var(--primary) 4.5%, transparent) 35%,
-    color-mix(in srgb, var(--primary) 8.5%, transparent) 50%,
-    color-mix(in srgb, var(--primary) 4.5%, transparent) 65%,
-    transparent
-  );
-  filter: blur(14px);
-}
-
-@keyframes beam-pulse {
-  0%,
-  100% {
-    opacity: 0.75;
-  }
-  50% {
-    opacity: 1;
-  }
-}
-
 .hero-inner {
   position: relative;
   max-width: 72rem;
@@ -1347,22 +1302,6 @@ main {
   justify-content: center;
 }
 
-.launch-beam {
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 50%;
-  width: 1px;
-  transform: translateX(-50%);
-  background: linear-gradient(
-    to bottom,
-    transparent,
-    color-mix(in srgb, var(--primary) 40%, transparent),
-    transparent
-  );
-  pointer-events: none;
-}
-
 .launch-title {
   font-size: clamp(3rem, 10vw, 8rem);
   color: var(--primary);
@@ -1376,9 +1315,12 @@ main {
 }
 
 .launch-ctas {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
+  margin: 0 auto;
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: 1fr;
+  width: fit-content;
+  align-items: center;
   gap: 1rem;
 }
 
@@ -1493,7 +1435,8 @@ main {
     padding: 0.7rem 1.05rem;
   }
   /* Stack the CTAs; the single implicit column keeps them the same width. */
-  .hero-ctas {
+  .hero-ctas,
+  .launch-ctas {
     grid-auto-flow: row;
   }
 }
@@ -1512,7 +1455,6 @@ main {
   }
 
   .fx-scanlines::after,
-  .hero-beam,
   .scroll-chevron,
   .blink-dot,
   .t-caret,


### PR DESCRIPTION
- Remove the vertical `.hero-beam` and `.launch-beam` divs and their CSS (including the now-unused `beam-pulse` keyframes) that cut a line through the middle of the hero and launch sections.
- Rename the launch section's Discord button from "JOIN THE DISCORD" to "JOIN DISCORD".
- Switch `.launch-ctas` to the same equal-width CSS grid layout already used by `.hero-ctas`, so the "GET STARTED" and "JOIN DISCORD" buttons match widths.