### PR TITLE
Bump the SDK to 0.10.0

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@astralbeam/sdk",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Frontend SDK for AstralBeam: drop-in agent UI, chat streaming, and server helpers",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
- Bump `@astralbeam/sdk` from `0.9.0` to `0.10.0` in `sdk/package.json` for the next npm release.
- Version only: `main` carries no `sdk/` or `examples/` source changes since the `0.9.0` bump in #134, so there are no breaking changes in this release.
- No other version references to update, since `examples/todos` depends on the SDK through `file:../../sdk` rather than a pinned version.
