### PR TITLE
Focus the chat composer from anywhere in its box

### DIFF
--- a/examples/todos/e2e/pages/chat-widget.ts
+++ b/examples/todos/e2e/pages/chat-widget.ts
@@ -42,6 +42,11 @@ export function chatWidget(page: Page) {
       return composer
     },
 
+    /** The composer's bottom row. Its middle is padding between the attach and send buttons. */
+    composerButtonRow(): Locator {
+      return root.locator('[data-slot="input-group-addon"][data-align="block-end"]')
+    },
+
     /** True once the widget has traded a session for a chat auth token and will accept a message. */
     async waitForReady(): Promise<void> {
       await expect(composer).toBeVisible()

--- a/examples/todos/e2e/specs/app/host-ui.spec.ts
+++ b/examples/todos/e2e/specs/app/host-ui.spec.ts
@@ -67,3 +67,12 @@ test("the debug switch reports its state", async ({ todos }) => {
   await todos.toggleDebug()
   await expect(todos.controls.debug).toHaveText("Debug: on")
 })
+
+test("a tap beside the text focuses the message input", async ({ chat }) => {
+  await chat.waitForReady()
+  await expect(chat.composer()).not.toBeFocused()
+
+  // The middle of the button row is padding: the attach button sits at its start, send at its end.
+  await chat.composerButtonRow().click()
+  await expect(chat.composer()).toBeFocused()
+})

--- a/sdk/AGENTS.md
+++ b/sdk/AGENTS.md
@@ -76,5 +76,6 @@ Generate shadcn components with `deno task ui add <component>` and allow only mi
 ## Build and publish
 
 - Keep `tsdown` pinned exactly to `0.22.3`. Newer versions pull `rolldown-plugin-dts@^0.27`, whose `yuku` native bindings Deno loads as JavaScript ([denoland/deno#36240](https://github.com/denoland/deno/issues/36240)). Re-test after that issue is fixed.
+- Bump `version` in `package.json` in the same pull request that changes anything the package publishes, behavior included, and give that pull request the tag, dry-run, and `npm stage approve` steps from [`CONTRIBUTING.md`](../CONTRIBUTING.md) so a maintainer can release it without looking them up.
 - Build with `deno task build` before an authorized npm release. The package ships only `dist`, `README.md`, `LICENSE`, and `package.json`.
 - Keep top-level `../examples/*` as standalone consumer apps on the built `dist` via `file:` dependencies, with no Tailwind or shadcn of their own, so they keep demonstrating the shadow-root style boundary.

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@astralbeam/sdk",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Frontend SDK for AstralBeam: drop-in agent UI, chat streaming, and server helpers",
   "license": "MIT",
   "type": "module",

--- a/sdk/src/widget/components/chat-composer.tsx
+++ b/sdk/src/widget/components/chat-composer.tsx
@@ -159,7 +159,7 @@ export function ChatComposer(
           }}
         />
       )}
