### PR TITLE
Smoke-test the Webapp binary without a database

### DIFF
--- a/webapp/scripts/check-binary.ts
+++ b/webapp/scripts/check-binary.ts
@@ -121,15 +121,6 @@ async function runBinaryCheck() {
   const status = waitForBinaryCheckProcess(binaryProcess)
 
   try {
-    const statusResponse = await fetchBinaryCheckResponse(new URL("/api/status", baseUrl))
-    if (statusResponse.headers.get("x-content-type-options") !== "nosniff") {
-      throw new Error("Binary did not send the application-wide response headers")
-    }
-    const status = await statusResponse.json() as { status?: unknown }
-    if (status.status !== "ok") {
-      throw new Error("Binary status endpoint did not report ok")
-    }
-
     const stylesheetResponse = await fetchBinaryCheckResponse(
       new URL(`/assets/${stylesheetName}`, baseUrl),
     )
@@ -152,6 +143,7 @@ async function runBinaryCheck() {
     await docs.body?.cancel()
     if (
       !etag || docs.headers.get("cache-control") !== "public, no-cache" ||
+      docs.headers.get("x-content-type-options") !== "nosniff" ||
       docs.headers.get("content-security-policy") !== "frame-ancestors 'none'"
     ) {
       throw new Error("Binary did not serve docs with cache and security headers")

--- a/webapp/src/routes/api/status.ts
+++ b/webapp/src/routes/api/status.ts
@@ -6,8 +6,8 @@ import { effectDatabase, runDatabaseEffect } from "@/db"
 import { organization } from "@/db/schema/organizations.server"
 
 /**
- * Liveness probe `scripts/check-binary.ts` reads, so it stays reachable without a session and never
- * reads, logs, or parses a request. It counts organization rows only to confirm the database answers.
+ * Liveness probe that stays reachable without a session and never reads, logs, or parses a
+ * request. It counts organization rows only to confirm the database answers.
  */
 async function handleStatusRequest() {
   try {

--- a/webapp/src/routes/docs/-content/self-hosting/deploy.md
+++ b/webapp/src/routes/docs/-content/self-hosting/deploy.md
@@ -14,7 +14,7 @@ chmod +x astralbeam-v0.1.0-linux-x86_64
 mv astralbeam-v0.1.0-linux-x86_64 /usr/local/bin/astralbeam
 ```
 
-The release carries no checksum or signature file, so verify what you downloaded by running it. With the two bootstrap variables set, it must answer `GET /api/status` with `{"status":"ok"}` and exit on SIGTERM. The same checks run in CI on every release.
+The release carries no checksum or signature file, so verify what you downloaded by running it. With the two bootstrap variables set, it must answer `GET /api/status` with `{"status":"ok"}` and exit on SIGTERM. CI smoke-tests every release binary the same way, without the database-backed status check.
 
 For any other platform, and for a fork, we build the binary ourselves. Deno is the only supported toolchain.
 


### PR DESCRIPTION
- `#146` made `/api/status` count organization rows, so the binary smoke check now gets a `503` in CI, where the `webapp` job provisions no PostgreSQL server. CI has been red on `main` since that merge.
- Drop the `/api/status` fetch from `webapp/scripts/check-binary.ts` and assert the application-wide `X-Content-Type-Options: nosniff` header on the docs response the check already makes, so the check stays database-free.
- Verified against a compiled binary pointed at an unreachable database: every SSR page route (`/`, `/configure`, `/auth/sign-in`) answers `500` because Better Auth is built from the database-backed config snapshot, so no page route can replace the probe. Only the prerendered docs, `robots.txt`, assets, and `/api/openapi.json` answer `200`, and the check already covers those.
- The check still covers startup, the 200 MiB ceiling, response headers, the stylesheet, the OpenAPI asset with its cache and CORS headers, docs revalidation, and a clean SIGTERM exit.
- Correct the `self-hosting/deploy.md` claim that CI runs the same status check, and drop the now-stale `scripts/check-binary.ts` reference from the status route comment.
- Validated with `deno task ready` and `deno task binary:check` from `webapp`, plus a `binary:check` run with `DATABASE_URL` pointed at a closed port to reproduce CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
