### PR TITLE
Prerender docs with ETag revalidation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@
 - Name planning documents with the `*.plan.md` suffix so they are distinguishable from durable documentation.
 - Keep plans and PR descriptions concise and evidence-backed; plans must still include motivation, authoritative references, affected files and API anchors, validation, and boundaries.
 - Keep each Markdown paragraph and list item on one source line.
+- Avoid semicolons and em dashes in documentation and Markdown prose. Use periods or commas instead.
 - Comment only non-obvious code or configuration decisions, including a link to authoritative documentation or an issue.
 - Keep code comments to at most two lines; longer reasoning belongs in the nearest `AGENTS.md` or a linked issue.
 

--- a/webapp/AGENTS.md
+++ b/webapp/AGENTS.md
@@ -58,6 +58,7 @@
   - Routes that do not render pages might be server routes (`createFileRoute({ server ... }))`
     - The are typically place in the `routes/api` folder unless there's a strong reason to have them outside.
   - Keep `/dev` utilities synthetic and development-only; they must return `404` in production.
+  - Keep prerendered docs generic. Load user-specific tokens and snippets client-side from authenticated responses marked `private, no-store`, and never serialize them into generated HTML or override their explicit cache policy.
   - Related routes can sometimes be grouped together using a route group folder e.g. `(auth)` if it better structures the codebase
 
 - `src/db` contains the database schema and migrations

--- a/webapp/knip.jsonc
+++ b/webapp/knip.jsonc
@@ -23,9 +23,10 @@
   // @daytona/sdk also `createRequire`s busboy at download time, which the built server bundle keeps
   // as a runtime specifier; webapp declares busboy only so that require resolves.
   "ignoreDependencies": ["busboy", "tslib"],
-  // Keep Deno-run generators and the TanStack Router and Start entries explicit.
+  // Keep Deno-run generators and framework entry points explicit.
   "entry": [
     "scripts/*.ts",
+    "src/lib/response-headers.server.ts",
     "src/router.tsx",
     "src/start.ts"
   ]

--- a/webapp/scripts/check-binary.ts
+++ b/webapp/scripts/check-binary.ts
@@ -136,6 +136,21 @@ async function runBinaryCheck() {
     if (!(await stylesheetResponse.text())) {
       throw new Error("Binary served an empty stylesheet")
     }
+
+    const docsUrl = new URL("/docs/sdk/getting-started", baseUrl)
+    const docs = await fetchBinaryCheckResponse(docsUrl)
+    const etag = docs.headers.get("etag")
+    await docs.body?.cancel()
+    if (
+      !etag || docs.headers.get("cache-control") !== "public, no-cache" ||
+      docs.headers.get("content-security-policy") !== "frame-ancestors 'none'"
+    ) {
+      throw new Error("Binary did not serve docs with cache and security headers")
+    }
+    const cached = await fetch(docsUrl, { headers: { "If-None-Match": etag } })
+    if (cached.status !== 304) {
+      throw new Error("Binary did not revalidate unchanged docs")
+    }
   } finally {
     try {
       await stopBinaryCheckProcess(binaryProcess, status)

--- a/webapp/src/lib/response-headers.server.ts
+++ b/webapp/src/lib/response-headers.server.ts
@@ -1,0 +1,57 @@
+import type { NitroAppPlugin } from "nitro/types"
+
+// The SDK widget loads these routes from a customer's own origin, so they must stay framable and
+// keep the CSP that `/api/chat/files` sets on downloaded artifacts.
+const EMBEDDED_API_BASE_PATH = "/api/chat"
+
+// One year is the shortest max-age the preload list accepts.
+// https://hstspreload.org/#deployment-recommendations
+const STRICT_TRANSPORT_SECURITY = "max-age=63072000; includeSubDomains"
+
+// Only features the app never uses; anything unlisted keeps its browser default.
+// https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Permissions-Policy
+const PERMISSIONS_POLICY =
+  "camera=(), display-capture=(), geolocation=(), microphone=(), payment=(), usb=()"
+
+function isSecureRequest(request: Request): boolean {
+  if (new URL(request.url).protocol === "https:") return true
+  // A forged value only adds a header browsers ignore over plain HTTP, so the proxy's protocol
+  // does not need the loopback check that `/configure` applies before enforcing HTTPS.
+  return request.headers.get("x-forwarded-proto")?.split(",")[0]?.trim() === "https"
+}
+
+function isEmbeddedApiPath(pathname: string): boolean {
+  return pathname === EMBEDDED_API_BASE_PATH ||
+    pathname.startsWith(`${EMBEDDED_API_BASE_PATH}/`)
+}
+
+export function applyResponseSecurityHeaders(
+  headers: Headers,
+  request: Request,
+  pathname: string,
+): void {
+  if (
+    (pathname === "/docs" || pathname.startsWith("/docs/")) && !headers.has("Cache-Control")
+  ) {
+    headers.set("Cache-Control", "public, no-cache")
+  }
+  if (isSecureRequest(request)) headers.set("Strict-Transport-Security", STRICT_TRANSPORT_SECURITY)
+  headers.set("X-Content-Type-Options", "nosniff")
+  headers.set("Referrer-Policy", "strict-origin-when-cross-origin")
+  headers.set("Permissions-Policy", PERMISSIONS_POLICY)
+  if (isEmbeddedApiPath(pathname)) return
+  headers.set("X-Frame-Options", "DENY")
+  // Script and style directives are deliberately absent: the framework's inline bootstrap,
+  // Turnstile, and the docs pages each need their own allowlist audit first.
+  headers.set("Content-Security-Policy", "frame-ancestors 'none'")
+}
+
+const responseHeadersPlugin: NitroAppPlugin = (nitro) => {
+  nitro.hooks.hook("response", (response, event) => {
+    const pathname = new URL(event.req.url).pathname
+    applyResponseSecurityHeaders(response.headers, event.req, pathname)
+  })
+}
+
+/** @knipignore Nitro loads this runtime plugin from vite.config.ts. */
+export default responseHeadersPlugin

--- a/webapp/src/lib/response-headers.test.ts
+++ b/webapp/src/lib/response-headers.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest"
 
-import { applyResponseSecurityHeaders } from "./start"
+import { applyResponseSecurityHeaders } from "./response-headers.server"
 
 function securityHeaders(url: string, pathname: string, requestHeaders: HeadersInit = {}): Headers {
   const headers = new Headers()
@@ -9,6 +9,12 @@ function securityHeaders(url: string, pathname: string, requestHeaders: HeadersI
 }
 
 describe("response security headers", () => {
+  test("preserves private cache policy for personalized docs responses", () => {
+    const headers = new Headers({ "Cache-Control": "private, no-store" })
+    applyResponseSecurityHeaders(headers, new Request("https://app.example/docs/sdk"), "/docs/sdk")
+    expect(headers.get("cache-control")).toBe("private, no-store")
+  })
+
   test("frames and referrers are restricted on application responses", () => {
     const headers = securityHeaders("https://app.example/organization", "/organization")
     expect(headers.get("x-frame-options")).toBe("DENY")

--- a/webapp/src/routes/__root.tsx
+++ b/webapp/src/routes/__root.tsx
@@ -69,8 +69,12 @@ const getSetupState = createIsomorphicFn()
       setupComplete: await isSetupComplete(),
     }
   })
-  // The server gates every document request; client-side navigation within a served app is safe.
+  // The server gates application documents. Public docs leave through a full document navigation.
   .client(() => ({ setupComplete: true }))
+
+function isDocsPath(pathname: string): boolean {
+  return pathname === "/docs" || pathname.startsWith("/docs/")
+}
 
 function isAppTheme(theme: string): theme is AppTheme {
   return APP_THEMES.some((appTheme) => appTheme === theme)
@@ -80,6 +84,7 @@ export const Route = createRootRouteWithContext<{
   queryClient: QueryClient
 }>()({
   beforeLoad: async ({ location }) => {
+    if (isDocsPath(location.pathname)) return
     const state = await getSetupState()
     const isConfigurePath = location.pathname === "/configure" ||
       location.pathname.startsWith("/configure/")
@@ -114,7 +119,7 @@ export const Route = createRootRouteWithContext<{
       replace: true,
     })
   },
-  loader: () => getPublicConfig(),
+  loader: ({ location }) => isDocsPath(location.pathname) ? null : getPublicConfig(),
   head: () => ({
     meta: [
       {

--- a/webapp/src/routes/docs/route.tsx
+++ b/webapp/src/routes/docs/route.tsx
@@ -12,7 +12,11 @@ function DocsLayout() {
     <div className="min-h-svh bg-background text-foreground">
       <header className="sticky top-0 z-10 border-b bg-background/95 backdrop-blur">
         <div className="container mx-auto flex h-14 items-center gap-3 px-4">
-          <Link to="/" className="flex items-center gap-2 font-heading font-semibold">
+          <Link
+            to="/"
+            reloadDocument
+            className="flex items-center gap-2 font-heading font-semibold"
+          >
             <img src={APP_LOGO_LIGHT_SVG_URL} alt="" className="size-6" />
             {APP_NAME}
           </Link>

--- a/webapp/src/start.ts
+++ b/webapp/src/start.ts
@@ -1,59 +1,9 @@
-import { createCsrfMiddleware, createMiddleware, createStart } from "@tanstack/react-start"
-
-// The SDK widget loads these routes from a customer's own origin, so they must stay framable and
-// keep the CSP that `/api/chat/files` sets on downloaded artifacts.
-const EMBEDDED_API_BASE_PATH = "/api/chat"
-
-// One year is the shortest max-age the preload list accepts.
-// https://hstspreload.org/#deployment-recommendations
-const STRICT_TRANSPORT_SECURITY = "max-age=63072000; includeSubDomains"
-
-// Only features the app never uses; anything unlisted keeps its browser default.
-// https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Permissions-Policy
-const PERMISSIONS_POLICY =
-  "camera=(), display-capture=(), geolocation=(), microphone=(), payment=(), usb=()"
-
-function isSecureRequest(request: Request): boolean {
-  if (new URL(request.url).protocol === "https:") return true
-  // A forged value only adds a header browsers ignore over plain HTTP, so the proxy's protocol
-  // does not need the loopback check that `/configure` applies before enforcing HTTPS.
-  return request.headers.get("x-forwarded-proto")?.split(",")[0]?.trim() === "https"
-}
-
-function isEmbeddedApiPath(pathname: string): boolean {
-  return pathname === EMBEDDED_API_BASE_PATH ||
-    pathname.startsWith(`${EMBEDDED_API_BASE_PATH}/`)
-}
-
-export function applyResponseSecurityHeaders(
-  headers: Headers,
-  request: Request,
-  pathname: string,
-): void {
-  if (isSecureRequest(request)) headers.set("Strict-Transport-Security", STRICT_TRANSPORT_SECURITY)
-  headers.set("X-Content-Type-Options", "nosniff")
-  headers.set("Referrer-Policy", "strict-origin-when-cross-origin")
-  headers.set("Permissions-Policy", PERMISSIONS_POLICY)
-  if (isEmbeddedApiPath(pathname)) return
-  headers.set("X-Frame-Options", "DENY")
-  // Script and style directives are deliberately absent: the framework's inline bootstrap,
-  // Turnstile, and the docs pages each need their own allowlist audit first.
-  headers.set("Content-Security-Policy", "frame-ancestors 'none'")
-}
-
-const responseSecurityHeadersMiddleware = createMiddleware({ type: "request" }).server(
-  async ({ request, pathname, next }) => {
-    const result = await next()
-    applyResponseSecurityHeaders(result.response.headers, request, pathname)
-    return result
-  },
-)
+import { createCsrfMiddleware, createStart } from "@tanstack/react-start"
 
 // Declaring request middleware replaces the CSRF middleware the framework installs on its own.
 // https://github.com/TanStack/router/blob/main/packages/start-server-core/src/createStartHandler.ts
 const csrfMiddleware = createCsrfMiddleware({ filter: (ctx) => ctx.handlerType === "serverFn" })
 
 export const startInstance = createStart(() => ({
-  // The header middleware runs outermost so a rejected request is answered with them too.
-  requestMiddleware: [responseSecurityHeadersMiddleware, csrfMiddleware],
+  requestMiddleware: [csrfMiddleware],
 }))

--- a/webapp/vite.config.ts
+++ b/webapp/vite.config.ts
@@ -72,7 +72,27 @@ const viteConfig = defineConfig(({ mode }) => {
         },
       },
       devtools(),
-      ...(mode === "test" ? [] : nitro()),
+      ...(mode === "test" ? [] : nitro({
+        // Nitro prerenders before indexing static assets, including their content-based ETags.
+        // https://nitro.build/docs/prerender
+        prerender: {
+          routes: ["/docs"],
+          crawlLinks: true,
+          ignore: [(path) => path !== "/docs" && !path.startsWith("/docs/")],
+          failOnError: true,
+        },
+        hooks: {
+          "prerender:config": (config) => {
+            // Shared route imports create lazy pools. Only the prerender bundle gets this URL.
+            // https://nitro.build/config#hooks
+            config.replace = {
+              ...config.replace,
+              "process.env.DATABASE_URL": JSON.stringify("postgres://127.0.0.1:1/prerender"),
+            }
+          },
+        },
+        plugins: ["./src/lib/response-headers.server.ts"],
+      })),
       tailwindcss(),
       tanstackStart(),
       viteReact(),


### PR DESCRIPTION
- Prerender public `/docs` pages from Markdown at build time and serve static HTML with content-based ETags.
- Move response headers into `src/lib/response-headers.server.ts` as a server-only Nitro runtime plugin because prerendered files bypass TanStack middleware. Nitro's response hook covers static and application responses, while `start.ts` stays dedicated to TanStack configuration and CSRF.
- Keep generated docs generic and preserve explicit `private, no-store` policies so authenticated token snippets can load later in the browser.
