### PR TITLE
Count organization rows from the status endpoint

### DIFF
--- a/webapp/src/routes/api/status.ts
+++ b/webapp/src/routes/api/status.ts
@@ -1,13 +1,32 @@
 import { createFileRoute } from "@tanstack/react-router"
+import { count } from "drizzle-orm"
+import * as Effect from "effect/Effect"
+
+import { effectDatabase, runDatabaseEffect } from "@/db"
+import { organization } from "@/db/schema/organizations.server"
 
 /**
- * Liveness probe `scripts/check-binary.ts` reads, so it stays reachable without a session; being
- * unauthenticated is why it answers one constant body and never reads, logs, or parses a request.
+ * Liveness probe `scripts/check-binary.ts` reads, so it stays reachable without a session and never
+ * reads, logs, or parses a request. It counts organization rows only to confirm the database answers.
  */
+async function handleStatusRequest() {
+  try {
+    await runDatabaseEffect(
+      Effect.gen(function* () {
+        const db = yield* effectDatabase
+        yield* db.select({ value: count() }).from(organization).pipe(Effect.orDie)
+      }),
+    )
+    return Response.json({ status: "ok" })
+  } catch {
+    return Response.json({ error: "Database query failed" }, { status: 503 })
+  }
+}
+
 export const Route = createFileRoute("/api/status")({
   server: {
     handlers: {
-      GET: () => Response.json({ status: "ok" }),
+      GET: handleStatusRequest,
     },
   },
 })

--- a/webapp/src/routes/docs/-content/self-hosting/deploy.md
+++ b/webapp/src/routes/docs/-content/self-hosting/deploy.md
@@ -153,7 +153,7 @@ Run each of these against the public origin:
 | `curl -s https://your-host/api/openapi.json` | The OpenAPI document, including the `/api/v1/tenants` path             |
 | `curl -i https://your-host/api/v1/tenants`   | `401` once setup is complete, `503` with `Retry-After` while it is not |
 
-`/api/status` is a liveness probe and nothing more. It answers one constant body without touching the database, so it stays `200` even when configuration is incomplete or PostgreSQL is unreachable. There is no separate readiness endpoint, so to check readiness, call an API route and treat `503` as not ready.
+`/api/status` counts organization rows and answers `{"status":"ok"}` when that query succeeds. A database failure returns `503` with an `error` field, without the count. There is no separate readiness endpoint, so to check API readiness, call an API route and treat `503` as not ready.
 
 ## Upgrade
 

--- a/webapp/src/routes/docs/-content/self-hosting/operations.md
+++ b/webapp/src/routes/docs/-content/self-hosting/operations.md
@@ -60,14 +60,14 @@ Then start the application with that `DATABASE_URL` and the encryption keyring t
 
 ## Health checks
 
-| Endpoint      | Behavior                                                                                                                       |
-| ------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| `/api/status` | Liveness only. Always `200` with `{"status":"ok"}`. It never touches the database or reads the request                         |
-| `/api/v1/*`   | `503` with `Retry-After: 10` and a problem document whose detail is `Server configuration required.` while setup is incomplete |
-| `/api/auth/*` | `503` with `{"error":"Application is not configured"}` while setup is incomplete                                               |
-| Page routes   | Redirect to `/configure` while setup is incomplete                                                                             |
+| Endpoint      | Behavior                                                                                                                                             |
+| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `/api/status` | Counts organization rows. `200` with `{"status":"ok"}` when that query succeeds, otherwise `503` with an `error` field. It does not read the request |
+| `/api/v1/*`   | `503` with `Retry-After: 10` and a problem document whose detail is `Server configuration required.` while setup is incomplete                       |
+| `/api/auth/*` | `503` with `{"error":"Application is not configured"}` while setup is incomplete                                                                     |
+| Page routes   | Redirect to `/configure` while setup is incomplete                                                                                                   |
 
-Point a process supervisor or load balancer liveness probe at `/api/status`. Because that probe deliberately answers without reading anything, it stays `200` when the database is down, and there is no separate readiness endpoint. For readiness, probe an API route and treat `503` as not ready and `401` as ready.
+Point a process supervisor or load balancer probe at `/api/status`. It counts organization rows and reports `{"status":"ok"}` only when that query succeeds, so a database outage returns `503` with an `error` field. There is no separate readiness endpoint. For API readiness, probe an API route and treat `503` as not ready and `401` as ready.
 
 ## Logs
 


### PR DESCRIPTION
- Probe `/api/status` with an organization table count and return `{"status":"ok"}` when it succeeds
- Return `503` with an `error` field on query failure, without the count
- Update self-hosting docs to match