-      <InputGroup className={cn(dropTarget && "border-ring ring-3 ring-ring/50")}>
+      <InputGroup className={cn("cursor-text", dropTarget && "border-ring ring-3 ring-ring/50")}>
         {attachments.length > 0 && (
           <InputGroupAddon align="block-start">
             <ComposerAttachments attachments={attachments} onRemove={onRemoveAttachment} />

--- a/sdk/src/widget/components/ui/input-group.tsx
+++ b/sdk/src/widget/components/ui/input-group.tsx
@@ -1,4 +1,6 @@
 // Added with: deno task ui add input-group
+// Local change: a click anywhere in the group focuses its control, a textarea included. The
+// registry focused only from the addons and queried `input`, so taps beside a textarea did nothing.
 import * as React from "react"
 import { cva, type VariantProps } from "class-variance-authority"
 
@@ -7,11 +9,21 @@ import { Button } from "@/widget/components/ui/button"
 import { Input } from "@/widget/components/ui/input"
 import { Textarea } from "@/widget/components/ui/textarea"
 
-function InputGroup({ className, ...props }: React.ComponentProps<"div">) {
+function focusGroupControl(event: React.MouseEvent<HTMLDivElement>) {
+  // Interactive descendants own their own click, and a control already takes focus natively.
+  if ((event.target as HTMLElement).closest("button, a, input, textarea, select")) return
+  event.currentTarget.querySelector<HTMLElement>("[data-slot=input-group-control]")?.focus()
+}
+
+function InputGroup({ className, onClick, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="input-group"
       role="group"
+      onClick={(event) => {
+        onClick?.(event)
+        focusGroupControl(event)
+      }}
       className={cn(
         "group/input-group relative flex h-8 w-full min-w-0 items-center rounded-lg border border-input transition-colors outline-none in-data-[slot=combobox-content]:focus-within:border-inherit in-data-[slot=combobox-content]:focus-within:ring-0 has-disabled:bg-input/50 has-disabled:opacity-50 has-[[data-slot=input-group-control]:focus-visible]:border-ring has-[[data-slot=input-group-control]:focus-visible]:ring-3 has-[[data-slot=input-group-control]:focus-visible]:ring-ring/50 has-[[data-slot][aria-invalid=true]]:border-destructive has-[[data-slot][aria-invalid=true]]:ring-3 has-[[data-slot][aria-invalid=true]]:ring-destructive/20 has-[>[data-align=block-end]]:h-auto has-[>[data-align=block-end]]:flex-col has-[>[data-align=block-start]]:h-auto has-[>[data-align=block-start]]:flex-col has-[>textarea]:h-auto dark:bg-input/30 dark:has-disabled:bg-input/80 dark:has-[[data-slot][aria-invalid=true]]:ring-destructive/40 has-[>[data-align=block-end]]:[&>input]:pt-3 has-[>[data-align=block-start]]:[&>input]:pb-3 has-[>[data-align=inline-end]]:[&>input]:pe-1.5 has-[>[data-align=inline-start]]:[&>input]:ps-1.5",
         className
@@ -53,12 +65,6 @@ function InputGroupAddon({
       data-slot="input-group-addon"
       data-align={align}
       className={cn(inputGroupAddonVariants({ align }), className)}
-      onClick={(e) => {
-        if ((e.target as HTMLElement).closest("button")) {
-          return
-        }
-        e.currentTarget.parentElement?.querySelector("input")?.focus()
-      }}
       {...props}
     />
   )


### PR DESCRIPTION
- A customer embedding the widget in a mobile PWA had to tap exactly on the textarea to raise the keyboard. A tap anywhere else in the composer's box, the wide empty area beside the attach button included, did nothing.
- The cause is in the registry's `input-group`: it focused a control only from a click on an addon, and it queried `input`, which never matches the composer's `textarea`. So the one row a thumb is most likely to hit was inert, and the box's own surface was never a target at all.
- Focuses the group's `[data-slot=input-group-control]` from a click anywhere in the group, buttons, links, and other controls aside, and drops the addon-only handler it replaces. The local divergence is recorded in the file's header, as the UI-file rule asks.
- Carries `cursor-text` on the composer's box, so a pointer reads the whole surface as text rather than only the textarea.
- Covers the tap in `examples/todos/e2e/specs/app`, and bumps the SDK to `0.10.1`. No API change: this only adds a target that previously did nothing.
- Replaces #150, which paired this fix with an `autoFocus` option. That option is kept out here, because a browser raises the on-screen keyboard only for a focus that follows a gesture, so `autoFocus` could not do what the customer actually asked for.

## Verification

`deno task --cwd sdk ready` and `deno task --cwd examples/todos ready` pass. `deno task --cwd examples/todos e2e --project=app` passes 15 tests, the new one included, and that spec was confirmed to fail against a build without this change.

Recorded against the seeded local webapp and the todos example in Chromium's iPhone 15 profile, driven by touch events rather than mouse clicks. The example's own layout is a fixed sidebar beside the todo list, so the recording hides the list to give the widget the phone screen, the way a PWA embeds it.

Before, two taps on the empty area beside the text left the composer unfocused and the typing went nowhere. Only a tap on the text itself worked.

![Before: tapping beside the text leaves the composer unfocused and typing goes nowhere](https://github.com/user-attachments/assets/a45f7046-bf46-449e-ab1b-d09a2eac7cf2)

After, one tap in the same place focuses the input and what follows lands in it.

![After: one tap in the same place focuses the input and the typed text lands in it](https://github.com/user-attachments/assets/47437e80-94ee-42f2-b5ad-2c1b9e786a6b)

The same pass as video. Before:

https://github.com/user-attachments/assets/dea7529e-a26c-4f18-abd4-09bfaf0d5515

After:

https://github.com/user-attachments/assets/48f7f33e-a969-4f78-a56a-2df439087118

## Release

The version in this branch is what a tag has to match, so release it once this merges to `main`.

1. Exercise the whole workflow first without publishing: Actions → **Release** → **Run workflow**, leaving `dry-run` checked. It builds the SDK and the webapp binary and verifies them, creating and staging nothing.
2. Tag the merge commit on `main` and push it: `git tag v0.10.1 && git push origin v0.10.1`. The tag must say `v0.10.1` exactly, because the workflow's first job fails when the tag and `sdk/package.json` disagree.
3. The **Release** workflow then builds the SDK, compiles and smoke-tests the webapp binary, creates the GitHub release with auto-generated notes and the Linux binary attached, and stages the SDK on npm with `npm stage publish`. The run's job summary prints the stage id.
4. Inspect the staged package before approving it: `npm stage list`, `npm stage view <stage-id>`, `npm stage download <stage-id>`.
5. Approve it with `npm stage approve <stage-id>`, or from the Staged Packages tab on npmjs.com. Approval prompts for 2FA, and only then is `@astralbeam/sdk@0.10.1` public.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
