### PR TITLE
Skip prerendering the bare docs section redirects

### DIFF
--- a/webapp/vite.config.ts
+++ b/webapp/vite.config.ts
@@ -1,4 +1,5 @@
 import { readdirSync, readFileSync } from "node:fs"
+import { extname } from "node:path"
 import process from "node:process"
 
 import tailwindcss from "@tailwindcss/vite"
@@ -83,6 +84,11 @@ const viteConfig = defineConfig(({ mode }) => {
           failOnError: true,
         },
         hooks: {
+          // A bare /docs/<section> URL redirects to the section's first page, and Nitro writes an
+          // extensionless response body over the directory holding that section's own pages.
+          "prerender:generate": (route) => {
+            if (!extname(route.fileName ?? "")) route.skip = true
+          },
           "prerender:config": (config) => {
             // Shared route imports create lazy pools. Only the prerender bundle gets this URL.
             // https://nitro.build/config#hooks


### PR DESCRIPTION
- `deno task build` logged `EISDIR: illegal operation on a directory, open '.output/public/docs/<section>'` for `start`, `sdk`, `dashboard`, and `self-hosting`.
- Cause: the docs breadcrumb links `/docs/<section>`, the crawler follows it, and that route redirects to the section's first page. The empty redirect body carries no content type, so Nitro falls back to the extensionless route path, which is already the directory holding that section's prerendered pages.
- Fix: a `prerender:generate` hook marks a route whose file name has no extension as skipped, so nothing is written for it. Keying on the missing extension rather than on the section list keeps the redirect decision owned by the router, and a real non-HTML docs asset such as a sitemap would still be written.
- `/docs/api` is unaffected: it is a real page, so it still prerenders to `docs/api/index.html`.
- Verified against a production build: 25 routes prerender with no errors, the four section roots log `(skipped)`, and the built server answers `/docs/sdk` and `/docs/self-hosting` with a 307 to their first page while `/docs/sdk/theming` and `/docs/api` serve prerendered HTML with ETags.
- `deno task ready` passes in `webapp` (47 test files, 274 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
